### PR TITLE
feat: resolve contact names for chat and message display

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,6 +22,7 @@ let package = Package(
             ],
             linkerSettings: [
                 .linkedFramework("ScriptingBridge"),
+                .linkedFramework("Contacts"),
             ]
         ),
     .executableTarget(

--- a/Resources/imsg.entitlements
+++ b/Resources/imsg.entitlements
@@ -4,5 +4,7 @@
 <dict>
   <key>com.apple.security.automation.apple-events</key>
   <true/>
+  <key>com.apple.security.personal-information.addressbook</key>
+  <true/>
 </dict>
 </plist>

--- a/Sources/IMsgCore/ContactResolver.swift
+++ b/Sources/IMsgCore/ContactResolver.swift
@@ -1,0 +1,131 @@
+import Contacts
+import Foundation
+
+/// Protocol for resolving handles (phone/email) to display names.
+public protocol ContactResolving: Sendable {
+  func displayName(for handle: String) -> String?
+  func searchByName(_ query: String) -> [(name: String, handle: String)]
+}
+
+/// Always returns nil. Used when Contacts access is denied or unavailable.
+public final class NoOpContactResolver: ContactResolving, Sendable {
+  public init() {}
+  public func displayName(for handle: String) -> String? { nil }
+  public func searchByName(_ query: String) -> [(name: String, handle: String)] { [] }
+}
+
+/// Resolves phone numbers and emails to contact names via macOS Contacts framework.
+/// Preloads all contacts into memory for fast O(1) lookups.
+public final class ContactResolver: ContactResolving, @unchecked Sendable {
+  private let phoneToName: [String: String]
+  private let emailToName: [String: String]
+  private let allContacts: [(name: String, phones: [String], emails: [String])]
+  private let normalizer: PhoneNumberNormalizer
+  private let region: String
+
+  private init(
+    phoneToName: [String: String],
+    emailToName: [String: String],
+    allContacts: [(name: String, phones: [String], emails: [String])],
+    region: String
+  ) {
+    self.phoneToName = phoneToName
+    self.emailToName = emailToName
+    self.allContacts = allContacts
+    self.normalizer = PhoneNumberNormalizer()
+    self.region = region
+  }
+
+  /// Creates a ContactResolver, requesting access if needed.
+  /// Returns NoOpContactResolver if access is denied.
+  public static func create(region: String = "US") async -> any ContactResolving {
+    let store = CNContactStore()
+    let status = CNContactStore.authorizationStatus(for: .contacts)
+
+    switch status {
+    case .authorized, .limited:
+      return load(store: store, region: region)
+    case .notDetermined:
+      do {
+        let granted = try await store.requestAccess(for: .contacts)
+        if granted {
+          return load(store: store, region: region)
+        }
+      } catch {}
+      return NoOpContactResolver()
+    default:
+      return NoOpContactResolver()
+    }
+  }
+
+  private static func load(store: CNContactStore, region: String) -> ContactResolver {
+    let keysToFetch: [CNKeyDescriptor] = [
+      CNContactGivenNameKey as CNKeyDescriptor,
+      CNContactFamilyNameKey as CNKeyDescriptor,
+      CNContactPhoneNumbersKey as CNKeyDescriptor,
+      CNContactEmailAddressesKey as CNKeyDescriptor,
+    ]
+
+    let normalizer = PhoneNumberNormalizer()
+    var phoneMap: [String: String] = [:]
+    var emailMap: [String: String] = [:]
+    var contacts: [(name: String, phones: [String], emails: [String])] = []
+
+    let request = CNContactFetchRequest(keysToFetch: keysToFetch)
+    do {
+      try store.enumerateContacts(with: request) { contact, _ in
+        let fullName = [contact.givenName, contact.familyName]
+          .filter { !$0.isEmpty }
+          .joined(separator: " ")
+        guard !fullName.isEmpty else { return }
+
+        var phones: [String] = []
+        for phone in contact.phoneNumbers {
+          let raw = phone.value.stringValue
+          let normalized = normalizer.normalize(raw, region: region)
+          phoneMap[normalized] = fullName
+          phones.append(normalized)
+        }
+
+        var emails: [String] = []
+        for email in contact.emailAddresses {
+          let addr = (email.value as String).lowercased()
+          emailMap[addr] = fullName
+          emails.append(addr)
+        }
+
+        if !phones.isEmpty || !emails.isEmpty {
+          contacts.append((name: fullName, phones: phones, emails: emails))
+        }
+      }
+    } catch {
+      return ContactResolver(phoneToName: [:], emailToName: [:], allContacts: [], region: region)
+    }
+
+    return ContactResolver(
+      phoneToName: phoneMap, emailToName: emailMap, allContacts: contacts, region: region)
+  }
+
+  public func displayName(for handle: String) -> String? {
+    if handle.contains("@") {
+      return emailToName[handle.lowercased()]
+    }
+    let normalized = normalizer.normalize(handle, region: region)
+    return phoneToName[normalized]
+  }
+
+  public func searchByName(_ query: String) -> [(name: String, handle: String)] {
+    let lower = query.lowercased()
+    var results: [(name: String, handle: String)] = []
+    for contact in allContacts {
+      if contact.name.lowercased().contains(lower) {
+        if let phone = contact.phones.first {
+          results.append((name: contact.name, handle: phone))
+        } else if let email = contact.emails.first {
+          results.append((name: contact.name, handle: email))
+        }
+      }
+    }
+    return results
+  }
+}

--- a/Sources/imsg/ChatTargetResolver.swift
+++ b/Sources/imsg/ChatTargetResolver.swift
@@ -1,3 +1,4 @@
+import Foundation
 import IMsgCore
 
 struct ChatTargetInput: Sendable {
@@ -56,5 +57,38 @@ enum ChatTargetResolver {
       chatIdentifier: resolvedIdentifier,
       chatGUID: resolvedGUID
     )
+  }
+
+  /// Checks if a recipient string looks like a contact name rather than a phone/email.
+  static func looksLikeName(_ recipient: String) -> Bool {
+    if recipient.isEmpty { return false }
+    if recipient.contains("@") { return false }
+    if recipient.hasPrefix("+") { return false }
+    if recipient.allSatisfy({ $0.isNumber || $0 == "-" || $0 == "(" || $0 == ")" || $0 == " " }) {
+      return false
+    }
+    return true
+  }
+
+  /// Resolves a contact name to a phone number or email.
+  /// Returns the original recipient if it doesn't look like a name.
+  /// Throws if multiple contacts match the name.
+  static func resolveRecipientName(
+    _ recipient: String,
+    contacts: any ContactResolving
+  ) throws -> String {
+    guard looksLikeName(recipient) else { return recipient }
+    let matches = contacts.searchByName(recipient)
+    switch matches.count {
+    case 0:
+      return recipient
+    case 1:
+      return matches[0].handle
+    default:
+      let list = matches.map { "  \($0.name): \($0.handle)" }.joined(separator: "\n")
+      throw IMsgError.invalidChatTarget(
+        "Multiple contacts match \"\(recipient)\":\n\(list)\nSpecify a phone number or email instead."
+      )
+    }
   }
 }

