### PR TITLE
feat: convert CAF audio and GIF attachments for model compatibility

### DIFF
--- a/Sources/IMsgCore/AttachmentResolver.swift
+++ b/Sources/IMsgCore/AttachmentResolver.swift
@@ -9,6 +9,81 @@ enum AttachmentResolver {
     return (expanded, !(exists && !isDir.boolValue))
   }
 
+  /// Convert .caf audio to .m4a (Whisper-compatible) if needed.
+  /// Returns the converted path, or the original if conversion isn't needed/fails.
+  static func convertAudioIfNeeded(_ resolvedPath: String) -> (path: String, mimeType: String?) {
+    guard resolvedPath.lowercased().hasSuffix(".caf") else { return (resolvedPath, nil) }
+    let cafURL = URL(fileURLWithPath: resolvedPath)
+    let m4aURL = cafURL.deletingPathExtension().appendingPathExtension("m4a")
+    let m4aPath = m4aURL.path
+
+    // If already converted, reuse
+    if FileManager.default.fileExists(atPath: m4aPath) {
+      return (m4aPath, "audio/mp4")
+    }
+
+    // Check source exists
+    guard FileManager.default.fileExists(atPath: resolvedPath) else {
+      return (resolvedPath, nil)
+    }
+
+    // Convert using ffmpeg (handles Opus-in-CAF from iMessage)
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/opt/homebrew/bin/ffmpeg")
+    process.arguments = [
+      "-i", resolvedPath,
+      "-c:a", "aac",        // AAC codec
+      "-b:a", "128k",       // 128kbps bitrate
+      "-y",                  // Overwrite without prompting
+      m4aPath
+    ]
+    do {
+      try process.run()
+      process.waitUntilExit()
+      if process.terminationStatus == 0 && FileManager.default.fileExists(atPath: m4aPath) {
+        return (m4aPath, "audio/mp4")
+      }
+    } catch {
+      // Conversion failed, return original
+    }
+    return (resolvedPath, nil)
+  }
+
+  /// Convert GIF to static PNG (first frame) for model compatibility.
+  static func convertGifIfNeeded(_ resolvedPath: String) -> (path: String, mimeType: String?) {
+    guard resolvedPath.lowercased().hasSuffix(".gif") else { return (resolvedPath, nil) }
+    let gifURL = URL(fileURLWithPath: resolvedPath)
+    let pngURL = gifURL.deletingPathExtension().appendingPathExtension("png")
+    let pngPath = pngURL.path
+
+    if FileManager.default.fileExists(atPath: pngPath) {
+      return (pngPath, "image/png")
+    }
+
+    guard FileManager.default.fileExists(atPath: resolvedPath) else {
+      return (resolvedPath, nil)
+    }
+
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/opt/homebrew/bin/ffmpeg")
+    process.arguments = [
+      "-i", resolvedPath,
+      "-vframes", "1",       // First frame only
+      "-y",
+      pngPath
+    ]
+    do {
+      try process.run()
+      process.waitUntilExit()
+      if process.terminationStatus == 0 && FileManager.default.fileExists(atPath: pngPath) {
+        return (pngPath, "image/png")
+      }
+    } catch {
+      // Conversion failed, return original
+    }
+    return (resolvedPath, nil)
+  }
+
   static func displayName(filename: String, transferName: String) -> String {
     if !transferName.isEmpty { return transferName }
     if !filename.isEmpty { return filename }

--- a/Sources/IMsgCore/MessageStore.swift
+++ b/Sources/IMsgCore/MessageStore.swift
@@ -250,16 +250,39 @@ extension MessageStore {
         let totalBytes = int64Value(row[4]) ?? 0
         let isSticker = boolValue(row[5])
         let resolved = AttachmentResolver.resolve(filename)
+        var finalPath = resolved.resolved
+        var finalMime = mimeType
+        var finalMissing = resolved.missing
+        // Convert .caf audio to .m4a for Whisper compatibility
+        if !resolved.missing && uti == "com.apple.coreaudio-format" {
+          let converted = AttachmentResolver.convertAudioIfNeeded(resolved.resolved)
+          finalPath = converted.path
+          if let convertedMime = converted.mimeType {
+            finalMime = convertedMime
+          }
+          let convertedExists = FileManager.default.fileExists(atPath: finalPath)
+          finalMissing = !convertedExists
+        }
+        // Convert GIF to static PNG for model compatibility
+        if !resolved.missing && uti == "com.compuserve.gif" {
+          let converted = AttachmentResolver.convertGifIfNeeded(resolved.resolved)
+          finalPath = converted.path
+          if let convertedMime = converted.mimeType {
+            finalMime = convertedMime
+          }
+          let convertedExists = FileManager.default.fileExists(atPath: finalPath)
+          finalMissing = !convertedExists
+        }
         metas.append(
           AttachmentMeta(
             filename: filename,
             transferName: transferName,
             uti: uti,
-            mimeType: mimeType,
+            mimeType: finalMime,
             totalBytes: totalBytes,
             isSticker: isSticker,
-            originalPath: resolved.resolved,
-            missing: resolved.missing
+            originalPath: finalPath,
+            missing: finalMissing
           ))
       }
       return metas


### PR DESCRIPTION
iMessage voice messages use Opus-in-CAF format which isn't supported by OpenAI Whisper. GIF images aren't accepted by all model APIs (e.g. xAI). This adds ffmpeg-based conversion: .caf→.m4a for audio, .gif→.png (first frame) for images. Converted files are cached alongside originals.