### PR TITLE
fix: use python3 instead of python in patch-deps.sh

### DIFF
--- a/scripts/patch-deps.sh
+++ b/scripts/patch-deps.sh
@@ -10,7 +10,7 @@ fi
 
 chmod u+w "$SQLITE_PACKAGE" || true
 
-python - <<'PY'
+python3 - <<'PY'
 from pathlib import Path
 path = Path('.build/checkouts/SQLite.swift/Package.swift')
 text = path.read_text()
@@ -25,7 +25,7 @@ PY
 
 if [[ -f "$PHONE_NUMBER_BUNDLE" ]]; then
   chmod u+w "$PHONE_NUMBER_BUNDLE" || true
-  python - <<'PY'
+  python3 - <<'PY'
 from pathlib import Path
 
 path = Path(".build/checkouts/PhoneNumberKit/PhoneNumberKit/Bundle+Resources.swift")


### PR DESCRIPTION
## Summary
- macOS no longer ships with `python` command, only `python3`
- Build fails on fresh macOS systems with `python: command not found`

## Test plan
- [x] Verified build completes successfully after change