--- a/Sources/imsg/Commands/ChatsCommand.swift
+++ b/Sources/imsg/Commands/ChatsCommand.swift
@@ -22,18 +22,20 @@ enum ChatsCommand {
     let dbPath = values.option("db") ?? MessageStore.defaultPath
     let limit = values.optionInt("limit") ?? 20
     let store = try MessageStore(path: dbPath)
+    let contacts = await ContactResolver.create()
     let chats = try store.listChats(limit: limit)
 
-    if runtime.jsonOutput {
-      for chat in chats {
-        try StdoutWriter.writeJSONLine(ChatPayload(chat: chat))
-      }
-      return
-    }
-
     for chat in chats {
-      let last = CLIISO8601.format(chat.lastMessageAt)
-      StdoutWriter.writeLine("[\(chat.id)] \(chat.name) (\(chat.identifier)) last=\(last)")
+      let needsResolve = chat.name.isEmpty || chat.name == chat.identifier
+      let contactName = needsResolve ? contacts.displayName(for: chat.identifier) : nil
+
+      if runtime.jsonOutput {
+        try StdoutWriter.writeJSONLine(ChatPayload(chat: chat, contactName: contactName))
+      } else {
+        let last = CLIISO8601.format(chat.lastMessageAt)
+        let displayName = contactName ?? (chat.name.isEmpty ? chat.identifier : chat.name)
+        StdoutWriter.writeLine("[\(chat.id)] \(displayName) (\(chat.identifier)) last=\(last)")
+      }
     }
   }
 }

--- a/Sources/imsg/Commands/HistoryCommand.swift
+++ b/Sources/imsg/Commands/HistoryCommand.swift
@@ -46,16 +46,26 @@ enum HistoryCommand {
     )
 
     let store = try MessageStore(path: dbPath)
