### PR TITLE
fix(react): add Enter keypress to confirm standard tapback selection

### DIFF
--- a/Sources/imsg/Commands/ReactCommand.swift
+++ b/Sources/imsg/Commands/ReactCommand.swift
@@ -164,6 +164,8 @@ enum ReactCommand {
             keystroke "t" using command down
             delay 0.2
             keystroke reactionKey
+            delay 0.1
+            key code 36
           end tell
         end tell
       end run


### PR DESCRIPTION
## Summary

Standard tapback reactions (love, like, dislike, laugh, emphasis, question) open the tapback menu but never confirm the selection. The custom emoji code path presses Enter (`key code 36`) after typing the emoji, but the standard reaction path was missing this.

## Changes

Added `delay 0.1` and `key code 36` after `keystroke reactionKey` in the standard reaction AppleScript, matching the custom emoji path.

## Testing

Tested locally on macOS 15 (Sequoia) with imsg 0.5.0:
- `imsg react --chat-id 3 --reaction like` ✅
- `imsg react --chat-id 3 --reaction love` ✅  
- `imsg react --chat-id 3 --reaction laugh` ✅

Fixes #53