### PR TITLE
Add Homebrew installation instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ A macOS Messages.app CLI to send, read, and stream iMessage/SMS (with attachment
 - For SMS relay, enable “Text Message Forwarding” on your iPhone to this Mac.
 
 ## Install
+
+### Homebrew
+```bash
+brew install steipete/tap/imsg
+```
+
+### Build from source
 ```bash
 make build
 # binary at ./bin/imsg


### PR DESCRIPTION
## Summary
- Adds `brew install steipete/tap/imsg` as the primary install method in the README
- Keeps build-from-source instructions as an alternative under a separate subheading

## Test plan
- [x] Verify `brew install steipete/tap/imsg` works correctly
- [x] Confirm README renders properly in GitHub markdown preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)