### PR TITLE
fix: use python3 with fallback in patch-deps.sh

### DIFF
--- a/scripts/patch-deps.sh
+++ b/scripts/patch-deps.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Use python3 if available, fall back to python
+PYTHON="${PYTHON:-$(command -v python3 || command -v python || echo python3)}"
+
 SQLITE_PACKAGE=".build/checkouts/SQLite.swift/Package.swift"
 PHONE_NUMBER_BUNDLE=".build/checkouts/PhoneNumberKit/PhoneNumberKit/Bundle+Resources.swift"
 
@@ -10,7 +13,7 @@ fi
 
 chmod u+w "$SQLITE_PACKAGE" || true
 
-python - <<'PY'
+$PYTHON - <<'PY'
 from pathlib import Path
 path = Path('.build/checkouts/SQLite.swift/Package.swift')
 text = path.read_text()
@@ -25,7 +28,7 @@ PY
 
 if [[ -f "$PHONE_NUMBER_BUNDLE" ]]; then
   chmod u+w "$PHONE_NUMBER_BUNDLE" || true
-  python - <<'PY'
+  $PYTHON - <<'PY'
 from pathlib import Path
 
 path = Path(".build/checkouts/PhoneNumberKit/PhoneNumberKit/Bundle+Resources.swift")


### PR DESCRIPTION
## Summary
- macOS no longer ships with the `python` command (removed in Monterey)
- Changed `patch-deps.sh` to prefer `python3` with fallback to `python`
- Added ability to override via `PYTHON` environment variable

## Problem
Build fails on modern macOS with:
```
scripts/patch-deps.sh: line 13: python: command not found
make: *** [build] Error 127
```

## Solution
Added a `PYTHON` variable that:
1. Checks for `python3` first (works on modern macOS/Linux)
2. Falls back to `python` (for older systems)
3. Allows override via env var if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)