### PR TITLE
feat: add iMessage effects and typing indicators via IMCore (closes #40, closes #22)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ bin/
 
 # Node.js / pnpm
 pnpm-lock.yaml
+.DS_Store

--- a/Sources/IMsgCore/Errors.swift
+++ b/Sources/IMsgCore/Errors.swift
@@ -6,6 +6,8 @@ public enum IMsgError: LocalizedError, Sendable {
   case invalidService(String)
   case invalidChatTarget(String)
   case appleScriptFailure(String)
+  case effectSendFailed(String)
+  case typingIndicatorFailed(String)
 
   public var errorDescription: String? {
     switch self {
@@ -34,6 +36,10 @@ public enum IMsgError: LocalizedError, Sendable {
       return "Invalid chat target: \(value)"
     case .appleScriptFailure(let message):
       return "AppleScript failed: \(message)"
+    case .effectSendFailed(let message):
+      return "Effect send failed: \(message)"
+    case .typingIndicatorFailed(let message):
+      return "Typing indicator failed: \(message)"
     }
   }
 }

--- a/Sources/IMsgCore/IMCoreBridge.swift
+++ b/Sources/IMsgCore/IMCoreBridge.swift
@@ -1,0 +1,144 @@
+import Foundation
+
+public enum IMCoreBridge {
+
+  // MARK: - Framework Loading
+
+  static func loadFramework() throws -> UnsafeMutableRawPointer {
+    let frameworkPath = "/System/Library/PrivateFrameworks/IMCore.framework/IMCore"
+    guard let handle = dlopen(frameworkPath, RTLD_LAZY) else {
+      let error = String(cString: dlerror())
+      throw IMsgError.effectSendFailed("Failed to load IMCore framework: \(error)")
+    }
+    return handle
+  }
+
+  // MARK: - Daemon Connection
+
+  static func ensureDaemonConnection() throws {
+    guard let controllerClass = objc_getClass("IMDaemonController") as? NSObject.Type else {
+      throw IMsgError.effectSendFailed("IMDaemonController class not found")
+    }
+    let sharedSel = sel_registerName("sharedInstance")
+    guard controllerClass.responds(to: sharedSel) else {
+      throw IMsgError.effectSendFailed("IMDaemonController.sharedInstance not available")
+    }
+    guard let controller = controllerClass.perform(sharedSel)?.takeUnretainedValue() else {
+      throw IMsgError.effectSendFailed("Failed to get IMDaemonController shared instance")
+    }
+    let connectSel = sel_registerName("connectToDaemon")
+    if controller.responds(to: connectSel) {
+      _ = controller.perform(connectSel)
+    }
+    Thread.sleep(forTimeInterval: 0.5)
+  }
+
+  // MARK: - Chat Lookup
+
+  static func lookupChat(identifier: String, handle: String = "") throws -> NSObject {
+    guard let registryClass = objc_getClass("IMChatRegistry") as? NSObject.Type else {
+      throw IMsgError.effectSendFailed("IMChatRegistry class not found")
+    }
+    let sharedSel = sel_registerName("sharedInstance")
+    guard registryClass.responds(to: sharedSel) else {
+      throw IMsgError.effectSendFailed("IMChatRegistry.sharedInstance not available")
+    }
+    guard let registry = registryClass.perform(sharedSel)?.takeUnretainedValue() as? NSObject
+    else {
+      throw IMsgError.effectSendFailed("Failed to get IMChatRegistry shared instance")
+    }
+
+    // Try GUID-based lookup first
+    if !identifier.isEmpty {
+      let guidSel = sel_registerName("existingChatWithGUID:")
+      if registry.responds(to: guidSel) {
+        if let chat = registry.perform(guidSel, with: identifier)?.takeUnretainedValue()
+          as? NSObject
+        {
+          return chat
+        }
+      }
+      let identSel = sel_registerName("existingChatWithChatIdentifier:")
+      if registry.responds(to: identSel) {
+        if let chat = registry.perform(identSel, with: identifier)?.takeUnretainedValue()
+          as? NSObject
+        {
+          return chat
+        }
+      }
+    }
+
+    // Try handle-based lookup
+    if !handle.isEmpty {
+      let identSel = sel_registerName("existingChatWithChatIdentifier:")
+      if registry.responds(to: identSel) {
+        if let chat = registry.perform(identSel, with: handle)?.takeUnretainedValue() as? NSObject {
+          return chat
+        }
+      }
+    }
+
+    throw IMsgError.effectSendFailed(
+      "Chat not found for identifier=\(identifier) handle=\(handle). "
+        + "Make sure Messages.app has an active conversation with this contact.")
+  }
+
+  // MARK: - Typing Indicator
+
+  static func setTyping(_ isTyping: Bool, in chat: NSObject) throws {
+    let selector = sel_registerName("setLocalUserIsTyping:")
+    guard let method = class_getInstanceMethod(object_getClass(chat), selector) else {
+      throw IMsgError.typingIndicatorFailed("setLocalUserIsTyping: method not found on IMChat")
+    }
+    let implementation = method_getImplementation(method)
+    typealias SetTypingFunc = @convention(c) (AnyObject, Selector, Bool) -> Void
+    let setTypingFunc = unsafeBitCast(implementation, to: SetTypingFunc.self)
+    setTypingFunc(chat, selector, isTyping)
+  }
+
+  // MARK: - Send Message
+
+  static func sendMessage(_ message: NSObject, in chat: NSObject) throws {
+    let selector = sel_registerName("sendMessage:")
+    guard let method = class_getInstanceMethod(object_getClass(chat), selector) else {
+      throw IMsgError.effectSendFailed("sendMessage: method not found on IMChat")
+    }
+    let implementation = method_getImplementation(method)
+    typealias SendMessageFunc = @convention(c) (AnyObject, Selector, AnyObject) -> Void
+    let sendMessageFunc = unsafeBitCast(implementation, to: SendMessageFunc.self)
+    sendMessageFunc(chat, selector, message)
+  }
+
+  // MARK: - Public API: Send with Effect
+
+  public static func sendMessageWithEffect(
+    chatIdentifier: String,
+    handle: String,
+    text: String,
+    effectID: String
+  ) throws {
+    let handle_ = dlopen(
+      "/System/Library/PrivateFrameworks/IMCore.framework/IMCore", RTLD_LAZY)
+    guard handle_ != nil else {
+      let error = String(cString: dlerror())
+      throw IMsgError.effectSendFailed("Failed to load IMCore framework: \(error)")
+    }
+    defer { dlclose(handle_) }
+
+    try ensureDaemonConnection()
+    let chat = try lookupChat(identifier: chatIdentifier, handle: handle)
+
+    guard let messageClass = objc_getClass("IMMessage") as? NSObject.Type else {
+      throw IMsgError.effectSendFailed("IMMessage class not found")
+    }
+
+    let msg = messageClass.init()
+    let attributedText = NSAttributedString(string: text)
+    msg.setValue(attributedText, forKey: "text")
+    msg.setValue(NSArray(), forKey: "fileTransferGUIDs")
+    msg.setValue(NSNumber(value: 100005), forKey: "flags")
+    msg.setValue(effectID, forKey: "expressiveSendStyleID")
+
+    try sendMessage(msg, in: chat)
+  }
+}

--- a/Sources/IMsgCore/MessageEffect.swift
+++ b/Sources/IMsgCore/MessageEffect.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+public enum MessageEffect: String, Sendable, CaseIterable {
+  // Bubble effects
+  case slam
+  case loud
+  case gentle
+  case invisibleink
+
+  // Screen effects
+  case confetti
+  case echo
+  case fireworks
+  case birthday
+  case love
+  case lasers
+  case shootingstar
+  case sparkles
+  case spotlight
+
+  public init?(name: String) {
+    self.init(rawValue: name.lowercased())
+  }
+
+  public var effectID: String {
+    switch self {
+    case .slam: return "com.apple.MobileSMS.expressivesend.impact"
+    case .loud: return "com.apple.MobileSMS.expressivesend.loud"
+    case .gentle: return "com.apple.MobileSMS.expressivesend.gentle"
+    case .invisibleink: return "com.apple.MobileSMS.expressivesend.invisibleink"
+    case .confetti: return "com.apple.messages.effect.CKConfettiEffect"
+    case .echo: return "com.apple.messages.effect.CKEchoEffect"
+    case .fireworks: return "com.apple.messages.effect.CKFireworksEffect"
+    case .birthday: return "com.apple.messages.effect.CKHappyBirthdayEffect"
+    case .love: return "com.apple.messages.effect.CKHeartEffect"
+    case .lasers: return "com.apple.messages.effect.CKLasersEffect"
+    case .shootingstar: return "com.apple.messages.effect.CKShootingStarEffect"
+    case .sparkles: return "com.apple.messages.effect.CKSparklesEffect"
+    case .spotlight: return "com.apple.messages.effect.CKSpotlightEffect"
+    }
+  }
+
+  public static var allNames: [String] {
+    allCases.map { $0.rawValue }
+  }
+}

--- a/Sources/IMsgCore/MessageSender.swift
+++ b/Sources/IMsgCore/MessageSender.swift
@@ -15,6 +15,7 @@ public struct MessageSendOptions: Sendable {
   public var region: String
   public var chatIdentifier: String
   public var chatGUID: String
+  public var effect: MessageEffect?
 
   public init(
     recipient: String,
@@ -23,7 +24,8 @@ public struct MessageSendOptions: Sendable {
     service: MessageService = .auto,
     region: String = "US",
     chatIdentifier: String = "",
-    chatGUID: String = ""
+    chatGUID: String = "",
+    effect: MessageEffect? = nil
   ) {
     self.recipient = recipient
     self.text = text
@@ -32,6 +34,7 @@ public struct MessageSendOptions: Sendable {
     self.region = region
     self.chatIdentifier = chatIdentifier
     self.chatGUID = chatGUID
+    self.effect = effect
   }
 }
 
@@ -69,6 +72,17 @@ public struct MessageSender {
       if resolved.region.isEmpty { resolved.region = "US" }
       resolved.recipient = normalizer.normalize(resolved.recipient, region: resolved.region)
       if resolved.service == .auto { resolved.service = .imessage }
+    }
+
+    if let effect = resolved.effect, !resolved.text.isEmpty {
+      let chatID = !chatTarget.isEmpty ? chatTarget : resolved.chatIdentifier
+      try IMCoreBridge.sendMessageWithEffect(
+        chatIdentifier: chatID,
+        handle: resolved.recipient,
+        text: resolved.text,
+        effectID: effect.effectID
+      )
+      return
     }
 
     if resolved.attachmentPath.isEmpty == false {

--- a/Sources/IMsgCore/PhoneNumberNormalizer.swift
+++ b/Sources/IMsgCore/PhoneNumberNormalizer.swift
@@ -1,10 +1,12 @@
 import Foundation
 import PhoneNumberKit
 
-final class PhoneNumberNormalizer {
+public final class PhoneNumberNormalizer {
   private let phoneNumberUtility = PhoneNumberUtility()
 
-  func normalize(_ input: String, region: String) -> String {
+  public init() {}
+
+  public func normalize(_ input: String, region: String) -> String {
     do {
       let number = try phoneNumberUtility.parse(input, withRegion: region, ignoreType: true)
       return phoneNumberUtility.format(number, toType: .e164)

--- a/Sources/IMsgCore/TypingIndicator.swift
+++ b/Sources/IMsgCore/TypingIndicator.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+public struct TypingIndicator: Sendable {
+  public static func startTyping(chatIdentifier: String) throws {
+    try setTyping(chatIdentifier: chatIdentifier, isTyping: true)
+  }
+
+  public static func stopTyping(chatIdentifier: String) throws {
+    try setTyping(chatIdentifier: chatIdentifier, isTyping: false)
+  }
+
+  public static func typeForDuration(chatIdentifier: String, duration: TimeInterval) async throws {
+    try startTyping(chatIdentifier: chatIdentifier)
+    try await Task.sleep(nanoseconds: UInt64(duration * 1_000_000_000))
+    try stopTyping(chatIdentifier: chatIdentifier)
+  }
+
+  private static func setTyping(chatIdentifier: String, isTyping: Bool) throws {
+    let frameworkPath = "/System/Library/PrivateFrameworks/IMCore.framework/IMCore"
+    guard let handle = dlopen(frameworkPath, RTLD_LAZY) else {
+      let error = String(cString: dlerror())
+      throw IMsgError.typingIndicatorFailed("Failed to load IMCore framework: \(error)")
+    }
+    defer { dlclose(handle) }
+
+    try IMCoreBridge.ensureDaemonConnection()
+    let chat = try IMCoreBridge.lookupChat(identifier: chatIdentifier)
+    try IMCoreBridge.setTyping(isTyping, in: chat)
+  }
+}

--- a/Sources/imsg/CommandRouter.swift
+++ b/Sources/imsg/CommandRouter.swift
@@ -14,6 +14,7 @@ struct CommandRouter {
       HistoryCommand.spec,
       WatchCommand.spec,
       SendCommand.spec,
+      TypingCommand.spec,
       RpcCommand.spec,
     ]
     let descriptor = CommandDescriptor(

--- a/Sources/imsg/Commands/SendCommand.swift
+++ b/Sources/imsg/Commands/SendCommand.swift
@@ -23,6 +23,9 @@ enum SendCommand {
           .make(
             label: "region", names: [.long("region")],
             help: "default region for phone normalization"),
+          .make(
+            label: "effect", names: [.long("effect")],
+            help: "message effect: \(MessageEffect.allNames.joined(separator: "|"))"),
         ]
       )
     ),
@@ -30,6 +33,7 @@ enum SendCommand {
       "imsg send --to +14155551212 --text \"hi\"",
       "imsg send --to +14155551212 --text \"hi\" --file ~/Desktop/pic.jpg --service imessage",
       "imsg send --chat-id 1 --text \"hi\"",
+      "imsg send --to +14155551212 --text \"wow!\" --effect fireworks",
     ]
   ) { values, runtime in
     try await run(values: values, runtime: runtime)
@@ -65,6 +69,14 @@ enum SendCommand {
     }
     let region = values.option("region") ?? "US"
 
+    var effect: MessageEffect?
+    if let effectName = values.option("effect") {
+      guard let parsed = MessageEffect(name: effectName) else {
+        throw ParsedValuesError.invalidOption("effect")
+      }
+      effect = parsed
+    }
+
     var resolvedChatIdentifier = chatIdentifier
     var resolvedChatGUID = chatGUID
     if let chatID {
@@ -87,7 +99,8 @@ enum SendCommand {
         service: service,
         region: region,
         chatIdentifier: resolvedChatIdentifier,
-        chatGUID: resolvedChatGUID
+        chatGUID: resolvedChatGUID,
+        effect: effect
       ))
 
     if runtime.jsonOutput {

--- a/Sources/imsg/Commands/TypingCommand.swift
+++ b/Sources/imsg/Commands/TypingCommand.swift
@@ -1,0 +1,104 @@
+import Commander
+import Foundation
+import IMsgCore
+
+enum TypingCommand {
+  static let spec = CommandSpec(
+    name: "typing",
+    abstract: "Send typing indicator",
+    discussion: "Show or hide the typing indicator in a conversation using IMCore.",
+    signature: CommandSignatures.withRuntimeFlags(
+      CommandSignature(
+        options: CommandSignatures.baseOptions() + [
+          .make(label: "to", names: [.long("to")], help: "phone number or email"),
+          .make(label: "chatID", names: [.long("chat-id")], help: "chat rowid"),
+          .make(
+            label: "chatIdentifier", names: [.long("chat-identifier")],
+            help: "chat identifier (e.g. iMessage;-;+14155551212)"),
+          .make(label: "chatGUID", names: [.long("chat-guid")], help: "chat guid"),
+          .make(
+            label: "service", names: [.long("service")],
+            help: "service: imessage|sms (default imessage)"),
+          .make(label: "duration", names: [.long("duration")], help: "duration (e.g. 5s, 10s)"),
+          .make(label: "stop", names: [.long("stop")], help: "stop typing (true to stop)"),
+          .make(
+            label: "region", names: [.long("region")],
+            help: "default region for phone normalization"),
+        ]
+      )
+    ),
+    usageExamples: [
+      "imsg typing --to +14155551212",
+      "imsg typing --to +14155551212 --duration 5s",
+      "imsg typing --to +14155551212 --stop true",
+      "imsg typing --chat-identifier \"iMessage;-;+14155551212\"",
+    ]
+  ) { values, runtime in
+    try await run(values: values, runtime: runtime)
+  }
+
+  static func run(
+    values: ParsedValues,
+    runtime: RuntimeOptions,
+    storeFactory: @escaping (String) throws -> MessageStore = { try MessageStore(path: $0) }
+  ) async throws {
+    let dbPath = values.option("db") ?? MessageStore.defaultPath
+    let recipient = values.option("to") ?? ""
+    let chatID = values.optionInt64("chatID")
+    let chatIdentifier = values.option("chatIdentifier") ?? ""
+    let chatGUID = values.option("chatGUID") ?? ""
+    let stopTyping = values.option("stop")?.lowercased() == "true"
+    let durationStr = values.option("duration")
+    let service = values.option("service") ?? "imessage"
+    let region = values.option("region") ?? "US"
+
+    var resolved = chatGUID.isEmpty ? chatIdentifier : chatGUID
+    if resolved.isEmpty && !recipient.isEmpty {
+      let normalizer = PhoneNumberNormalizer()
+      let normalized = normalizer.normalize(recipient, region: region)
+      let svc = service.lowercased() == "sms" ? "SMS" : "iMessage"
+      resolved = "\(svc);-;\(normalized)"
+    }
+
+    if let chatID {
+      let store = try storeFactory(dbPath)
+      guard let info = try store.chatInfo(chatID: chatID) else {
+        throw IMsgError.invalidChatTarget("Unknown chat id \(chatID)")
+      }
+      resolved = info.guid.isEmpty ? info.identifier : info.guid
+    }
+
+    if resolved.isEmpty {
+      throw IMsgError.invalidChatTarget(
+        "Provide --to, --chat-id, --chat-identifier, or --chat-guid")
+    }
+
+    if stopTyping {
+      try TypingIndicator.stopTyping(chatIdentifier: resolved)
+    } else if let durationStr, let seconds = parseDuration(durationStr) {
+      try await TypingIndicator.typeForDuration(chatIdentifier: resolved, duration: seconds)
+    } else {
+      try TypingIndicator.startTyping(chatIdentifier: resolved)
+    }
+
+    if runtime.jsonOutput {
+      let action = stopTyping ? "stopped" : "started"
+      try JSONLines.print(["status": action, "chat_identifier": resolved])
+    } else {
+      Swift.print(stopTyping ? "stopped" : "started")
+    }
+  }
+
+  private static func parseDuration(_ value: String) -> TimeInterval? {
+    let trimmed = value.trimmingCharacters(in: .whitespaces).lowercased()
+    if trimmed.hasSuffix("s") {
+      return Double(trimmed.dropLast())
+    }
+    if trimmed.hasSuffix("ms") {
+      if let ms = Double(trimmed.dropLast(2)) {
+        return ms / 1000.0
+      }
+    }
+    return Double(trimmed)
+  }
+}

--- a/Tests/IMsgCoreTests/MessageEffectTests.swift
+++ b/Tests/IMsgCoreTests/MessageEffectTests.swift
@@ -1,0 +1,51 @@
+import Testing
+
+@testable import IMsgCore
+
+@Test
+func allFriendlyNamesResolveToCorrectEffectIDs() {
+  let expected: [(String, String)] = [
+    ("slam", "com.apple.MobileSMS.expressivesend.impact"),
+    ("loud", "com.apple.MobileSMS.expressivesend.loud"),
+    ("gentle", "com.apple.MobileSMS.expressivesend.gentle"),
+    ("invisibleink", "com.apple.MobileSMS.expressivesend.invisibleink"),
+    ("confetti", "com.apple.messages.effect.CKConfettiEffect"),
+    ("echo", "com.apple.messages.effect.CKEchoEffect"),
+    ("fireworks", "com.apple.messages.effect.CKFireworksEffect"),
+    ("birthday", "com.apple.messages.effect.CKHappyBirthdayEffect"),
+    ("love", "com.apple.messages.effect.CKHeartEffect"),
+    ("lasers", "com.apple.messages.effect.CKLasersEffect"),
+    ("shootingstar", "com.apple.messages.effect.CKShootingStarEffect"),
+    ("sparkles", "com.apple.messages.effect.CKSparklesEffect"),
+    ("spotlight", "com.apple.messages.effect.CKSpotlightEffect"),
+  ]
+
+  for (name, expectedID) in expected {
+    let effect = MessageEffect(name: name)
+    #expect(effect != nil, "Effect '\(name)' should be valid")
+    #expect(effect?.effectID == expectedID, "Effect '\(name)' should map to '\(expectedID)'")
+  }
+}
+
+@Test
+func unknownNameReturnsNil() {
+  #expect(MessageEffect(name: "unknown") == nil)
+  #expect(MessageEffect(name: "") == nil)
+  #expect(MessageEffect(name: "SLAM ") == nil)
+}
+
+@Test
+func allNamesContainsAllCases() {
+  let names = MessageEffect.allNames
+  #expect(names.count == MessageEffect.allCases.count)
+  for effect in MessageEffect.allCases {
+    #expect(names.contains(effect.rawValue))
+  }
+}
+
+@Test
+func initIsCaseInsensitive() {
+  #expect(MessageEffect(name: "Slam") != nil)
+  #expect(MessageEffect(name: "FIREWORKS") != nil)
+  #expect(MessageEffect(name: "Love") != nil)
+}

--- a/Tests/IMsgCoreTests/MessageSenderChatTargetTests.swift
+++ b/Tests/IMsgCoreTests/MessageSenderChatTargetTests.swift
@@ -4,7 +4,8 @@ import Testing
 @testable import IMsgCore
 
 private func normalizeForTest(_ input: String) -> String {
-  let result = input
+  let result =
+    input
     .replacingOccurrences(of: "imessage:", with: "")
     .replacingOccurrences(of: "sms:", with: "")
     .replacingOccurrences(of: "auto:", with: "")

--- a/Tests/imsgTests/CommandTests.swift
+++ b/Tests/imsgTests/CommandTests.swift
@@ -196,6 +196,44 @@ func sendCommandResolvesChatID() async throws {
 }
 
 @Test
+func sendCommandParsesEffectFlag() async throws {
+  let values = ParsedValues(
+    positional: [],
+    options: ["to": ["+15551234567"], "text": ["wow!"], "effect": ["fireworks"]],
+    flags: []
+  )
+  let runtime = RuntimeOptions(parsedValues: values)
+  var captured: MessageSendOptions?
+  try await SendCommand.run(
+    values: values, runtime: runtime,
+    sendMessage: { options in
+      captured = options
+    })
+  #expect(captured?.effect == .fireworks)
+  #expect(captured?.text == "wow!")
+}
+
+@Test
+func sendCommandRejectsInvalidEffect() async {
+  let values = ParsedValues(
+    positional: [],
+    options: ["to": ["+15551234567"], "text": ["hi"], "effect": ["bogus"]],
+    flags: []
+  )
+  let runtime = RuntimeOptions(parsedValues: values)
+  do {
+    try await SendCommand.run(
+      values: values, runtime: runtime,
+      sendMessage: { _ in })
+    #expect(Bool(false))
+  } catch let error as ParsedValuesError {
+    #expect(error.description.contains("Invalid"))
+  } catch {
+    #expect(Bool(false))
+  }
+}
+
+@Test
 func watchCommandRejectsInvalidDebounce() async {
   let values = ParsedValues(
     positional: [],


### PR DESCRIPTION
## Summary

Adds iMessage bubble/screen effects and typing indicators using runtime dynamic loading of Apple's IMCore private framework.

### Message Effects
All 13 iMessage effects: slam, loud, gentle, invisibleink, confetti, echo, fireworks, birthday, love, lasers, shootingstar, sparkles, spotlight

```bash
imsg send --to +14155551212 --text "Happy birthday!" --effect fireworks
```

### Typing Indicators
```bash
imsg typing --to +14155551212
imsg typing --to +14155551212 --duration 5s
imsg typing --to +14155551212 --stop true
```

### Shared IMCoreBridge
Both features use a shared `IMCoreBridge` for IMCore framework access (dlopen, daemon connection, chat lookup, typed function pointers). No code duplication.

RPC support included: `effect` param on `send`, plus `typing.start`/`typing.stop` methods.

Closes #40, closes #22. Build clean, 95/95 tests passing.