### PR TITLE
fix: re-confirm is_from_me after INSERT to prevent echo loops

### DIFF
--- a/Sources/IMsgCore/MessageStore+Messages.swift
+++ b/Sources/IMsgCore/MessageStore+Messages.swift
@@ -42,6 +42,89 @@ extension MessageStore {
     return try messages(chatID: chatID, limit: limit, filter: nil)
   }
 
+  /// Fetch a single message by its ROWID. Returns nil if not found.
+  public func message(rowID: Int64) throws -> Message? {
+    let bodyColumn = hasAttributedBody ? "m.attributedBody" : "NULL"
+    let guidColumn = hasReactionColumns ? "m.guid" : "NULL"
+    let associatedGuidColumn = hasReactionColumns ? "m.associated_message_guid" : "NULL"
+    let associatedTypeColumn = hasReactionColumns ? "m.associated_message_type" : "NULL"
+    let destinationCallerColumn = hasDestinationCallerID ? "m.destination_caller_id" : "NULL"
+    let audioMessageColumn = hasAudioMessageColumn ? "m.is_audio_message" : "0"
+    let threadOriginatorColumn =
+      hasThreadOriginatorGUIDColumn ? "m.thread_originator_guid" : "NULL"
+    let sql = """
+      SELECT m.ROWID, cmj.chat_id, m.handle_id, h.id, IFNULL(m.text, '') AS text, m.date, m.is_from_me, m.service,
+             \(audioMessageColumn) AS is_audio_message, \(destinationCallerColumn) AS destination_caller_id,
+             \(guidColumn) AS guid, \(associatedGuidColumn) AS associated_guid, \(associatedTypeColumn) AS associated_type,
+             (SELECT COUNT(*) FROM message_attachment_join maj WHERE maj.message_id = m.ROWID) AS attachments,
+             \(bodyColumn) AS body,
+             \(threadOriginatorColumn) AS thread_originator_guid
+      FROM message m
+      LEFT JOIN chat_message_join cmj ON m.ROWID = cmj.message_id
+      LEFT JOIN handle h ON m.handle_id = h.ROWID
+      WHERE m.ROWID = ?
+      LIMIT 1
+      """
+    let columns = MessageRowColumns(
+      rowID: 0,
+      chatID: 1,
+      handleID: 2,
+      sender: 3,
+      text: 4,
+      date: 5,
+      isFromMe: 6,
+      service: 7,
+      isAudioMessage: 8,
+      destinationCallerID: 9,
+      guid: 10,
+      associatedGUID: 11,
+      associatedType: 12,
+      attachments: 13,
+      body: 14,
+      threadOriginatorGUID: 15
+    )
+    return try withConnection { db in
+      for row in try db.prepare(sql, [rowID as Binding?]) {
+        let decoded = try decodeMessageRow(row, columns: columns, fallbackChatID: nil)
+        let replyToGUID = replyToGUID(
+          associatedGuid: decoded.associatedGUID,
+          associatedType: decoded.associatedType
+        )
+        let reaction = decodeReaction(
+          associatedType: decoded.associatedType,
+          associatedGUID: decoded.associatedGUID,
+          text: decoded.text
+        )
+        return Message(
+          rowID: decoded.rowID,
+          chatID: decoded.chatID,
+          sender: decoded.sender,
+          text: decoded.text,
+          date: decoded.date,
+          isFromMe: decoded.isFromMe,
+          service: decoded.service,
+          handleID: decoded.handleID,
+          attachmentsCount: decoded.attachments,
+          guid: decoded.guid,
+          routing: Message.RoutingMetadata(
+            replyToGUID: replyToGUID,
+            threadOriginatorGUID: decoded.threadOriginatorGUID.isEmpty
+              ? nil : decoded.threadOriginatorGUID,
+            destinationCallerID: decoded.destinationCallerID.isEmpty
+              ? nil : decoded.destinationCallerID
+          ),
+          reaction: Message.ReactionMetadata(
+            isReaction: reaction.isReaction,
+            reactionType: reaction.reactionType,
+            isReactionAdd: reaction.isReactionAdd,
+            reactedToGUID: reaction.reactedToGUID
+          )
+        )
+      }
+      return nil
+    }
+  }
+
   public func messages(chatID: Int64, limit: Int, filter: MessageFilter?) throws -> [Message] {
     let bodyColumn = hasAttributedBody ? "m.attributedBody" : "NULL"
     let guidColumn = hasReactionColumns ? "m.guid" : "NULL"

--- a/Sources/IMsgCore/MessageWatcher.swift
+++ b/Sources/IMsgCore/MessageWatcher.swift
@@ -6,13 +6,22 @@ public struct MessageWatcherConfiguration: Sendable, Equatable {
   public var batchLimit: Int
   /// When true, reaction events (tapback add/remove) are included in the stream
   public var includeReactions: Bool
+  /// Delay in milliseconds before re-reading a message row to confirm is_from_me.
+  /// macOS may write is_from_me=0 on INSERT and update it to 1 shortly after.
+  /// Messages where is_from_me is still false after the delay are emitted normally.
+  /// Set to 0 to disable re-confirmation (preserves original behavior).
+  public var reconfirmDelayMs: Int
 
   public init(
-    debounceInterval: TimeInterval = 0.25, batchLimit: Int = 100, includeReactions: Bool = false
+    debounceInterval: TimeInterval = 0.25,
+    batchLimit: Int = 100,
+    includeReactions: Bool = false,
+    reconfirmDelayMs: Int = 400
   ) {
     self.debounceInterval = debounceInterval
     self.batchLimit = batchLimit
     self.includeReactions = includeReactions
+    self.reconfirmDelayMs = reconfirmDelayMs
   }
 }
 
@@ -54,6 +63,8 @@ private final class WatchState: @unchecked Sendable {
   private var cursor: Int64
   private var sources: [DispatchSourceFileSystemObject] = []
   private var pending = false
+  /// RowIDs currently pending re-confirmation (awaiting is_from_me re-read)
+  private var pendingReconfirm: Set<Int64> = []
 
   init(
     store: MessageStore,
@@ -137,13 +148,42 @@ private final class WatchState: @unchecked Sendable {
         includeReactions: configuration.includeReactions
       )
       for message in messages {
-        continuation.yield(message)
         if message.rowID > cursor {
           cursor = message.rowID
+        }
+        // If reconfirmDelayMs > 0 and the message appears outbound (is_from_me=false
+        // with no handle), schedule a re-read: macOS may not have set is_from_me=1 yet.
+        let delayMs = configuration.reconfirmDelayMs
+        if delayMs > 0 && !message.isFromMe && message.handleID == nil {
+          let rowID = message.rowID
+          guard !pendingReconfirm.contains(rowID) else { continue }
+          pendingReconfirm.insert(rowID)
+          let delay = DispatchTimeInterval.milliseconds(delayMs)
+          queue.asyncAfter(deadline: .now() + delay) { [weak self] in
+            self?.reconfirm(rowID: rowID, original: message)
+          }
+        } else {
+          continuation.yield(message)
         }
       }
     } catch {
       continuation.finish(throwing: error)
+    }
+  }
+
+  private func reconfirm(rowID: Int64, original: Message) {
+    pendingReconfirm.remove(rowID)
+    do {
+      if let fresh = try store.message(rowID: rowID) {
+        // Suppress if macOS has now marked this as sent by us
+        if fresh.isFromMe { return }
+        continuation.yield(fresh)
+      } else {
+        // Row gone — suppress
+      }
+    } catch {
+      // On error, fall back to emitting the original
+      continuation.yield(original)
     }
   }
 }