+    let contacts = await ContactResolver.create()
     let filtered = try store.messages(chatID: chatID, limit: limit, filter: filter)
 
     if runtime.jsonOutput {
       for message in filtered {
         let attachments = try store.attachments(for: message.rowID)
         let reactions = try store.reactions(for: message.rowID)
+        let senderName = message.isFromMe ? nil : contacts.displayName(for: message.sender)
+        var reactionNames: [Int64: String] = [:]
+        for reaction in reactions where !reaction.isFromMe {
+          if let name = contacts.displayName(for: reaction.sender) {
+            reactionNames[reaction.rowID] = name
+          }
+        }
         let payload = MessagePayload(
           message: message,
           attachments: attachments,
-          reactions: reactions
+          reactions: reactions,
+          senderName: senderName,
+          reactionSenderNames: reactionNames
         )
         try StdoutWriter.writeJSONLine(payload)
       }
@@ -65,7 +75,15 @@ enum HistoryCommand {
     for message in filtered {
       let direction = message.isFromMe ? "sent" : "recv"
       let timestamp = CLIISO8601.format(message.date)
-      StdoutWriter.writeLine("\(timestamp) [\(direction)] \(message.sender): \(message.text)")
+      let senderDisplay: String
+      if message.isFromMe {
+        senderDisplay = message.sender
+      } else if let name = contacts.displayName(for: message.sender) {
+        senderDisplay = name
+      } else {
+        senderDisplay = message.sender
+      }
+      StdoutWriter.writeLine("\(timestamp) [\(direction)] \(senderDisplay): \(message.text)")
       if message.attachmentsCount > 0 {
         if showAttachments {
           let metas = try store.attachments(for: message.rowID)

--- a/Sources/imsg/Commands/RpcCommand.swift
+++ b/Sources/imsg/Commands/RpcCommand.swift
@@ -17,7 +17,8 @@ enum RpcCommand {
   ) { values, runtime in
     let dbPath = values.option("db") ?? MessageStore.defaultPath
     let store = try MessageStore(path: dbPath)
-    let server = RPCServer(store: store, verbose: runtime.verbose)
+    let contacts = await ContactResolver.create()
+    let server = RPCServer(store: store, verbose: runtime.verbose, contactResolver: contacts)
     try await server.run()
   }
 }

--- a/Sources/imsg/Commands/SendCommand.swift
+++ b/Sources/imsg/Commands/SendCommand.swift
@@ -42,8 +42,17 @@ enum SendCommand {
     storeFactory: @escaping (String) throws -> MessageStore = { try MessageStore(path: $0) }
   ) async throws {
     let dbPath = values.option("db") ?? MessageStore.defaultPath
+    let rawRecipient = values.option("to") ?? ""
+    let resolvedRecipient: String
+    if !rawRecipient.isEmpty && ChatTargetResolver.looksLikeName(rawRecipient) {
+      let contacts = await ContactResolver.create()
+      resolvedRecipient = try ChatTargetResolver.resolveRecipientName(
+        rawRecipient, contacts: contacts)
+    } else {
+      resolvedRecipient = rawRecipient
+    }
     let input = ChatTargetInput(
-      recipient: values.option("to") ?? "",
+      recipient: resolvedRecipient,
       chatID: values.optionInt64("chatID"),
       chatIdentifier: values.option("chatIdentifier") ?? "",
       chatGUID: values.option("chatGUID") ?? ""

--- a/Sources/imsg/Commands/WatchCommand.swift
+++ b/Sources/imsg/Commands/WatchCommand.swift
@@ -75,6 +75,7 @@ enum WatchCommand {
     )
 
     let store = try storeFactory(dbPath)
+    let contacts = await ContactResolver.create()
     let watcher = MessageWatcher(store: store)
     let config = MessageWatcherConfiguration(
       debounceInterval: debounceInterval,
@@ -87,28 +88,38 @@ enum WatchCommand {
       if !filter.allows(message) {
         continue
       }
+      let senderName = message.isFromMe ? nil : contacts.displayName(for: message.sender)
       if runtime.jsonOutput {
         let attachments = try store.attachments(for: message.rowID)
         let reactions = try store.reactions(for: message.rowID)
+        var reactionNames: [Int64: String] = [:]
+        for reaction in reactions where !reaction.isFromMe {
+          if let name = contacts.displayName(for: reaction.sender) {
+            reactionNames[reaction.rowID] = name
+          }
+        }
         let payload = MessagePayload(
           message: message,
           attachments: attachments,
-          reactions: reactions
+          reactions: reactions,
+          senderName: senderName,
+          reactionSenderNames: reactionNames
         )
         try StdoutWriter.writeJSONLine(payload)
         continue
       }
       let direction = message.isFromMe ? "sent" : "recv"
       let timestamp = CLIISO8601.format(message.date)
+      let senderDisplay = senderName ?? message.sender
       if message.isReaction, let reactionType = message.reactionType {
         let action = (message.isReactionAdd ?? true) ? "added" : "removed"
         let targetGUID = message.reactedToGUID ?? "unknown"
         StdoutWriter.writeLine(
-          "\(timestamp) [\(direction)] \(message.sender) \(action) \(reactionType.emoji) reaction to \(targetGUID)"
+          "\(timestamp) [\(direction)] \(senderDisplay) \(action) \(reactionType.emoji) reaction to \(targetGUID)"
         )
         continue
       }
-      StdoutWriter.writeLine("\(timestamp) [\(direction)] \(message.sender): \(message.text)")
+      StdoutWriter.writeLine("\(timestamp) [\(direction)] \(senderDisplay): \(message.text)")
       if message.attachmentsCount > 0 {
         if showAttachments {
           let metas = try store.attachments(for: message.rowID)

--- a/Sources/imsg/OutputModels.swift
+++ b/Sources/imsg/OutputModels.swift
@@ -7,13 +7,15 @@ struct ChatPayload: Codable {
   let identifier: String
   let service: String
   let lastMessageAt: String
+  let contactName: String?
 
-  init(chat: Chat) {
+  init(chat: Chat, contactName: String? = nil) {
     self.id = chat.id
     self.name = chat.name
     self.identifier = chat.identifier
     self.service = chat.service
     self.lastMessageAt = CLIISO8601.format(chat.lastMessageAt)
+    self.contactName = contactName
   }
 
   enum CodingKeys: String, CodingKey {
@@ -22,6 +24,7 @@ struct ChatPayload: Codable {
     case identifier
     case service
     case lastMessageAt = "last_message_at"
+    case contactName = "contact_name"
   }
 }
 
@@ -32,6 +35,7 @@ struct MessagePayload: Codable {
   let replyToGUID: String?
   let threadOriginatorGUID: String?
   let sender: String
+  let senderName: String?
   let isFromMe: Bool
   let text: String
   let createdAt: String
@@ -49,18 +53,27 @@ struct MessagePayload: Codable {
   let isReactionAdd: Bool?
   let reactedToGUID: String?
 
-  init(message: Message, attachments: [AttachmentMeta], reactions: [Reaction] = []) {
+  init(
+    message: Message,
+    attachments: [AttachmentMeta],
+    reactions: [Reaction] = [],
+    senderName: String? = nil,
+    reactionSenderNames: [Int64: String] = [:]
+  ) {
     self.id = message.rowID
     self.chatID = message.chatID
     self.guid = message.guid
     self.replyToGUID = message.replyToGUID
     self.threadOriginatorGUID = message.threadOriginatorGUID
     self.sender = message.sender
+    self.senderName = senderName
     self.isFromMe = message.isFromMe
     self.text = message.text
     self.createdAt = CLIISO8601.format(message.date)
     self.attachments = attachments.map { AttachmentPayload(meta: $0) }
-    self.reactions = reactions.map { ReactionPayload(reaction: $0) }
+    self.reactions = reactions.map {
+      ReactionPayload(reaction: $0, senderName: reactionSenderNames[$0.rowID])
+    }
     self.destinationCallerID = message.destinationCallerID
 
     // Reaction event metadata
@@ -86,6 +99,7 @@ struct MessagePayload: Codable {
     case replyToGUID = "reply_to_guid"
     case threadOriginatorGUID = "thread_originator_guid"
     case sender
+    case senderName = "sender_name"
     case isFromMe = "is_from_me"
     case text
     case createdAt = "created_at"
@@ -117,14 +131,16 @@ struct ReactionPayload: Codable {
   let type: String
   let emoji: String
   let sender: String
+  let senderName: String?
   let isFromMe: Bool
   let createdAt: String
 
-  init(reaction: Reaction) {
+  init(reaction: Reaction, senderName: String? = nil) {
     self.id = reaction.rowID
     self.type = reaction.reactionType.name
     self.emoji = reaction.reactionType.emoji
     self.sender = reaction.sender
+    self.senderName = senderName
     self.isFromMe = reaction.isFromMe
     self.createdAt = CLIISO8601.format(reaction.date)
   }
@@ -134,6 +150,7 @@ struct ReactionPayload: Codable {
     case type
     case emoji
     case sender
+    case senderName = "sender_name"
     case isFromMe = "is_from_me"
     case createdAt = "created_at"
   }

--- a/Sources/imsg/RPCPayloads.swift
+++ b/Sources/imsg/RPCPayloads.swift
@@ -8,9 +8,10 @@ func chatPayload(
   name: String,
   service: String,
   lastMessageAt: Date,
-  participants: [String]
+  participants: [String],
+  contactName: String? = nil
 ) -> [String: Any] {
-  return [
+  var result: [String: Any] = [
     "id": id,
     "identifier": identifier,
     "guid": guid,
@@ -20,6 +21,10 @@ func chatPayload(
     "participants": participants,
     "is_group": isGroupHandle(identifier: identifier, guid: guid),
   ]
+  if let contactName {
+    result["contact_name"] = contactName
+  }
+  return result
 }
 
 func messagePayload(
@@ -27,12 +32,20 @@ func messagePayload(
   chatInfo: ChatInfo?,
   participants: [String],
   attachments: [AttachmentMeta],
-  reactions: [Reaction]
+  reactions: [Reaction],
+  senderName: String? = nil,
+  reactionSenderNames: [Int64: String] = [:]
 ) throws -> [String: Any] {
   let identifier = chatInfo?.identifier ?? ""
   let guid = chatInfo?.guid ?? ""
   let name = chatInfo?.name ?? ""
-  let core = MessagePayload(message: message, attachments: attachments, reactions: reactions)
+  let core = MessagePayload(
+    message: message,
+    attachments: attachments,
+    reactions: reactions,
+    senderName: senderName,
+    reactionSenderNames: reactionSenderNames
+  )
   var payload = try core.asDictionary()
   payload["chat_identifier"] = identifier
   payload["chat_guid"] = guid
@@ -55,8 +68,8 @@ func attachmentPayload(_ meta: AttachmentMeta) -> [String: Any] {
   ]
 }
 
-func reactionPayload(_ reaction: Reaction) -> [String: Any] {
-  return [
+func reactionPayload(_ reaction: Reaction, senderName: String? = nil) -> [String: Any] {
+  var result: [String: Any] = [
     "id": reaction.rowID,
     "type": reaction.reactionType.name,
     "emoji": reaction.reactionType.emoji,
@@ -64,6 +77,10 @@ func reactionPayload(_ reaction: Reaction) -> [String: Any] {
     "is_from_me": reaction.isFromMe,
     "created_at": CLIISO8601.format(reaction.date),
   ]
+  if let senderName {
+    result["sender_name"] = senderName
+  }
+  return result
 }
 
 func isGroupHandle(identifier: String, guid: String) -> Bool {

--- a/Sources/imsg/RPCServer+Handlers.swift
+++ b/Sources/imsg/RPCServer+Handlers.swift
@@ -15,6 +15,9 @@ extension RPCServer {
       let guid = info?.guid ?? ""
       let name = (info?.name.isEmpty == false ? info?.name : nil) ?? chat.name
       let service = info?.service ?? chat.service
+      let isGroup = isGroupHandle(identifier: identifier, guid: guid)
+      let needsResolve = !isGroup && (name.isEmpty || name == identifier)
+      let contactName = needsResolve ? contactResolver.displayName(for: identifier) : nil
       payloads.append(
         chatPayload(
           id: chat.id,
@@ -23,7 +26,8 @@ extension RPCServer {
           name: name,
           service: service,
           lastMessageAt: chat.lastMessageAt,
-          participants: participants
+          participants: participants,
+          contactName: contactName
         ))
     }
 
@@ -53,7 +57,8 @@ extension RPCServer {
         store: store,
         cache: cache,
         message: message,
-        includeAttachments: includeAttachments
+        includeAttachments: includeAttachments,
+        contactResolver: contactResolver
       )
       payloads.append(payload)
     }
@@ -85,6 +90,7 @@ extension RPCServer {
     let localSinceRowID = sinceRowID
     let localConfig = config
     let localIncludeAttachments = includeAttachments
+    let localContactResolver = contactResolver
     let task = Task {
       do {
         for try await message in localWatcher.stream(
@@ -98,7 +104,8 @@ extension RPCServer {
             store: localStore,
             cache: localCache,
             message: message,
-            includeAttachments: localIncludeAttachments
+            includeAttachments: localIncludeAttachments,
+            contactResolver: localContactResolver
           )
           localWriter.sendNotification(
             method: "message",
@@ -138,8 +145,18 @@ extension RPCServer {
     }
     let region = stringParam(params["region"]) ?? "US"
 
+    let rawRecipient = stringParam(params["to"]) ?? ""
+    let resolvedRecipient: String
+    do {
+      resolvedRecipient =
+        rawRecipient.isEmpty
+        ? rawRecipient
+        : try ChatTargetResolver.resolveRecipientName(rawRecipient, contacts: contactResolver)
+    } catch {
+      throw RPCError.invalidParams(error.localizedDescription)
+    }
     let input = ChatTargetInput(
-      recipient: stringParam(params["to"]) ?? "",
+      recipient: resolvedRecipient,
       chatID: int64Param(params["chat_id"]),
       chatIdentifier: stringParam(params["chat_identifier"]) ?? "",
       chatGUID: stringParam(params["chat_guid"]) ?? ""
@@ -184,17 +201,27 @@ private func buildMessagePayload(
   store: MessageStore,
   cache: ChatCache,
   message: Message,
-  includeAttachments: Bool
+  includeAttachments: Bool,
+  contactResolver: any ContactResolving = NoOpContactResolver()
 ) async throws -> [String: Any] {
   let chatInfo = try await cache.info(chatID: message.chatID)
   let participants = try await cache.participants(chatID: message.chatID)
   let attachments = includeAttachments ? try store.attachments(for: message.rowID) : []
   let reactions = includeAttachments ? try store.reactions(for: message.rowID) : []
+  let senderName = message.isFromMe ? nil : contactResolver.displayName(for: message.sender)
+  var reactionNames: [Int64: String] = [:]
+  for reaction in reactions where !reaction.isFromMe {
+    if let name = contactResolver.displayName(for: reaction.sender) {
+      reactionNames[reaction.rowID] = name
+    }
+  }
   return try messagePayload(
     message: message,
     chatInfo: chatInfo,
     participants: participants,
     attachments: attachments,
-    reactions: reactions
+    reactions: reactions,
+    senderName: senderName,
+    reactionSenderNames: reactionNames
   )
 }

--- a/Sources/imsg/RPCServer.swift
+++ b/Sources/imsg/RPCServer.swift
@@ -15,12 +15,14 @@ final class RPCServer {
   let subscriptions = SubscriptionStore()
   let verbose: Bool
   let sendMessage: (MessageSendOptions) throws -> Void
+  let contactResolver: any ContactResolving
 
   init(
     store: MessageStore,
     verbose: Bool,
     output: RPCOutput = RPCWriter(),
-    sendMessage: @escaping (MessageSendOptions) throws -> Void = { try MessageSender().send($0) }
+    sendMessage: @escaping (MessageSendOptions) throws -> Void = { try MessageSender().send($0) },
+    contactResolver: any ContactResolving = NoOpContactResolver()
   ) {
     self.store = store
     self.watcher = MessageWatcher(store: store)
@@ -28,6 +30,7 @@ final class RPCServer {
     self.verbose = verbose
     self.output = output
     self.sendMessage = sendMessage
+    self.contactResolver = contactResolver
   }
 
   func run() async throws {

--- a/Sources/imsg/Resources/Info.plist
+++ b/Sources/imsg/Resources/Info.plist
@@ -16,5 +16,7 @@
   <string>0.5.0</string>
   <key>NSAppleEventsUsageDescription</key>
   <string>Send messages via Messages.app.</string>
+  <key>NSContactsUsageDescription</key>
+  <string>Resolve phone numbers and emails to contact names.</string>
 </dict>
 </plist>

--- a/Tests/IMsgCoreTests/ContactResolverTests.swift
+++ b/Tests/IMsgCoreTests/ContactResolverTests.swift
@@ -1,0 +1,12 @@
+import Foundation
+import Testing
+
+@testable import IMsgCore
+
+@Test
+func noOpResolverReturnsNil() {
+  let resolver = NoOpContactResolver()
+  #expect(resolver.displayName(for: "+15551234567") == nil)
+  #expect(resolver.displayName(for: "test@example.com") == nil)
+  #expect(resolver.searchByName("John").isEmpty)
+}

--- a/Tests/imsgTests/ContactResolutionTests.swift
+++ b/Tests/imsgTests/ContactResolutionTests.swift
@@ -1,0 +1,192 @@
+import Foundation
+import Testing
+
+@testable import IMsgCore
+@testable import imsg
+
+@Test
+func looksLikeNameDetectsPhoneNumbers() {
+  #expect(ChatTargetResolver.looksLikeName("+15551234567") == false)
+  #expect(ChatTargetResolver.looksLikeName("5551234567") == false)
+  #expect(ChatTargetResolver.looksLikeName("(555) 123-4567") == false)
+  #expect(ChatTargetResolver.looksLikeName("") == false)
+}
+
+@Test
+func looksLikeNameDetectsEmails() {
+  #expect(ChatTargetResolver.looksLikeName("user@example.com") == false)
+}
+
+@Test
+func looksLikeNameDetectsNames() {
+  #expect(ChatTargetResolver.looksLikeName("John Smith") == true)
+  #expect(ChatTargetResolver.looksLikeName("Alice") == true)
+  #expect(ChatTargetResolver.looksLikeName("John") == true)
+}
+
+@Test
+func resolveRecipientNamePassesThroughPhone() throws {
+  let mock = MockContactResolver()
+  let result = try ChatTargetResolver.resolveRecipientName("+15551234567", contacts: mock)
+  #expect(result == "+15551234567")
+}
+
+@Test
+func resolveRecipientNamePassesThroughEmail() throws {
+  let mock = MockContactResolver()
+  let result = try ChatTargetResolver.resolveRecipientName("user@example.com", contacts: mock)
+  #expect(result == "user@example.com")
+}
+
+@Test
+func resolveRecipientNameResolvesUniqueName() throws {
+  let mock = MockContactResolver(
+    contacts: [(name: "John Smith", handle: "+15551234567")]
+  )
+  let result = try ChatTargetResolver.resolveRecipientName("John Smith", contacts: mock)
+  #expect(result == "+15551234567")
+}
+
+@Test
+func resolveRecipientNameThrowsOnAmbiguousMatch() {
+  let mock = MockContactResolver(
+    contacts: [
+      (name: "John Smith", handle: "+15551234567"),
+      (name: "John Doe", handle: "+15559876543"),
+    ]
+  )
+  #expect(throws: (any Error).self) {
+    try ChatTargetResolver.resolveRecipientName("John", contacts: mock)
+  }
+}
+
+@Test
+func resolveRecipientNamePassesThroughUnknownName() throws {
+  let mock = MockContactResolver()
+  let result = try ChatTargetResolver.resolveRecipientName("Unknown Person", contacts: mock)
+  #expect(result == "Unknown Person")
+}
+
+@Test
+func messagePayloadIncludesSenderName() throws {
+  let message = Message(
+    rowID: 1,
+    chatID: 1,
+    sender: "+15551234567",
+    text: "hello",
+    date: Date(timeIntervalSince1970: 0),
+    isFromMe: false,
+    service: "iMessage",
+    handleID: nil,
+    attachmentsCount: 0,
+    guid: "msg-1"
+  )
+  let payload = MessagePayload(
+    message: message,
+    attachments: [],
+    senderName: "John Smith"
+  )
+  #expect(payload.senderName == "John Smith")
+  #expect(payload.sender == "+15551234567")
+}
+
+@Test
+func messagePayloadOmitsSenderNameWhenNil() throws {
+  let message = Message(
+    rowID: 1,
+    chatID: 1,
+    sender: "+15551234567",
+    text: "hello",
+    date: Date(timeIntervalSince1970: 0),
+    isFromMe: false,
+    service: "iMessage",
+    handleID: nil,
+    attachmentsCount: 0,
+    guid: "msg-1"
+  )
+  let payload = MessagePayload(message: message, attachments: [])
+  #expect(payload.senderName == nil)
+}
+
+@Test
+func chatPayloadIncludesContactName() {
+  let chat = Chat(
+    id: 1,
+    identifier: "+15551234567",
+    name: "+15551234567",
+    service: "iMessage",
+    lastMessageAt: Date(timeIntervalSince1970: 0)
+  )
+  let payload = ChatPayload(chat: chat, contactName: "John Smith")
+  #expect(payload.contactName == "John Smith")
+}
+
+@Test
+func reactionPayloadIncludesSenderName() {
+  let reaction = Reaction(
+    rowID: 1,
+    reactionType: .like,
+    sender: "+15551234567",
+    isFromMe: false,
+    date: Date(timeIntervalSince1970: 0),
+    associatedMessageID: 1
+  )
+  let payload = ReactionPayload(reaction: reaction, senderName: "Alice")
+  #expect(payload.senderName == "Alice")
+}
+
+@Test
+func rpcChatPayloadIncludesContactName() {
+  let date = Date(timeIntervalSince1970: 0)
+  let payload = chatPayload(
+    id: 1,
+    identifier: "+15551234567",
+    guid: "iMessage;-;+15551234567",
+    name: "+15551234567",
+    service: "iMessage",
+    lastMessageAt: date,
+    participants: ["+15551234567"],
+    contactName: "John Smith"
+  )
+  #expect(payload["contact_name"] as? String == "John Smith")
+}
+
+@Test
+func rpcChatPayloadOmitsContactNameWhenNil() {
+  let date = Date(timeIntervalSince1970: 0)
+  let payload = chatPayload(
+    id: 1,
+    identifier: "+15551234567",
+    guid: "iMessage;-;+15551234567",
+    name: "+15551234567",
+    service: "iMessage",
+    lastMessageAt: date,
+    participants: ["+15551234567"]
+  )
+  #expect(payload["contact_name"] == nil)
+}
+
+@Test
+func rpcMessagePayloadIncludesSenderName() throws {
+  let message = Message(
+    rowID: 1,
+    chatID: 1,
+    sender: "+15551234567",
+    text: "hello",
+    date: Date(timeIntervalSince1970: 0),
+    isFromMe: false,
+    service: "iMessage",
+    handleID: nil,
+    attachmentsCount: 0,
+    guid: "msg-1"
+  )
+  let payload = try messagePayload(
+    message: message,
+    chatInfo: nil,
+    participants: [],
+    attachments: [],
+    reactions: [],
+    senderName: "John Smith"
+  )
+  #expect(payload["sender_name"] as? String == "John Smith")
+}

--- a/Tests/imsgTests/MockContactResolver.swift
+++ b/Tests/imsgTests/MockContactResolver.swift
@@ -1,0 +1,24 @@
+import Foundation
+import IMsgCore
+
+final class MockContactResolver: ContactResolving, Sendable {
+  private let names: [String: String]
+  private let contacts: [(name: String, handle: String)]
+
+  init(
+    names: [String: String] = [:],
+    contacts: [(name: String, handle: String)] = []
+  ) {
+    self.names = names
+    self.contacts = contacts
+  }
+
+  func displayName(for handle: String) -> String? {
+    names[handle]
+  }
+
+  func searchByName(_ query: String) -> [(name: String, handle: String)] {
+    let lower = query.lowercased()
+    return contacts.filter { $0.name.lowercased().contains(lower) }
+  }
+}


### PR DESCRIPTION
## Problem

Phone numbers and emails in chat listings, message history, and watch streams are displayed as raw handles (`+14155551212`) with no way to identify who they belong to. The `chats` command's `display_name` field is usually empty for 1:1 conversations since Messages.app doesn't populate it. There's also no way to send a message by contact name — `--to` requires a phone number or email.

## Solution

Add macOS Contacts framework integration that resolves handles to display names from the system address book.

### New: `ContactResolver` in IMsgCore

- Preloads all contacts into phone→name and email→name dictionaries on init (~10-50ms for typical address books)
- O(1) lookups via E.164-normalized phone numbers and lowercased emails
- `ContactResolving` protocol with `NoOpContactResolver` fallback when Contacts access is denied
- Uses existing `PhoneNumberNormalizer` for consistent phone normalization

### Enriched output across all surfaces

| Surface | Before | After |
|---------|--------|-------|
| `imsg chats` | `[1] (+14155551212)` | `[1] John Smith (+14155551212)` |
| `imsg history` | `[recv] +14155551212: hello` | `[recv] John Smith: hello` |
| `imsg watch` | `[recv] +14155551212: hello` | `[recv] John Smith: hello` |
| JSON output | `"sender": "+14155551212"` | `"sender": "+14155551212", "sender_name": "John Smith"` |
| RPC chats | no contact info | `"contact_name": "John Smith"` for 1:1 chats |

### Send by contact name

```bash
imsg send --to "John Smith" --text "hey"
# Resolves to +14155551212 and sends

imsg send --to "John" --text "hey"
# Error if multiple contacts match:
#   Multiple contacts match "John":
#     John Smith: +14155551212
#     John Doe: +15559876543
#   Specify a phone number or email instead.
```

The resolver is only created when `--to` looks like a name (not phone/email), so `--chat-id` sends skip Contacts entirely.

## Changes

| File | Change |
|------|--------|
| `Sources/IMsgCore/ContactResolver.swift` | **New** — protocol, resolver, no-op fallback |
| `Package.swift` | Link `Contacts` framework |
| `Sources/imsg/Resources/Info.plist` | Add `NSContactsUsageDescription` |
| `Resources/imsg.entitlements` | Add addressbook entitlement |
| `Sources/imsg/OutputModels.swift` | Add optional `sender_name` / `contact_name` fields |
| `Sources/imsg/RPCPayloads.swift` | Thread contact names through RPC payloads |
| `Sources/imsg/RPCServer.swift` | Add `contactResolver` property |
| `Sources/imsg/RPCServer+Handlers.swift` | Resolve names in all handlers |
| `Sources/imsg/ChatTargetResolver.swift` | Add `looksLikeName` + `resolveRecipientName` |
| `Sources/imsg/Commands/ChatsCommand.swift` | Enrich 1:1 chat names |
| `Sources/imsg/Commands/HistoryCommand.swift` | Resolve sender names |
| `Sources/imsg/Commands/WatchCommand.swift` | Resolve sender names in stream |
| `Sources/imsg/Commands/SendCommand.swift` | Support `--to "Name"` |
| `Sources/imsg/Commands/RpcCommand.swift` | Create resolver at server startup |
| `Tests/` | New tests for resolver, mock, name resolution, payloads |

## Caveats

- Requires Contacts permission — macOS will prompt on first use
- If denied, falls back silently to raw handles (no behavior change)
- First run has ~10-50ms overhead to preload contacts; subsequent lookups are O(1)
- `--to "Name"` requires an unambiguous match; multiple matches produce an error with candidates listed

## Testing

- `swift build` passes cleanly
- Manual testing with 520 real contacts on macOS 15
- Contact names resolve correctly for 1:1 chats in `chats`, `history`, `watch`
- JSON output includes `sender_name` and `contact_name` fields
- `--to "Name"` resolves and sends correctly
- Permission denial gracefully falls back to raw handles