### PR TITLE
feat(contacts): resolve contact names and add participants command

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,6 +22,7 @@ let package = Package(
             ],
             linkerSettings: [
                 .linkedFramework("ScriptingBridge"),
+                .linkedFramework("Contacts"),
             ]
         ),
     .executableTarget(

--- a/Sources/IMsgCore/ContactResolver.swift
+++ b/Sources/IMsgCore/ContactResolver.swift
@@ -1,0 +1,109 @@
+@preconcurrency import Contacts
+import Foundation
+
+/// Resolves phone numbers and email addresses to contact display names
+/// via CNContactStore. Results are cached for the lifetime of the instance.
+/// If Contacts access is denied, all lookups silently return nil.
+public final class ContactResolver: @unchecked Sendable {
+  private let store: CNContactStore
+  private var cache: [String: String?] = [:]
+  private var denied: Bool = false
+  private let queue = DispatchQueue(label: "imsg.contacts", qos: .userInitiated)
+
+  private var keysToFetch: [CNKeyDescriptor] {
+    [
+      CNContactGivenNameKey as CNKeyDescriptor,
+      CNContactFamilyNameKey as CNKeyDescriptor,
+      CNContactNicknameKey as CNKeyDescriptor,
+      CNContactPhoneNumbersKey as CNKeyDescriptor,
+      CNContactEmailAddressesKey as CNKeyDescriptor,
+    ]
+  }
+
+  public init() {
+    self.store = CNContactStore()
+    let status = CNContactStore.authorizationStatus(for: .contacts)
+    if status == .denied || status == .restricted {
+      self.denied = true
+    }
+  }
+
+  /// Resolve a single identifier (phone number or email) to a display name.
+  /// Returns nil if no matching contact is found or access is denied.
+  public func resolve(_ identifier: String) -> String? {
+    queue.sync {
+      if denied { return nil }
+      if let existing = cache[identifier] { return existing }
+      let result = lookup(identifier)
+      cache[identifier] = result
+      return result
+    }
+  }
+
+  /// Batch resolve multiple identifiers. Returns a dictionary mapping
+  /// identifiers to display names (only includes resolved entries).
+  public func resolve(_ identifiers: [String]) -> [String: String] {
+    var results: [String: String] = [:]
+    for identifier in identifiers {
+      if let name = resolve(identifier) {
+        results[identifier] = name
+      }
+    }
+    return results
+  }
+
+  private func lookup(_ identifier: String) -> String? {
+    let trimmed = identifier.trimmingCharacters(in: .whitespaces)
+    guard !trimmed.isEmpty else { return nil }
+
+    do {
+      let predicate: NSPredicate
+      if trimmed.contains("@") {
+        predicate = CNContact.predicateForContacts(matchingEmailAddress: trimmed)
+      } else if trimmed.hasPrefix("+") || trimmed.first?.isNumber == true {
+        let phoneNumber = CNPhoneNumber(stringValue: trimmed)
+        predicate = CNContact.predicateForContacts(matching: phoneNumber)
+      } else {
+        return nil
+      }
+
+      let contacts = try store.unifiedContacts(
+        matching: predicate,
+        keysToFetch: keysToFetch
+      )
+      guard let contact = contacts.first else { return nil }
+      return ContactResolver.displayName(for: contact)
+    } catch let error as NSError where error.domain == CNErrorDomain
+      && error.code == CNError.authorizationDenied.rawValue
+    {
+      denied = true
+      return nil
+    } catch {
+      return nil
+    }
+  }
+
+  /// Resolve the best display name for a chat given its identifier, DB name, and participants.
+  /// Checks phone/email identifiers first (since the DB name can be a raw phone fallback),
+  /// then falls back to the DB name, then resolves group participants, then the raw identifier.
+  public func displayNameForChat(
+    identifier: String, name: String, participants: [String]
+  ) -> String {
+    if identifier.hasPrefix("+") || identifier.contains("@") {
+      return resolve(identifier) ?? identifier
+    }
+    guard name.isEmpty else { return name }
+    guard !participants.isEmpty else { return identifier }
+    let resolved = resolve(participants)
+    return participants.map { resolved[$0] ?? $0 }.joined(separator: ", ")
+  }
+
+  private static func displayName(for contact: CNContact) -> String? {
+    if !contact.nickname.isEmpty {
+      return contact.nickname
+    }
+    let parts = [contact.givenName, contact.familyName].filter { !$0.isEmpty }
+    guard !parts.isEmpty else { return nil }
+    return parts.joined(separator: " ")
+  }
+}

--- a/Sources/imsg/CommandRouter.swift
+++ b/Sources/imsg/CommandRouter.swift
@@ -12,6 +12,7 @@ struct CommandRouter {
     self.specs = [
       ChatsCommand.spec,
       HistoryCommand.spec,
+      ParticipantsCommand.spec,
       WatchCommand.spec,
       SendCommand.spec,
       ReactCommand.spec,

--- a/Sources/imsg/Commands/ChatsCommand.swift
+++ b/Sources/imsg/Commands/ChatsCommand.swift
@@ -23,17 +23,23 @@ enum ChatsCommand {
     let limit = values.optionInt("limit") ?? 20
     let store = try MessageStore(path: dbPath)
     let chats = try store.listChats(limit: limit)
-
-    if runtime.jsonOutput {
-      for chat in chats {
-        try StdoutWriter.writeJSONLine(ChatPayload(chat: chat))
-      }
-      return
-    }
+    let resolver = ContactResolver()
 
     for chat in chats {
+      let participants = (try? store.participants(chatID: chat.id)) ?? []
+      let displayName = resolver.displayNameForChat(
+        identifier: chat.identifier, name: chat.name, participants: participants
+      )
       let last = CLIISO8601.format(chat.lastMessageAt)
-      StdoutWriter.writeLine("[\(chat.id)] \(chat.name) (\(chat.identifier)) last=\(last)")
+
+      if runtime.jsonOutput {
+        try StdoutWriter.writeJSONLine(
+          ChatPayload(chat: chat, displayName: displayName)
+        )
+        continue
+      }
+
+      StdoutWriter.writeLine("[\(chat.id)] \(displayName) last=\(last)")
     }
   }
 }

--- a/Sources/imsg/Commands/HistoryCommand.swift
+++ b/Sources/imsg/Commands/HistoryCommand.swift
@@ -47,25 +47,37 @@ enum HistoryCommand {
 
     let store = try MessageStore(path: dbPath)
     let filtered = try store.messages(chatID: chatID, limit: limit, filter: filter)
+    let resolver = ContactResolver()
 
-    if runtime.jsonOutput {
-      for message in filtered {
+    // Batch resolve all unique senders
+    let uniqueSenders = Array(Set(filtered.map(\.sender)))
+    let resolvedNames = resolver.resolve(uniqueSenders)
+
+    for message in filtered {
+      let senderName = message.isFromMe
+        ? "You"
+        : (resolvedNames[message.sender] ?? message.sender)
+
+      if runtime.jsonOutput {
         let attachments = try store.attachments(for: message.rowID)
         let reactions = try store.reactions(for: message.rowID)
+        // Resolve any reaction senders not already in the batch
+        let reactionNames = resolver.resolve(reactions.map(\.sender))
+        let allResolved = resolvedNames.merging(reactionNames) { existing, _ in existing }
         let payload = MessagePayload(
           message: message,
           attachments: attachments,
-          reactions: reactions
+          reactions: reactions,
+          senderDisplayName: resolvedNames[message.sender],
+          resolvedNames: allResolved
         )
         try StdoutWriter.writeJSONLine(payload)
+        continue
       }
-      return
-    }
 
-    for message in filtered {
       let direction = message.isFromMe ? "sent" : "recv"
       let timestamp = CLIISO8601.format(message.date)
-      StdoutWriter.writeLine("\(timestamp) [\(direction)] \(message.sender): \(message.text)")
+      StdoutWriter.writeLine("\(timestamp) [\(direction)] \(senderName): \(message.text)")
       if message.attachmentsCount > 0 {
         if showAttachments {
           let metas = try store.attachments(for: message.rowID)

--- a/Sources/imsg/Commands/HistoryCommand.swift
+++ b/Sources/imsg/Commands/HistoryCommand.swift
@@ -53,6 +53,38 @@ enum HistoryCommand {
     let uniqueSenders = Array(Set(filtered.map(\.sender)))
     let resolvedNames = resolver.resolve(uniqueSenders)
 
+    // Print header (CLI only)
+    if !runtime.jsonOutput {
+      let chatInfo = try store.chatInfo(chatID: chatID)
+      let participantHandles = try store.participants(chatID: chatID)
+      let identifier = chatInfo?.identifier ?? ""
+      let guid = chatInfo?.guid ?? ""
+      let dbName = chatInfo?.name ?? ""
+      let service = chatInfo?.service ?? ""
+      let isGroup = isGroupHandle(identifier: identifier, guid: guid)
+      let displayName = resolver.displayNameForChat(
+        identifier: identifier, name: dbName, participants: participantHandles
+      )
+
+      if isGroup {
+        StdoutWriter.writeLine("\(displayName) \u{00B7} \(service)")
+        // Show participant list only if we have a DB name (otherwise displayName IS the participants)
+        if !dbName.isEmpty {
+          let resolved = resolver.resolve(participantHandles)
+          let names = participantHandles.map { resolved[$0] ?? $0 }
+          StdoutWriter.writeLine("  \(names.joined(separator: ", "))")
+        }
+      } else {
+        let resolvedChat = resolver.resolve(identifier)
+        if let resolvedChat, resolvedChat != identifier {
+          StdoutWriter.writeLine("Chat with \(resolvedChat) (\(identifier)) \u{00B7} \(service)")
+        } else {
+          StdoutWriter.writeLine("Chat with \(displayName) \u{00B7} \(service)")
+        }
+      }
+      StdoutWriter.writeLine(String(repeating: "\u{2500}", count: 49))
+    }
+
     for message in filtered {
       let senderName = message.isFromMe
         ? "You"

--- a/Sources/imsg/Commands/ParticipantsCommand.swift
+++ b/Sources/imsg/Commands/ParticipantsCommand.swift
@@ -1,0 +1,72 @@
+import Commander
+import Foundation
+import IMsgCore
+
+enum ParticipantsCommand {
+  static let spec = CommandSpec(
+    name: "participants",
+    abstract: "List participants in a chat",
+    discussion: nil,
+    signature: CommandSignatures.withRuntimeFlags(
+      CommandSignature(
+        options: CommandSignatures.baseOptions() + [
+          .make(label: "chatID", names: [.long("chat-id")], help: "chat rowid from 'imsg chats'")
+        ]
+      )
+    ),
+    usageExamples: [
+      "imsg participants --chat-id 42",
+      "imsg participants --chat-id 42 --json",
+    ]
+  ) { values, runtime in
+    guard let chatID = values.optionInt64("chatID") else {
+      throw ParsedValuesError.missingOption("chat-id")
+    }
+    let dbPath = values.option("db") ?? MessageStore.defaultPath
+    let store = try MessageStore(path: dbPath)
+
+    guard let info = try store.chatInfo(chatID: chatID) else {
+      throw ParsedValuesError.invalidOption("chat-id: no chat found with id \(chatID)")
+    }
+
+    let participantHandles = try store.participants(chatID: chatID)
+    let resolver = ContactResolver()
+    let resolved = resolver.resolve(participantHandles)
+    let isGroup = isGroupHandle(identifier: info.identifier, guid: info.guid)
+    let displayName = resolver.displayNameForChat(
+      identifier: info.identifier, name: info.name, participants: participantHandles
+    )
+
+    if runtime.jsonOutput {
+      let payloads = participantHandles.map {
+        ParticipantPayload(identifier: $0, displayName: resolved[$0])
+      }
+      let response = ParticipantsResponse(
+        chatID: chatID,
+        identifier: info.identifier,
+        displayName: displayName,
+        service: info.service,
+        isGroup: isGroup,
+        participants: payloads
+      )
+      try StdoutWriter.writeJSONLine(response)
+      return
+    }
+
+    // CLI output
+    if isGroup {
+      StdoutWriter.writeLine("\(displayName) \u{00B7} \(info.service)")
+    } else {
+      StdoutWriter.writeLine("Chat with \(displayName) \u{00B7} \(info.service)")
+    }
+    StdoutWriter.writeLine("")
+    for handle in participantHandles {
+      if let name = resolved[handle] {
+        let padded = name.padding(toLength: max(name.count, 24), withPad: " ", startingAt: 0)
+        StdoutWriter.writeLine("  \(padded)\(handle)")
+      } else {
+        StdoutWriter.writeLine("  \(handle)")
+      }
+    }
+  }
+}

--- a/Sources/imsg/Commands/WatchCommand.swift
+++ b/Sources/imsg/Commands/WatchCommand.swift
@@ -83,6 +83,8 @@ enum WatchCommand {
     )
 
     let resolver = ContactResolver()
+    // Cache for group chat display names (only used when watching all chats)
+    var chatDisplayCache: [Int64: (name: String, isGroup: Bool)] = [:]
     let stream = streamProvider(watcher, chatID, sinceRowID, config)
     for try await message in stream {
       if !filter.allows(message) {
@@ -107,17 +109,40 @@ enum WatchCommand {
         try StdoutWriter.writeJSONLine(payload)
         continue
       }
+
+      // Resolve group label when watching all chats (no --chat-id)
+      var groupLabel = ""
+      if chatID == nil {
+        let cached = chatDisplayCache[message.chatID] ?? {
+          let info = try? store.chatInfo(chatID: message.chatID)
+          let participants = (try? store.participants(chatID: message.chatID)) ?? []
+          let identifier = info?.identifier ?? ""
+          let guid = info?.guid ?? ""
+          let name = info?.name ?? ""
+          let isGroup = isGroupHandle(identifier: identifier, guid: guid)
+          let displayName = resolver.displayNameForChat(
+            identifier: identifier, name: name, participants: participants
+          )
+          let entry = (name: displayName, isGroup: isGroup)
+          chatDisplayCache[message.chatID] = entry
+          return entry
+        }()
+        if cached.isGroup {
+          groupLabel = " (\(cached.name))"
+        }
+      }
+
       let direction = message.isFromMe ? "sent" : "recv"
       let timestamp = CLIISO8601.format(message.date)
       if message.isReaction, let reactionType = message.reactionType {
         let action = (message.isReactionAdd ?? true) ? "added" : "removed"
         let targetGUID = message.reactedToGUID ?? "unknown"
         StdoutWriter.writeLine(
-          "\(timestamp) [\(direction)] \(senderName) \(action) \(reactionType.emoji) reaction to \(targetGUID)"
+          "\(timestamp) [\(direction)] \(senderName)\(groupLabel) \(action) \(reactionType.emoji) reaction to \(targetGUID)"
         )
         continue
       }
-      StdoutWriter.writeLine("\(timestamp) [\(direction)] \(senderName): \(message.text)")
+      StdoutWriter.writeLine("\(timestamp) [\(direction)] \(senderName)\(groupLabel): \(message.text)")
       if message.attachmentsCount > 0 {
         if showAttachments {
           let metas = try store.attachments(for: message.rowID)

--- a/Sources/imsg/Commands/WatchCommand.swift
+++ b/Sources/imsg/Commands/WatchCommand.swift
@@ -82,18 +82,27 @@ enum WatchCommand {
       includeReactions: includeReactions
     )
 
+    let resolver = ContactResolver()
     let stream = streamProvider(watcher, chatID, sinceRowID, config)
     for try await message in stream {
       if !filter.allows(message) {
         continue
       }
+      let resolvedName = resolver.resolve(message.sender)
+      let senderName = message.isFromMe ? "You" : (resolvedName ?? message.sender)
+
       if runtime.jsonOutput {
         let attachments = try store.attachments(for: message.rowID)
         let reactions = try store.reactions(for: message.rowID)
+        let reactionNames = resolver.resolve(reactions.map(\.sender))
+        var allResolved = reactionNames
+        if let resolvedName { allResolved[message.sender] = resolvedName }
         let payload = MessagePayload(
           message: message,
           attachments: attachments,
-          reactions: reactions
+          reactions: reactions,
+          senderDisplayName: resolvedName,
+          resolvedNames: allResolved
         )
         try StdoutWriter.writeJSONLine(payload)
         continue
@@ -104,11 +113,11 @@ enum WatchCommand {
         let action = (message.isReactionAdd ?? true) ? "added" : "removed"
         let targetGUID = message.reactedToGUID ?? "unknown"
         StdoutWriter.writeLine(
-          "\(timestamp) [\(direction)] \(message.sender) \(action) \(reactionType.emoji) reaction to \(targetGUID)"
+          "\(timestamp) [\(direction)] \(senderName) \(action) \(reactionType.emoji) reaction to \(targetGUID)"
         )
         continue
       }
-      StdoutWriter.writeLine("\(timestamp) [\(direction)] \(message.sender): \(message.text)")
+      StdoutWriter.writeLine("\(timestamp) [\(direction)] \(senderName): \(message.text)")
       if message.attachmentsCount > 0 {
         if showAttachments {
           let metas = try store.attachments(for: message.rowID)

--- a/Sources/imsg/OutputModels.swift
+++ b/Sources/imsg/OutputModels.swift
@@ -189,6 +189,34 @@ struct AttachmentPayload: Codable {
   }
 }
 
+struct ParticipantPayload: Codable {
+  let identifier: String
+  let displayName: String?
+
+  enum CodingKeys: String, CodingKey {
+    case identifier
+    case displayName = "display_name"
+  }
+}
+
+struct ParticipantsResponse: Codable {
+  let chatID: Int64
+  let identifier: String
+  let displayName: String?
+  let service: String
+  let isGroup: Bool
+  let participants: [ParticipantPayload]
+
+  enum CodingKeys: String, CodingKey {
+    case chatID = "chat_id"
+    case identifier
+    case displayName = "display_name"
+    case service
+    case isGroup = "is_group"
+    case participants
+  }
+}
+
 enum CLIISO8601 {
   static func format(_ date: Date) -> String {
     let formatter = ISO8601DateFormatter()

--- a/Sources/imsg/OutputModels.swift
+++ b/Sources/imsg/OutputModels.swift
@@ -7,13 +7,15 @@ struct ChatPayload: Codable {
   let identifier: String
   let service: String
   let lastMessageAt: String
+  let displayName: String?
 
-  init(chat: Chat) {
+  init(chat: Chat, displayName: String? = nil) {
     self.id = chat.id
     self.name = chat.name
     self.identifier = chat.identifier
     self.service = chat.service
     self.lastMessageAt = CLIISO8601.format(chat.lastMessageAt)
+    self.displayName = displayName
   }
 
   enum CodingKeys: String, CodingKey {
@@ -22,6 +24,7 @@ struct ChatPayload: Codable {
     case identifier
     case service
     case lastMessageAt = "last_message_at"
+    case displayName = "display_name"
   }
 }
 
@@ -32,6 +35,7 @@ struct MessagePayload: Codable {
   let replyToGUID: String?
   let threadOriginatorGUID: String?
   let sender: String
+  let senderDisplayName: String?
   let isFromMe: Bool
   let text: String
   let createdAt: String
@@ -49,18 +53,27 @@ struct MessagePayload: Codable {
   let isReactionAdd: Bool?
   let reactedToGUID: String?
 
-  init(message: Message, attachments: [AttachmentMeta], reactions: [Reaction] = []) {
+  init(
+    message: Message,
+    attachments: [AttachmentMeta],
+    reactions: [Reaction] = [],
+    senderDisplayName: String? = nil,
+    resolvedNames: [String: String] = [:]
+  ) {
     self.id = message.rowID
     self.chatID = message.chatID
     self.guid = message.guid
     self.replyToGUID = message.replyToGUID
     self.threadOriginatorGUID = message.threadOriginatorGUID
     self.sender = message.sender
+    self.senderDisplayName = senderDisplayName
     self.isFromMe = message.isFromMe
     self.text = message.text
     self.createdAt = CLIISO8601.format(message.date)
     self.attachments = attachments.map { AttachmentPayload(meta: $0) }
-    self.reactions = reactions.map { ReactionPayload(reaction: $0) }
+    self.reactions = reactions.map {
+      ReactionPayload(reaction: $0, senderDisplayName: resolvedNames[$0.sender])
+    }
     self.destinationCallerID = message.destinationCallerID
 
     // Reaction event metadata
@@ -86,6 +99,7 @@ struct MessagePayload: Codable {
     case replyToGUID = "reply_to_guid"
     case threadOriginatorGUID = "thread_originator_guid"
     case sender
+    case senderDisplayName = "sender_display_name"
     case isFromMe = "is_from_me"
     case text
     case createdAt = "created_at"
@@ -117,14 +131,16 @@ struct ReactionPayload: Codable {
   let type: String
   let emoji: String
   let sender: String
+  let senderDisplayName: String?
   let isFromMe: Bool
   let createdAt: String
 
-  init(reaction: Reaction) {
+  init(reaction: Reaction, senderDisplayName: String? = nil) {
     self.id = reaction.rowID
     self.type = reaction.reactionType.name
     self.emoji = reaction.reactionType.emoji
     self.sender = reaction.sender
+    self.senderDisplayName = senderDisplayName
     self.isFromMe = reaction.isFromMe
     self.createdAt = CLIISO8601.format(reaction.date)
   }
@@ -134,6 +150,7 @@ struct ReactionPayload: Codable {
     case type
     case emoji
     case sender
+    case senderDisplayName = "sender_display_name"
     case isFromMe = "is_from_me"
     case createdAt = "created_at"
   }

--- a/Sources/imsg/RPCPayloads.swift
+++ b/Sources/imsg/RPCPayloads.swift
@@ -8,9 +8,10 @@ func chatPayload(
   name: String,
   service: String,
   lastMessageAt: Date,
-  participants: [String]
+  participants: [String],
+  displayName: String? = nil
 ) -> [String: Any] {
-  return [
+  var dict: [String: Any] = [
     "id": id,
     "identifier": identifier,
     "guid": guid,
@@ -20,6 +21,10 @@ func chatPayload(
     "participants": participants,
     "is_group": isGroupHandle(identifier: identifier, guid: guid),
   ]
+  if let displayName {
+    dict["display_name"] = displayName
+  }
+  return dict
 }
 
 func messagePayload(
@@ -27,12 +32,20 @@ func messagePayload(
   chatInfo: ChatInfo?,
   participants: [String],
   attachments: [AttachmentMeta],
-  reactions: [Reaction]
+  reactions: [Reaction],
+  senderDisplayName: String? = nil,
+  resolvedNames: [String: String] = [:]
 ) throws -> [String: Any] {
   let identifier = chatInfo?.identifier ?? ""
   let guid = chatInfo?.guid ?? ""
   let name = chatInfo?.name ?? ""
-  let core = MessagePayload(message: message, attachments: attachments, reactions: reactions)
+  let core = MessagePayload(
+    message: message,
+    attachments: attachments,
+    reactions: reactions,
+    senderDisplayName: senderDisplayName,
+    resolvedNames: resolvedNames
+  )
   var payload = try core.asDictionary()
   payload["chat_identifier"] = identifier
   payload["chat_guid"] = guid
@@ -55,8 +68,8 @@ func attachmentPayload(_ meta: AttachmentMeta) -> [String: Any] {
   ]
 }
 
-func reactionPayload(_ reaction: Reaction) -> [String: Any] {
-  return [
+func reactionPayload(_ reaction: Reaction, senderDisplayName: String? = nil) -> [String: Any] {
+  var dict: [String: Any] = [
     "id": reaction.rowID,
     "type": reaction.reactionType.name,
     "emoji": reaction.reactionType.emoji,
@@ -64,6 +77,10 @@ func reactionPayload(_ reaction: Reaction) -> [String: Any] {
     "is_from_me": reaction.isFromMe,
     "created_at": CLIISO8601.format(reaction.date),
   ]
+  if let senderDisplayName {
+    dict["sender_display_name"] = senderDisplayName
+  }
+  return dict
 }
 
 func isGroupHandle(identifier: String, guid: String) -> Bool {

--- a/Sources/imsg/RPCServer+Handlers.swift
+++ b/Sources/imsg/RPCServer+Handlers.swift
@@ -15,6 +15,11 @@ extension RPCServer {
       let guid = info?.guid ?? ""
       let name = (info?.name.isEmpty == false ? info?.name : nil) ?? chat.name
       let service = info?.service ?? chat.service
+
+      let displayName = resolver.displayNameForChat(
+        identifier: identifier, name: name, participants: participants
+      )
+
       payloads.append(
         chatPayload(
           id: chat.id,
@@ -23,7 +28,8 @@ extension RPCServer {
           name: name,
           service: service,
           lastMessageAt: chat.lastMessageAt,
-          participants: participants
+          participants: participants,
+          displayName: displayName
         ))
     }
 
@@ -53,7 +59,8 @@ extension RPCServer {
         store: store,
         cache: cache,
         message: message,
-        includeAttachments: includeAttachments
+        includeAttachments: includeAttachments,
+        resolver: resolver
       )
       payloads.append(payload)
     }
@@ -85,6 +92,7 @@ extension RPCServer {
     let localSinceRowID = sinceRowID
     let localConfig = config
     let localIncludeAttachments = includeAttachments
+    let localResolver = resolver
     let task = Task {
       do {
         for try await message in localWatcher.stream(
@@ -98,7 +106,8 @@ extension RPCServer {
             store: localStore,
             cache: localCache,
             message: message,
-            includeAttachments: localIncludeAttachments
+            includeAttachments: localIncludeAttachments,
+            resolver: localResolver
           )
           localWriter.sendNotification(
             method: "message",
@@ -184,17 +193,25 @@ private func buildMessagePayload(
   store: MessageStore,
   cache: ChatCache,
   message: Message,
-  includeAttachments: Bool
+  includeAttachments: Bool,
+  resolver: ContactResolver
 ) async throws -> [String: Any] {
   let chatInfo = try await cache.info(chatID: message.chatID)
   let participants = try await cache.participants(chatID: message.chatID)
   let attachments = includeAttachments ? try store.attachments(for: message.rowID) : []
   let reactions = includeAttachments ? try store.reactions(for: message.rowID) : []
+  // Batch resolve message sender + all reaction senders
+  var allSenders = [message.sender]
+  allSenders.append(contentsOf: reactions.map(\.sender))
+  let resolvedNames = resolver.resolve(allSenders)
+
   return try messagePayload(
     message: message,
     chatInfo: chatInfo,
     participants: participants,
     attachments: attachments,
-    reactions: reactions
+    reactions: reactions,
+    senderDisplayName: resolvedNames[message.sender],
+    resolvedNames: resolvedNames
   )
 }

--- a/Sources/imsg/RPCServer+Handlers.swift
+++ b/Sources/imsg/RPCServer+Handlers.swift
@@ -36,6 +36,34 @@ extension RPCServer {
     respond(id: id, result: ["chats": payloads])
   }
 
+  func handleParticipantsList(id: Any?, params: [String: Any]) async throws {
+    guard let chatID = int64Param(params["chat_id"]) else {
+      throw RPCError.invalidParams("chat_id is required")
+    }
+    guard let info = try await cache.info(chatID: chatID) else {
+      throw RPCError.invalidParams("no chat found with id \(chatID)")
+    }
+    let participantHandles = try await cache.participants(chatID: chatID)
+    let resolved = resolver.resolve(participantHandles)
+    let isGroup = isGroupHandle(identifier: info.identifier, guid: info.guid)
+    let displayName = resolver.displayNameForChat(
+      identifier: info.identifier, name: info.name, participants: participantHandles
+    )
+
+    let participants: [[String: Any?]] = participantHandles.map { handle in
+      ["identifier": handle, "display_name": resolved[handle]]
+    }
+
+    respond(id: id, result: [
+      "chat_id": chatID,
+      "identifier": info.identifier,
+      "display_name": displayName,
+      "service": info.service,
+      "is_group": isGroup,
+      "participants": participants,
+    ] as [String: Any])
+  }
+
   func handleMessagesHistory(id: Any?, params: [String: Any]) async throws {
     guard let chatID = int64Param(params["chat_id"]) else {
       throw RPCError.invalidParams("chat_id is required")

--- a/Sources/imsg/RPCServer.swift
+++ b/Sources/imsg/RPCServer.swift
@@ -12,6 +12,7 @@ final class RPCServer {
   let watcher: MessageWatcher
   let output: RPCOutput
   let cache: ChatCache
+  let resolver: ContactResolver
   let subscriptions = SubscriptionStore()
   let verbose: Bool
   let sendMessage: (MessageSendOptions) throws -> Void
@@ -25,6 +26,7 @@ final class RPCServer {
     self.store = store
     self.watcher = MessageWatcher(store: store)
     self.cache = ChatCache(store: store)
+    self.resolver = ContactResolver()
     self.verbose = verbose
     self.output = output
     self.sendMessage = sendMessage

--- a/Sources/imsg/RPCServer.swift
+++ b/Sources/imsg/RPCServer.swift
@@ -82,6 +82,8 @@ final class RPCServer {
       switch method {
       case "chats.list":
         try await handleChatsList(id: id, params: params)
+      case "participants.list":
+        try await handleParticipantsList(id: id, params: params)
       case "messages.history":
         try await handleMessagesHistory(id: id, params: params)
       case "watch.subscribe":

--- a/Tests/IMsgCoreTests/ContactResolverTests.swift
+++ b/Tests/IMsgCoreTests/ContactResolverTests.swift
@@ -1,0 +1,46 @@
+import Foundation
+import Testing
+
+@testable import IMsgCore
+
+@Test
+func resolverReturnsNilForEmptyInput() {
+  let resolver = ContactResolver()
+  #expect(resolver.resolve("") == nil)
+  #expect(resolver.resolve("   ") == nil)
+}
+
+@Test
+func resolverReturnsNilForNonPhoneNonEmail() {
+  let resolver = ContactResolver()
+  // Chat identifiers and opaque IDs should not be looked up
+  #expect(resolver.resolve("chat123456789") == nil)
+  #expect(resolver.resolve("a36a822c067c4404a04ddeb731dab9b2") == nil)
+}
+
+@Test
+func batchResolveReturnsEmptyForUnknownNumbers() {
+  let resolver = ContactResolver()
+  let results = resolver.resolve(["+15550000001", "+15550000002"])
+  // These fake numbers won't match any contact
+  #expect(results["+15550000001"] == nil)
+  #expect(results["+15550000002"] == nil)
+}
+
+@Test
+func batchResolveReturnsOnlyResolvedEntries() {
+  let resolver = ContactResolver()
+  let results = resolver.resolve(["+15550000001"])
+  // Should not contain entries for unresolved numbers
+  #expect(results.isEmpty)
+}
+
+@Test
+func resolverCachesResults() {
+  let resolver = ContactResolver()
+  // First call
+  let result1 = resolver.resolve("+15550000001")
+  // Second call should hit cache (same result)
+  let result2 = resolver.resolve("+15550000001")
+  #expect(result1 == result2)
+}

--- a/Tests/imsgTests/CommandTestDatabase.swift
+++ b/Tests/imsgTests/CommandTestDatabase.swift
@@ -12,7 +12,7 @@ enum CommandTestDatabase {
   static func makePath() throws -> String {
     let path = try makeDatabasePath()
     let db = try Connection(path)
-    try createSchema(db, includeChatHandleJoin: false)
+    try createSchema(db, includeChatHandleJoin: true)
     try seedBasicChat(db)
     return path
   }
@@ -28,6 +28,36 @@ enum CommandTestDatabase {
     )
     try db.run("INSERT INTO message_attachment_join(message_id, attachment_id) VALUES (1, 1)")
     return path
+  }
+
+  static func makePathWithParticipants() throws -> String {
+    let path = try makeDatabasePath()
+    let db = try Connection(path)
+    try createSchema(db, includeChatHandleJoin: true)
+    try seedRPCChat(db)
+    return path
+  }
+
+  /// Creates a file-based DB with a 1:1 chat (non-group identifier/guid) and one participant.
+  static func makePathWith1on1Chat() throws -> String {
+    let path = try makeDatabasePath()
+    let db = try Connection(path)
+    try createSchema(db, includeChatHandleJoin: true)
+    try seed1on1Chat(db)
+    return path
+  }
+
+  /// Creates an in-memory store with a 1:1 chat for use in watch/RPC tests.
+  static func makeStoreFor1on1() throws -> MessageStore {
+    let db = try Connection(.inMemory)
+    try createSchema(db, includeChatHandleJoin: true)
+    try seed1on1Chat(db)
+    return try MessageStore(
+      connection: db,
+      path: ":memory:",
+      hasAttributedBody: false,
+      hasReactionColumns: false
+    )
   }
 
   static func makeStoreForRPC() throws -> MessageStore {
@@ -107,6 +137,26 @@ enum CommandTestDatabase {
       """
       INSERT INTO message(ROWID, handle_id, text, date, is_from_me, service)
       VALUES (1, 1, 'hello', ?, 0, 'iMessage')
+      """,
+      appleEpoch(now)
+    )
+    try db.run("INSERT INTO chat_message_join(chat_id, message_id) VALUES (1, 1)")
+  }
+
+  private static func seed1on1Chat(_ db: Connection) throws {
+    let now = Date()
+    try db.run(
+      """
+      INSERT INTO chat(ROWID, chat_identifier, guid, display_name, service_name)
+      VALUES (1, '+15551234567', 'iMessage;-;+15551234567', '', 'iMessage')
+      """
+    )
+    try db.run("INSERT INTO handle(ROWID, id) VALUES (1, '+15551234567')")
+    try db.run("INSERT INTO chat_handle_join(chat_id, handle_id) VALUES (1, 1)")
+    try db.run(
+      """
+      INSERT INTO message(ROWID, handle_id, text, date, is_from_me, service)
+      VALUES (1, 1, 'hey there', ?, 0, 'iMessage')
       """,
       appleEpoch(now)
     )

--- a/Tests/imsgTests/DisplayNameTests.swift
+++ b/Tests/imsgTests/DisplayNameTests.swift
@@ -1,0 +1,180 @@
+import Foundation
+import Testing
+
+@testable import IMsgCore
+@testable import imsg
+
+// MARK: - ChatPayload display_name encoding
+
+@Test
+func chatPayloadEncodesDisplayNameWhenProvided() throws {
+  let chat = Chat(
+    id: 27, identifier: "+14253433719", name: "", service: "iMessage",
+    lastMessageAt: Date(timeIntervalSince1970: 0))
+  let payload = ChatPayload(chat: chat, displayName: "Shyawn Karim")
+  let data = try JSONEncoder().encode(payload)
+  let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+  #expect(json?["display_name"] as? String == "Shyawn Karim")
+  #expect(json?["name"] as? String == "")
+  #expect(json?["identifier"] as? String == "+14253433719")
+}
+
+@Test
+func chatPayloadEncodesNullDisplayNameWhenNil() throws {
+  let chat = Chat(
+    id: 84, identifier: "a36a822c067c4404a04ddeb731dab9b2", name: "", service: "iMessage",
+    lastMessageAt: Date(timeIntervalSince1970: 0))
+  let payload = ChatPayload(chat: chat)
+  let data = try JSONEncoder().encode(payload)
+  let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+  // display_name key is absent when nil (default Codable behavior)
+  #expect(json?["display_name"] == nil)
+}
+
+// MARK: - MessagePayload sender_display_name encoding
+
+@Test
+func messagePayloadEncodesSenderDisplayName() throws {
+  let message = Message(
+    rowID: 10, chatID: 1, sender: "+14253433719", text: "hey",
+    date: Date(timeIntervalSince1970: 1), isFromMe: false,
+    service: "iMessage", handleID: nil, attachmentsCount: 0, guid: "msg-10")
+  let payload = MessagePayload(
+    message: message, attachments: [], senderDisplayName: "Shyawn Karim")
+  let data = try JSONEncoder().encode(payload)
+  let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+  #expect(json?["sender_display_name"] as? String == "Shyawn Karim")
+  #expect(json?["sender"] as? String == "+14253433719")
+}
+
+@Test
+func messagePayloadDefaultsSenderDisplayNameToNil() throws {
+  let message = Message(
+    rowID: 11, chatID: 1, sender: "+15550000001", text: "hi",
+    date: Date(timeIntervalSince1970: 1), isFromMe: false,
+    service: "iMessage", handleID: nil, attachmentsCount: 0, guid: "msg-11")
+  let payload = MessagePayload(message: message, attachments: [])
+  let data = try JSONEncoder().encode(payload)
+  let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+  #expect(json?["sender_display_name"] == nil)
+}
+
+// MARK: - ReactionPayload sender_display_name encoding
+
+@Test
+func reactionPayloadEncodesSenderDisplayName() throws {
+  let reaction = Reaction(
+    rowID: 50, reactionType: .like, sender: "+14253433719",
+    isFromMe: false, date: Date(timeIntervalSince1970: 2), associatedMessageID: 10)
+  let payload = ReactionPayload(reaction: reaction, senderDisplayName: "Shyawn Karim")
+  let data = try JSONEncoder().encode(payload)
+  let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+  #expect(json?["sender_display_name"] as? String == "Shyawn Karim")
+  #expect(json?["sender"] as? String == "+14253433719")
+}
+
+@Test
+func reactionPayloadDefaultsSenderDisplayNameToNil() throws {
+  let reaction = Reaction(
+    rowID: 51, reactionType: .laugh, sender: "+15550000001",
+    isFromMe: false, date: Date(timeIntervalSince1970: 2), associatedMessageID: 10)
+  let payload = ReactionPayload(reaction: reaction)
+  let data = try JSONEncoder().encode(payload)
+  let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+  #expect(json?["sender_display_name"] == nil)
+}
+
+// MARK: - Reactions in MessagePayload get resolved independently
+
+@Test
+func messagePayloadResolvesReactionSendersFromResolvedNames() throws {
+  let message = Message(
+    rowID: 12, chatID: 1, sender: "+11111111111", text: "hello",
+    date: Date(timeIntervalSince1970: 1), isFromMe: false,
+    service: "iMessage", handleID: nil, attachmentsCount: 0, guid: "msg-12")
+  let reaction = Reaction(
+    rowID: 60, reactionType: .love, sender: "+12222222222",
+    isFromMe: false, date: Date(timeIntervalSince1970: 2), associatedMessageID: 12)
+  let resolvedNames = [
+    "+11111111111": "Alice",
+    "+12222222222": "Bob",
+  ]
+  let payload = MessagePayload(
+    message: message, attachments: [], reactions: [reaction],
+    senderDisplayName: "Alice", resolvedNames: resolvedNames)
+  let data = try JSONEncoder().encode(payload)
+  let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+
+  // Message sender resolved
+  #expect(json?["sender_display_name"] as? String == "Alice")
+
+  // Reaction sender resolved independently (Bob, not Alice)
+  let reactions = json?["reactions"] as? [[String: Any]]
+  #expect(reactions?.count == 1)
+  #expect(reactions?.first?["sender_display_name"] as? String == "Bob")
+  #expect(reactions?.first?["sender"] as? String == "+12222222222")
+}
+
+// MARK: - ContactResolver edge cases
+
+@Test
+func resolverTreatsEmailLikeIdentifierAsEmailLookup() {
+  let resolver = ContactResolver()
+  // Should attempt email lookup, not phone - won't match but shouldn't crash
+  let result = resolver.resolve("nobody@fake-domain-12345.test")
+  #expect(result == nil)
+}
+
+@Test
+func resolverTreatsNumberWithoutPlusAsPhone() {
+  let resolver = ContactResolver()
+  // Numbers without + prefix should still attempt phone lookup
+  let result = resolver.resolve("14255550000")
+  #expect(result == nil)
+}
+
+@Test
+func batchResolveWithMixedIdentifierTypes() {
+  let resolver = ContactResolver()
+  let results = resolver.resolve([
+    "+15550000001",
+    "nobody@fake-domain-12345.test",
+    "chat999999999",
+    "",
+  ])
+  // None should resolve, but none should crash
+  #expect(results.isEmpty)
+}
+
+// MARK: - RPC payload display_name fields
+
+@Test
+func rpcChatPayloadIncludesDisplayName() {
+  let payload = chatPayload(
+    id: 27, identifier: "+14253433719", guid: "", name: "",
+    service: "iMessage", lastMessageAt: Date(timeIntervalSince1970: 0),
+    participants: ["+14253433719"], displayName: "Shyawn Karim")
+  #expect(payload["display_name"] as? String == "Shyawn Karim")
+  #expect(payload["name"] as? String == "")
+}
+
+@Test
+func rpcChatPayloadOmitsDisplayNameWhenNil() {
+  let payload = chatPayload(
+    id: 84, identifier: "a36a822c", guid: "", name: "",
+    service: "iMessage", lastMessageAt: Date(timeIntervalSince1970: 0),
+    participants: [])
+  #expect(payload["display_name"] == nil)
+}
+
+@Test
+func rpcMessagePayloadIncludesSenderDisplayName() throws {
+  let message = Message(
+    rowID: 13, chatID: 1, sender: "+123", text: "test",
+    date: Date(timeIntervalSince1970: 1), isFromMe: false,
+    service: "iMessage", handleID: nil, attachmentsCount: 0, guid: "msg-13")
+  let payload = try messagePayload(
+    message: message, chatInfo: nil, participants: [],
+    attachments: [], reactions: [], senderDisplayName: "Alice")
+  #expect(payload["sender_display_name"] as? String == "Alice")
+}

--- a/Tests/imsgTests/HistoryHeaderTests.swift
+++ b/Tests/imsgTests/HistoryHeaderTests.swift
@@ -1,0 +1,103 @@
+import Commander
+import Foundation
+import Testing
+
+@testable import IMsgCore
+@testable import imsg
+
+@Test
+func historyHeaderShowsGroupInfo() async throws {
+  let path = try CommandTestDatabase.makePathWithParticipants()
+  let values = ParsedValues(
+    positional: [],
+    options: ["chatID": ["1"], "db": [path]],
+    flags: []
+  )
+  let runtime = RuntimeOptions(parsedValues: values)
+
+  let (output, _) = try await StdoutCapture.capture {
+    try await HistoryCommand.spec.run(values, runtime)
+  }
+  // Group chat header should show chat name and service
+  #expect(output.contains("Group Chat"))
+  #expect(output.contains("iMessage"))
+  // Should show separator
+  #expect(output.contains("\u{2500}"))
+  // Should show participant list on second line
+  #expect(output.contains("+123"))
+  #expect(output.contains("me@icloud.com"))
+  // Should also show message content
+  #expect(output.contains("hello"))
+}
+
+@Test
+func historyHeaderShows1on1Format() async throws {
+  let path = try CommandTestDatabase.makePathWith1on1Chat()
+  let values = ParsedValues(
+    positional: [],
+    options: ["chatID": ["1"], "db": [path]],
+    flags: []
+  )
+  let runtime = RuntimeOptions(parsedValues: values)
+
+  let (output, _) = try await StdoutCapture.capture {
+    try await HistoryCommand.spec.run(values, runtime)
+  }
+  // 1:1 header should show "Chat with +15551234567 · iMessage"
+  #expect(output.contains("Chat with"))
+  #expect(output.contains("+15551234567"))
+  #expect(output.contains("\u{00B7} iMessage"))
+  // Should show separator
+  #expect(output.contains("\u{2500}"))
+  // Should show message
+  #expect(output.contains("hey there"))
+  // Should NOT show participant list line (that's group-only)
+  let lines = output.split(separator: "\n").map(String.init)
+  let indentedLines = lines.filter { $0.hasPrefix("  ") && !$0.contains("attachment") }
+  #expect(indentedLines.isEmpty)
+}
+
+@Test
+func historyHeaderShowsWithEmptyMessages() async throws {
+  let path = try CommandTestDatabase.makePathWith1on1Chat()
+  // Use a limit of 0 or a date range that excludes all messages
+  let values = ParsedValues(
+    positional: [],
+    options: [
+      "chatID": ["1"],
+      "db": [path],
+      "start": ["2099-01-01T00:00:00Z"],
+    ],
+    flags: []
+  )
+  let runtime = RuntimeOptions(parsedValues: values)
+
+  let (output, _) = try await StdoutCapture.capture {
+    try await HistoryCommand.spec.run(values, runtime)
+  }
+  // Header should still appear even with no messages
+  #expect(output.contains("Chat with"))
+  #expect(output.contains("\u{2500}"))
+  // But no message content
+  #expect(!output.contains("hey there"))
+}
+
+@Test
+func historyHeaderNotInJSONMode() async throws {
+  let path = try CommandTestDatabase.makePathWithParticipants()
+  let values = ParsedValues(
+    positional: [],
+    options: ["chatID": ["1"], "db": [path]],
+    flags: ["jsonOutput"]
+  )
+  let runtime = RuntimeOptions(parsedValues: values)
+
+  let (output, _) = try await StdoutCapture.capture {
+    try await HistoryCommand.spec.run(values, runtime)
+  }
+  // JSON mode should NOT contain the header
+  #expect(!output.contains("Group Chat \u{00B7}"))
+  #expect(!output.contains("\u{2500}"))
+  // Should contain JSON message data
+  #expect(output.contains("\"text\":\"hello\""))
+}

--- a/Tests/imsgTests/ParticipantsCommandTests.swift
+++ b/Tests/imsgTests/ParticipantsCommandTests.swift
@@ -1,0 +1,129 @@
+import Commander
+import Foundation
+import Testing
+
+@testable import IMsgCore
+@testable import imsg
+
+@Test
+func participantsCommandShowsGroupCLI() async throws {
+  let path = try CommandTestDatabase.makePathWithParticipants()
+  let values = ParsedValues(
+    positional: [],
+    options: ["chatID": ["1"], "db": [path]],
+    flags: []
+  )
+  let runtime = RuntimeOptions(parsedValues: values)
+
+  let (output, _) = try await StdoutCapture.capture {
+    try await ParticipantsCommand.spec.run(values, runtime)
+  }
+  // Should show group header (the RPC chat has identifier "iMessage;+;chat123")
+  #expect(output.contains("Group Chat"))
+  #expect(output.contains("iMessage"))
+  // Should list participants
+  #expect(output.contains("+123"))
+  #expect(output.contains("me@icloud.com"))
+}
+
+@Test
+func participantsCommandShowsJSON() async throws {
+  let path = try CommandTestDatabase.makePathWithParticipants()
+  let values = ParsedValues(
+    positional: [],
+    options: ["chatID": ["1"], "db": [path]],
+    flags: ["jsonOutput"]
+  )
+  let runtime = RuntimeOptions(parsedValues: values)
+
+  let (output, _) = try await StdoutCapture.capture {
+    try await ParticipantsCommand.spec.run(values, runtime)
+  }
+  let data = output.trimmingCharacters(in: .whitespacesAndNewlines).data(using: .utf8)!
+  let json = try JSONDecoder().decode(ParticipantsResponse.self, from: data)
+  #expect(json.chatID == 1)
+  #expect(json.isGroup == true)
+  #expect(json.participants.count == 2)
+  #expect(json.participants[0].identifier == "+123")
+  #expect(json.participants[1].identifier == "me@icloud.com")
+}
+
+@Test
+func participantsCommandShows1on1CLI() async throws {
+  let path = try CommandTestDatabase.makePathWith1on1Chat()
+  let values = ParsedValues(
+    positional: [],
+    options: ["chatID": ["1"], "db": [path]],
+    flags: []
+  )
+  let runtime = RuntimeOptions(parsedValues: values)
+
+  let (output, _) = try await StdoutCapture.capture {
+    try await ParticipantsCommand.spec.run(values, runtime)
+  }
+  // 1:1 should show "Chat with" prefix, not bare name
+  #expect(output.contains("Chat with"))
+  #expect(output.contains("+15551234567"))
+  #expect(output.contains("iMessage"))
+  // Should NOT contain group-style header (no "Chat with" would be missing for groups)
+  #expect(!output.contains("Group"))
+}
+
+@Test
+func participantsCommandSingleColumnForUnresolved() async throws {
+  let path = try CommandTestDatabase.makePathWith1on1Chat()
+  let values = ParsedValues(
+    positional: [],
+    options: ["chatID": ["1"], "db": [path]],
+    flags: []
+  )
+  let runtime = RuntimeOptions(parsedValues: values)
+
+  let (output, _) = try await StdoutCapture.capture {
+    try await ParticipantsCommand.spec.run(values, runtime)
+  }
+  let lines = output.split(separator: "\n").map(String.init)
+  // Find the participant line — should be "  +15551234567" with no duplicate
+  let participantLine = lines.first { $0.trimmingCharacters(in: .whitespaces).hasPrefix("+1555") }
+  #expect(participantLine != nil)
+  // The number should appear exactly once in the participant line (single column)
+  let count = participantLine!.components(separatedBy: "+15551234567").count - 1
+  #expect(count == 1)
+}
+
+@Test
+func participantsCommandRejectsMissingChatID() async throws {
+  let values = ParsedValues(
+    positional: [],
+    options: ["db": ["/tmp/unused"]],
+    flags: []
+  )
+  let runtime = RuntimeOptions(parsedValues: values)
+  do {
+    _ = try await StdoutCapture.capture {
+      try await ParticipantsCommand.spec.run(values, runtime)
+    }
+    #expect(Bool(false))
+  } catch is ParsedValuesError {
+    // Expected
+  }
+}
+
+@Test
+func participantsCommandRejectsInvalidChatID() async throws {
+  let path = try CommandTestDatabase.makePathWithParticipants()
+  let values = ParsedValues(
+    positional: [],
+    options: ["chatID": ["999"], "db": [path]],
+    flags: []
+  )
+  let runtime = RuntimeOptions(parsedValues: values)
+  do {
+    _ = try await StdoutCapture.capture {
+      try await ParticipantsCommand.spec.run(values, runtime)
+    }
+    #expect(Bool(false))
+  } catch is ParsedValuesError {
+    // Expected — no chat found
+  }
+}

--- a/Tests/imsgTests/RPCPayloadsTests.swift
+++ b/Tests/imsgTests/RPCPayloadsTests.swift
@@ -121,6 +121,64 @@ func messagePayloadOmitsEmptyReplyToGuid() throws {
 }
 
 @Test
+func chatPayloadIncludesDisplayName() {
+  let date = Date(timeIntervalSince1970: 0)
+  let payload = chatPayload(
+    id: 1,
+    identifier: "+15551234567",
+    guid: "",
+    name: "",
+    service: "iMessage",
+    lastMessageAt: date,
+    participants: ["+15551234567"],
+    displayName: "Alice Smith"
+  )
+  #expect(payload["display_name"] as? String == "Alice Smith")
+  #expect(payload["name"] as? String == "")
+}
+
+@Test
+func chatPayloadOmitsDisplayNameWhenNil() {
+  let date = Date(timeIntervalSince1970: 0)
+  let payload = chatPayload(
+    id: 1,
+    identifier: "+15551234567",
+    guid: "",
+    name: "",
+    service: "iMessage",
+    lastMessageAt: date,
+    participants: []
+  )
+  #expect(payload["display_name"] == nil)
+}
+
+@Test
+func messagePayloadIncludesSenderDisplayName() throws {
+  let message = Message(
+    rowID: 7,
+    chatID: 10,
+    sender: "+123",
+    text: "hello",
+    date: Date(timeIntervalSince1970: 1),
+    isFromMe: false,
+    service: "iMessage",
+    handleID: nil,
+    attachmentsCount: 0,
+    guid: "msg-guid-7"
+  )
+  let payload = try messagePayload(
+    message: message,
+    chatInfo: nil,
+    participants: [],
+    attachments: [],
+    reactions: [],
+    senderDisplayName: "Bob Jones"
+  )
+  #expect(payload["sender_display_name"] as? String == "Bob Jones")
+  #expect(payload["sender"] as? String == "+123")
+}
+
+@Test
 func paramParsingHelpers() {
   #expect(stringParam(123 as NSNumber) == "123")
   #expect(intParam("42") == 42)

--- a/Tests/imsgTests/RPCPayloadsTests.swift
+++ b/Tests/imsgTests/RPCPayloadsTests.swift
@@ -179,6 +179,48 @@ func messagePayloadIncludesSenderDisplayName() throws {
 }
 
 @Test
+func participantsResponseEncodesSnakeCaseKeys() throws {
+  let response = ParticipantsResponse(
+    chatID: 42,
+    identifier: "iMessage;+;chat123",
+    displayName: "Family Chat",
+    service: "iMessage",
+    isGroup: true,
+    participants: [
+      ParticipantPayload(identifier: "+15551234567", displayName: "Mom"),
+      ParticipantPayload(identifier: "+15559999999", displayName: nil),
+    ]
+  )
+  let data = try JSONEncoder().encode(response)
+  let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+
+  // Verify snake_case keys
+  #expect(json["chat_id"] as? Int64 == 42)
+  #expect(json["display_name"] as? String == "Family Chat")
+  #expect(json["is_group"] as? Bool == true)
+  #expect(json["service"] as? String == "iMessage")
+
+  let participants = json["participants"] as! [[String: Any]]
+  #expect(participants.count == 2)
+  #expect(participants[0]["identifier"] as? String == "+15551234567")
+  #expect(participants[0]["display_name"] as? String == "Mom")
+  #expect(participants[1]["identifier"] as? String == "+15559999999")
+  // Null display_name: Swift's JSONEncoder omits nil optionals
+  #expect(participants[1]["display_name"] as? String == nil)
+  #expect(!participants[1].keys.contains("display_name"))
+}
+
+@Test
+func participantPayloadOmitsNilDisplayName() throws {
+  let payload = ParticipantPayload(identifier: "+15559999999", displayName: nil)
+  let data = try JSONEncoder().encode(payload)
+  let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+  #expect(json["identifier"] as? String == "+15559999999")
+  // Swift's JSONEncoder omits nil optionals — key not present
+  #expect(!json.keys.contains("display_name"))
+}
+
+@Test
 func paramParsingHelpers() {
   #expect(stringParam(123 as NSNumber) == "123")
   #expect(intParam("42") == 42)

--- a/Tests/imsgTests/RPCServerTests.swift
+++ b/Tests/imsgTests/RPCServerTests.swift
@@ -287,3 +287,50 @@ func rpcWatchUnsubscribeRequiresSubscription() async throws {
   let error = output.errors.first?["error"] as? [String: Any]
   #expect(int64Value(error?["code"]) == -32602)
 }
+
+@Test
+func rpcParticipantsListReturnsParticipants() async throws {
+  let store = try CommandTestDatabase.makeStoreForRPC()
+  let output = TestRPCOutput()
+  let server = RPCServer(store: store, verbose: false, output: output)
+
+  let line =
+    #"{"jsonrpc":"2.0","id":"p1","method":"participants.list","params":{"chat_id":1}}"#
+  await server.handleLineForTesting(line)
+
+  #expect(output.responses.count == 1)
+  let result = output.responses[0]["result"] as? [String: Any]
+  #expect(int64Value(result?["chat_id"]) == 1)
+  #expect(result?["is_group"] as? Bool == true)
+  #expect(result?["display_name"] as? String == "Group Chat")
+  let participants = result?["participants"] as? [[String: Any?]] ?? []
+  #expect(participants.count == 2)
+}
+
+@Test
+func rpcParticipantsListRequiresChatID() async throws {
+  let store = try CommandTestDatabase.makeStoreForRPC()
+  let output = TestRPCOutput()
+  let server = RPCServer(store: store, verbose: false, output: output)
+
+  let line = #"{"jsonrpc":"2.0","id":"p2","method":"participants.list","params":{}}"#
+  await server.handleLineForTesting(line)
+
+  let error = output.errors.first?["error"] as? [String: Any]
+  #expect(int64Value(error?["code"]) == -32602)
+}
+
+@Test
+func rpcParticipantsListRejectsNonexistentChat() async throws {
+  let store = try CommandTestDatabase.makeStoreForRPC()
+  let output = TestRPCOutput()
+  let server = RPCServer(store: store, verbose: false, output: output)
+
+  let line =
+    #"{"jsonrpc":"2.0","id":"p3","method":"participants.list","params":{"chat_id":999}}"#
+  await server.handleLineForTesting(line)
+
+  #expect(output.errors.count == 1)
+  let error2 = output.errors.first?["error"] as? [String: Any]
+  #expect(int64Value(error2?["code"]) == -32602)
+}

--- a/Tests/imsgTests/WatchCommandTests.swift
+++ b/Tests/imsgTests/WatchCommandTests.swift
@@ -240,3 +240,107 @@ func watchCommandFlushesJsonOutput() async throws {
   }
   #expect(output.contains("\"text\":\"hello\""))
 }
+
+@Test
+func watchCommandShowsGroupLabelWhenWatchingAll() async throws {
+  let values = ParsedValues(
+    positional: [],
+    options: ["db": ["/tmp/unused"], "debounce": ["1ms"]],
+    flags: []
+  )
+  let runtime = RuntimeOptions(parsedValues: values)
+  let store = try CommandTestDatabase.makeStoreForRPC()
+  let message = Message(
+    rowID: 10,
+    chatID: 1,
+    sender: "+123",
+    text: "group msg",
+    date: Date(),
+    isFromMe: false,
+    service: "iMessage",
+    handleID: nil,
+    attachmentsCount: 0
+  )
+
+  let (output, _) = try await StdoutCapture.capture {
+    try await WatchCommand.run(
+      values: values,
+      runtime: runtime,
+      storeFactory: { _ in store },
+      streamProvider: singleMessageStreamProvider(message)
+    )
+  }
+  // Group chat message should show group name in parentheses
+  #expect(output.contains("(Group Chat)"))
+  #expect(output.contains("group msg"))
+}
+
+@Test
+func watchCommandNoGroupLabelWhenScopedToChat() async throws {
+  let values = ParsedValues(
+    positional: [],
+    options: ["chatID": ["1"], "db": ["/tmp/unused"], "debounce": ["1ms"]],
+    flags: []
+  )
+  let runtime = RuntimeOptions(parsedValues: values)
+  let store = try CommandTestDatabase.makeStoreForRPC()
+  let message = Message(
+    rowID: 10,
+    chatID: 1,
+    sender: "+123",
+    text: "scoped msg",
+    date: Date(),
+    isFromMe: false,
+    service: "iMessage",
+    handleID: nil,
+    attachmentsCount: 0
+  )
+
+  let (output, _) = try await StdoutCapture.capture {
+    try await WatchCommand.run(
+      values: values,
+      runtime: runtime,
+      storeFactory: { _ in store },
+      streamProvider: singleMessageStreamProvider(message)
+    )
+  }
+  // Scoped watch should NOT show group label
+  #expect(!output.contains("(Group Chat)"))
+  #expect(output.contains("scoped msg"))
+}
+
+@Test
+func watchCommandNoLabelFor1on1WhenWatchingAll() async throws {
+  let values = ParsedValues(
+    positional: [],
+    options: ["db": ["/tmp/unused"], "debounce": ["1ms"]],
+    flags: []
+  )
+  let runtime = RuntimeOptions(parsedValues: values)
+  let store = try CommandTestDatabase.makeStoreFor1on1()
+  let message = Message(
+    rowID: 10,
+    chatID: 1,
+    sender: "+15551234567",
+    text: "direct msg",
+    date: Date(),
+    isFromMe: false,
+    service: "iMessage",
+    handleID: nil,
+    attachmentsCount: 0
+  )
+
+  let (output, _) = try await StdoutCapture.capture {
+    try await WatchCommand.run(
+      values: values,
+      runtime: runtime,
+      storeFactory: { _ in store },
+      streamProvider: singleMessageStreamProvider(message)
+    )
+  }
+  // 1:1 messages should NOT have parenthetical group label even when watching all chats
+  #expect(!output.contains("("))
+  #expect(!output.contains(")"))
+  #expect(output.contains("direct msg"))
+  #expect(output.contains("+15551234567"))
+}


### PR DESCRIPTION
## Summary
- Resolve phone numbers and emails to contact display names across all commands (chats, history, watch, RPC)
- Add `participants` command to list who's in a chat with resolved names
- Add chat header to `history` CLI output showing chat name, service, and participants
- Add inline `(GroupName)` labels in `watch` stream for group chat messages

## Problem
Raw phone numbers and email addresses are hard to read in chat listings and message history. There's no way to see who's in a group chat without looking at the database directly. When watching all chats, group messages are indistinguishable from 1:1 messages.

## Fix
- `ContactResolver` uses macOS Contacts framework to resolve identifiers to display names with caching and graceful auth denial handling
- New `participants` command with CLI and JSON output, plus `participants.list` RPC method
- History command prints a header before messages (CLI only, no JSON contract changes)
- Watch command appends `(ChatDisplayName)` to sender for group messages when watching all chats (no `--chat-id`)

## Why
Contact resolution makes the tool usable for real conversations — you see names instead of phone numbers. The participants command, history header, and watch labels provide essential context about who you're talking to without requiring extra lookups.

## Test Plan
- 136 tests covering participants command (group, 1:1, JSON, error cases), history header (group, 1:1, empty history, JSON exclusion), watch group labels (all-chats vs scoped, group vs 1:1), RPC handler, and payload encoding
- Manual verification: `imsg participants --chat-id <id>`, `imsg history --chat-id <id>`, `imsg watch` with group and 1:1 chats