--- a/Sources/imsg/Commands/WatchCommand.swift
+++ b/Sources/imsg/Commands/WatchCommand.swift
@@ -15,6 +15,9 @@ enum WatchCommand {
             label: "debounce", names: [.long("debounce")],
             help: "debounce interval for filesystem events (e.g. 250ms)"),
           .make(
+            label: "reconfirmDelay", names: [.long("reconfirm-delay")],
+            help: "re-read delay to confirm is_from_me after INSERT (e.g. 400ms, 0 to disable)"),
+          .make(
             label: "sinceRowID", names: [.long("since-rowid")],
             help: "start watching after this rowid"),
           .make(
@@ -62,6 +65,15 @@ enum WatchCommand {
     guard let debounceInterval = DurationParser.parse(debounceString) else {
       throw ParsedValuesError.invalidOption("debounce")
     }
+    let reconfirmDelayString = values.option("reconfirmDelay") ?? "400ms"
+    let reconfirmDelayMs: Int
+    if reconfirmDelayString == "0" || reconfirmDelayString == "0ms" {
+      reconfirmDelayMs = 0
+    } else if let d = DurationParser.parse(reconfirmDelayString) {
+      reconfirmDelayMs = Int(d * 1000)
+    } else {
+      throw ParsedValuesError.invalidOption("reconfirm-delay")
+    }
     let sinceRowID = values.optionInt64("sinceRowID")
     let showAttachments = values.flag("attachments")
     let includeReactions = values.flag("reactions")
@@ -79,7 +91,8 @@ enum WatchCommand {
     let config = MessageWatcherConfiguration(
       debounceInterval: debounceInterval,
       batchLimit: 100,
-      includeReactions: includeReactions
+      includeReactions: includeReactions,
+      reconfirmDelayMs: reconfirmDelayMs
     )
 
     let stream = streamProvider(watcher, chatID, sinceRowID, config)

--- a/Sources/imsg/RPCServer+Handlers.swift
+++ b/Sources/imsg/RPCServer+Handlers.swift
@@ -69,12 +69,13 @@ extension RPCServer {
     let endISO = stringParam(params["end"])
     let includeAttachments = boolParam(params["attachments"]) ?? false
     let includeReactions = boolParam(params["include_reactions"]) ?? false
+    let reconfirmDelayMs = intParam(params["reconfirm_delay_ms"]) ?? 400
     let filter = try MessageFilter.fromISO(
       participants: participants,
       startISO: startISO,
       endISO: endISO
     )
-    let config = MessageWatcherConfiguration(includeReactions: includeReactions)
+    let config = MessageWatcherConfiguration(includeReactions: includeReactions, reconfirmDelayMs: reconfirmDelayMs)
     let subID = await subscriptions.allocateID()
     let localStore = store
     let localWatcher = watcher


### PR DESCRIPTION
## Problem

When `imsg send` sends a message, macOS writes `is_from_me=0` on the initial SQLite INSERT, then updates it to `1` shortly after. The filesystem watcher fires on the INSERT event and emits the message with `is_from_me: false`, causing agents (e.g. OpenClaw) to treat their own sent messages as inbound — triggering an infinite echo loop.

## Fix

When a new message arrives with `is_from_me=false` and no `handle_id` (the fingerprint of a potentially-unconfirmed outbound message), delay emission by `reconfirmDelayMs` (default: 400ms) and re-read the row from the DB. If `is_from_me` is now `true`, suppress the event. If still `false`, emit normally.

## Changes

- `MessageWatcherConfiguration`: new `reconfirmDelayMs` param (default `400`, set `0` to disable and preserve original behavior)
- `MessageWatcher/WatchState`: re-confirmation logic with a `pendingReconfirm` set to avoid duplicate scheduling
- `MessageStore+Messages`: new `message(rowID:)` single-row lookup
- `WatchCommand`: new `--reconfirm-delay` flag (same duration format as `--debounce`, default `400ms`)
- `RPCServer+Handlers`: new optional `reconfirm_delay_ms` param in `watch.subscribe`

## Backwards compatibility

Setting `reconfirmDelayMs = 0` / `--reconfirm-delay 0` preserves the exact original behavior with zero overhead.