### PR TITLE
feat: CLI JSON group metadata + imsg group command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 ## Unreleased
+- feat: expose group-chat metadata (`is_group`, `chat_identifier`, `chat_guid`, `chat_name`, `participants`, raw `display_name`, `guid`) in `imsg chats`, `imsg history`, and `imsg watch` JSON output — matching the existing RPC surface. `participants` reports external handles only (the local user is implicit, as in the underlying `chat_handle_join` table).
+- feat: new `imsg group --chat-id <id> [--json]` command prints chat identity and participants for one chat id.
+- feat: `imsg chats` plain text marks groups with a `[<id> group]` tag; `imsg history` prints a group-chat header; `imsg watch` appends ` (group)` to group messages.
+- refactor: move `ChatCache` actor into its own `Sources/imsg/ChatCache.swift`; reuse it in `imsg watch` to memoize per-chat lookups.
+- refactor: move `isGroupHandle(...)` from the CLI target into `IMsgCore` so both CLI JSON and RPC paths share one group-detection source of truth.
 - fix: dedupe URL balloon preview duplicates in watch stream without cross-chat/schema regressions (#64, thanks @lesaai)
 - fix: remove non-functional `typing` command and related RPC methods
 - fix: remove unsupported standalone IMCore typing path and stale error branch

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ make build
 ```
 
 ## Commands
-- `imsg chats [--limit 20] [--json]` — list recent conversations.
+- `imsg chats [--limit 20] [--json]` — list recent conversations (group chats are marked with `[group]` in plain text and carry `is_group`, `guid`, `display_name`, and `participants` in JSON).
+- `imsg group --chat-id <id> [--json]` — show identity and participants for one chat (works for direct chats too).
 - `imsg history --chat-id <id> [--limit 50] [--attachments] [--participants +15551234567,...] [--start 2025-01-01T00:00:00Z] [--end 2025-02-01T00:00:00Z] [--json]`
 - `imsg watch [--chat-id <id>] [--since-rowid <n>] [--debounce 250ms] [--attachments] [--participants …] [--start …] [--end …] [--json]`
 - `imsg send --to <handle> [--text "hi"] [--file /path/img.jpg] [--service imessage|sms|auto] [--region US]`
@@ -34,8 +35,11 @@ make build
 # list 5 chats
 imsg chats --limit 5
 
-# list chats as JSON
+# list chats as JSON (includes is_group, guid, display_name, participants)
 imsg chats --limit 5 --json
+
+# show identity + participants for one chat (works for direct chats too)
+imsg group --chat-id 1 --json
 
 # last 10 messages in chat 1 with attachments
 imsg history --chat-id 1 --limit 10 --attachments

--- a/Sources/IMsgCore/GroupDetection.swift
+++ b/Sources/IMsgCore/GroupDetection.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+/// Returns `true` when the chat identifier or GUID encodes a group chat.
+///
+/// Messages stores group chats with a `SERVICE;+;TARGET` encoding (for example
+/// `iMessage;+;chat1234567890`). Direct 1:1 chats use `SERVICE;-;TARGET`. Only
+/// the `;+;` marker is treated as a group here; the `;-;` form is intentionally
+/// excluded so SMS/iMessage direct chats are not misclassified.
+public func isGroupHandle(identifier: String, guid: String) -> Bool {
+  return guid.contains(";+;") || identifier.contains(";+;")
+}

--- a/Sources/IMsgCore/MessageStore.swift
+++ b/Sources/IMsgCore/MessageStore.swift
@@ -21,6 +21,8 @@ public final class MessageStore: @unchecked Sendable {
   let hasAudioMessageColumn: Bool
   let hasAttachmentUserInfo: Bool
   let hasBalloonBundleIDColumn: Bool
+  let hasChatTable: Bool
+  let hasChatHandleJoinTable: Bool
 
   private struct URLBalloonDedupeEntry: Sendable {
     let rowID: Int64
@@ -54,6 +56,12 @@ public final class MessageStore: @unchecked Sendable {
       self.hasAudioMessageColumn = messageColumns.contains("is_audio_message")
       self.hasAttachmentUserInfo = attachmentColumns.contains("user_info")
       self.hasBalloonBundleIDColumn = messageColumns.contains("balloon_bundle_id")
+      self.hasChatTable = !MessageStore.tableColumns(
+        connection: self.connection, table: "chat"
+      ).isEmpty
+      self.hasChatHandleJoinTable = !MessageStore.tableColumns(
+        connection: self.connection, table: "chat_handle_join"
+      ).isEmpty
     } catch {
       throw MessageStore.enhance(error: error, path: normalized)
     }
@@ -112,12 +120,16 @@ public final class MessageStore: @unchecked Sendable {
     } else {
       self.hasBalloonBundleIDColumn = messageColumns.contains("balloon_bundle_id")
     }
+    self.hasChatTable = !MessageStore.tableColumns(connection: connection, table: "chat").isEmpty
+    self.hasChatHandleJoinTable = !MessageStore.tableColumns(
+      connection: connection, table: "chat_handle_join"
+    ).isEmpty
   }
 
   public func listChats(limit: Int) throws -> [Chat] {
     let sql = """
       SELECT c.ROWID, IFNULL(c.display_name, c.chat_identifier) AS name, c.chat_identifier, c.service_name,
-             MAX(m.date) AS last_date
+             MAX(m.date) AS last_date, c.guid, c.display_name
       FROM chat c
       JOIN chat_message_join cmj ON c.ROWID = cmj.chat_id
       JOIN message m ON m.ROWID = cmj.message_id
@@ -133,15 +145,27 @@ public final class MessageStore: @unchecked Sendable {
         let identifier = stringValue(row[2])
         let service = stringValue(row[3])
         let lastDate = appleDate(from: int64Value(row[4]))
+        let rawGuid = stringValue(row[5])
+        let guid = rawGuid.isEmpty ? nil : rawGuid
+        let rawDisplayName = stringValue(row[6])
+        let displayName = rawDisplayName.isEmpty ? nil : rawDisplayName
         chats.append(
           Chat(
-            id: id, identifier: identifier, name: name, service: service, lastMessageAt: lastDate))
+            id: id,
+            identifier: identifier,
+            name: name,
+            service: service,
+            lastMessageAt: lastDate,
+            guid: guid,
+            displayName: displayName
+          ))
       }
       return chats
     }
   }
 
   public func chatInfo(chatID: Int64) throws -> ChatInfo? {
+    guard hasChatTable else { return nil }
     let sql = """
       SELECT c.ROWID, IFNULL(c.chat_identifier, '') AS identifier, IFNULL(c.guid, '') AS guid,
              IFNULL(c.display_name, c.chat_identifier) AS name, IFNULL(c.service_name, '') AS service
@@ -169,6 +193,7 @@ public final class MessageStore: @unchecked Sendable {
   }
 
   public func participants(chatID: Int64) throws -> [String] {
+    guard hasChatHandleJoinTable else { return [] }
     let sql = """
       SELECT h.id
       FROM chat_handle_join chj

--- a/Sources/IMsgCore/Models.swift
+++ b/Sources/IMsgCore/Models.swift
@@ -190,13 +190,28 @@ public struct Chat: Sendable, Equatable {
   public let name: String
   public let service: String
   public let lastMessageAt: Date
+  /// Raw `chat.guid` value when available. `nil` when the underlying row had no guid.
+  public let guid: String?
+  /// Raw `chat.display_name` value when available. `nil` when the group/chat has no
+  /// explicit display name (in which case `name` falls back to `identifier`).
+  public let displayName: String?
 
-  public init(id: Int64, identifier: String, name: String, service: String, lastMessageAt: Date) {
+  public init(
+    id: Int64,
+    identifier: String,
+    name: String,
+    service: String,
+    lastMessageAt: Date,
+    guid: String? = nil,
+    displayName: String? = nil
+  ) {
     self.id = id
     self.identifier = identifier
     self.name = name
     self.service = service
     self.lastMessageAt = lastMessageAt
+    self.guid = guid
+    self.displayName = displayName
   }
 }
 

--- a/Sources/imsg/ChatCache.swift
+++ b/Sources/imsg/ChatCache.swift
@@ -1,0 +1,37 @@
+import Foundation
+import IMsgCore
+
+/// Per-`chatID` memoizer for `ChatInfo` and participant lookups.
+///
+/// Long-lived streams (the RPC watch subscription, `imsg watch`) visit many
+/// messages belonging to a small set of chats. Repeatedly re-querying
+/// `chatInfo` and `participants` for the same chat id is wasteful, so the
+/// cache amortizes those reads across the lifetime of the stream.
+///
+/// Callers that only visit a single chat id (for example `imsg history`) do
+/// not need this actor — the two direct calls cost the same.
+actor ChatCache {
+  private let store: MessageStore
+  private var infoCache: [Int64: ChatInfo] = [:]
+  private var participantsCache: [Int64: [String]] = [:]
+
+  init(store: MessageStore) {
+    self.store = store
+  }
+
+  func info(chatID: Int64) throws -> ChatInfo? {
+    if let cached = infoCache[chatID] { return cached }
+    if let info = try store.chatInfo(chatID: chatID) {
+      infoCache[chatID] = info
+      return info
+    }
+    return nil
+  }
+
+  func participants(chatID: Int64) throws -> [String] {
+    if let cached = participantsCache[chatID] { return cached }
+    let participants = try store.participants(chatID: chatID)
+    participantsCache[chatID] = participants
+    return participants
+  }
+}

--- a/Sources/imsg/CommandRouter.swift
+++ b/Sources/imsg/CommandRouter.swift
@@ -11,6 +11,7 @@ struct CommandRouter {
     self.version = CommandRouter.resolveVersion()
     self.specs = [
       ChatsCommand.spec,
+      GroupCommand.spec,
       HistoryCommand.spec,
       WatchCommand.spec,
       SendCommand.spec,

--- a/Sources/imsg/Commands/ChatsCommand.swift
+++ b/Sources/imsg/Commands/ChatsCommand.swift
@@ -26,14 +26,17 @@ enum ChatsCommand {
 
     if runtime.jsonOutput {
       for chat in chats {
-        try StdoutWriter.writeJSONLine(ChatPayload(chat: chat))
+        let participants = try store.participants(chatID: chat.id)
+        try StdoutWriter.writeJSONLine(ChatPayload(chat: chat, participants: participants))
       }
       return
     }
 
     for chat in chats {
       let last = CLIISO8601.format(chat.lastMessageAt)
-      StdoutWriter.writeLine("[\(chat.id)] \(chat.name) (\(chat.identifier)) last=\(last)")
+      let tag = isGroupHandle(identifier: chat.identifier, guid: chat.guid ?? "") ? " group" : ""
+      StdoutWriter.writeLine(
+        "[\(chat.id)\(tag)] \(chat.name) (\(chat.identifier)) last=\(last)")
     }
   }
 }

--- a/Sources/imsg/Commands/GroupCommand.swift
+++ b/Sources/imsg/Commands/GroupCommand.swift
@@ -1,0 +1,55 @@
+import Commander
+import Foundation
+import IMsgCore
+
+enum GroupCommand {
+  static let spec = CommandSpec(
+    name: "group",
+    abstract: "Show chat identity and participants for a chat id",
+    discussion: "Prints chat identifier, guid, display name, service, group flag, "
+      + "and participants for a given chat rowid. Works for direct chats too — "
+      + "is_group just reports false.",
+    signature: CommandSignatures.withRuntimeFlags(
+      CommandSignature(
+        options: CommandSignatures.baseOptions() + [
+          .make(label: "chatID", names: [.long("chat-id")], help: "chat rowid from 'imsg chats'")
+        ]
+      )
+    ),
+    usageExamples: [
+      "imsg group --chat-id 1",
+      "imsg group --chat-id 1 --json",
+    ]
+  ) { values, runtime in
+    guard let chatID = values.optionInt64("chatID") else {
+      throw ParsedValuesError.missingOption("chat-id")
+    }
+    let dbPath = values.option("db") ?? MessageStore.defaultPath
+    let store = try MessageStore(path: dbPath)
+    guard let info = try store.chatInfo(chatID: chatID) else {
+      throw IMsgError.invalidChatTarget("Unknown chat id \(chatID)")
+    }
+    let participants = try store.participants(chatID: chatID)
+    let isGroup = isGroupHandle(identifier: info.identifier, guid: info.guid)
+
+    if runtime.jsonOutput {
+      try StdoutWriter.writeJSONLine(GroupPayload(chatInfo: info, participants: participants))
+      return
+    }
+
+    StdoutWriter.writeLine("id: \(info.id)")
+    StdoutWriter.writeLine("identifier: \(info.identifier)")
+    StdoutWriter.writeLine("guid: \(info.guid)")
+    StdoutWriter.writeLine("name: \(info.name)")
+    StdoutWriter.writeLine("service: \(info.service)")
+    StdoutWriter.writeLine("is_group: \(isGroup)")
+    if participants.isEmpty {
+      StdoutWriter.writeLine("participants: (none)")
+    } else {
+      StdoutWriter.writeLine("participants:")
+      for handle in participants {
+        StdoutWriter.writeLine("  - \(handle)")
+      }
+    }
+  }
+}

--- a/Sources/imsg/Commands/HistoryCommand.swift
+++ b/Sources/imsg/Commands/HistoryCommand.swift
@@ -46,6 +46,8 @@ enum HistoryCommand {
     )
 
     let store = try MessageStore(path: dbPath)
+    let chatInfo = try store.chatInfo(chatID: chatID)
+    let chatParticipants = try store.participants(chatID: chatID)
     let filtered = try store.messages(chatID: chatID, limit: limit, filter: filter)
 
     if runtime.jsonOutput {
@@ -55,11 +57,20 @@ enum HistoryCommand {
         let payload = MessagePayload(
           message: message,
           attachments: attachments,
-          reactions: reactions
+          reactions: reactions,
+          chatInfo: chatInfo,
+          participants: chatParticipants
         )
         try StdoutWriter.writeJSONLine(payload)
       }
       return
+    }
+
+    if let chatInfo,
+      isGroupHandle(identifier: chatInfo.identifier, guid: chatInfo.guid)
+    {
+      let joined = chatParticipants.joined(separator: ", ")
+      StdoutWriter.writeLine("# group chat: \(chatInfo.name) (participants: \(joined))")
     }
 
     for message in filtered {

--- a/Sources/imsg/Commands/WatchCommand.swift
+++ b/Sources/imsg/Commands/WatchCommand.swift
@@ -81,34 +81,43 @@ enum WatchCommand {
       batchLimit: 100,
       includeReactions: includeReactions
     )
+    let chatCache = ChatCache(store: store)
 
     let stream = streamProvider(watcher, chatID, sinceRowID, config)
     for try await message in stream {
       if !filter.allows(message) {
         continue
       }
+      let chatInfo = try await chatCache.info(chatID: message.chatID)
+      let chatParticipants = try await chatCache.participants(chatID: message.chatID)
+      let isGroup =
+        chatInfo.map { isGroupHandle(identifier: $0.identifier, guid: $0.guid) } ?? false
       if runtime.jsonOutput {
         let attachments = try store.attachments(for: message.rowID)
         let reactions = try store.reactions(for: message.rowID)
         let payload = MessagePayload(
           message: message,
           attachments: attachments,
-          reactions: reactions
+          reactions: reactions,
+          chatInfo: chatInfo,
+          participants: chatParticipants
         )
         try StdoutWriter.writeJSONLine(payload)
         continue
       }
       let direction = message.isFromMe ? "sent" : "recv"
       let timestamp = CLIISO8601.format(message.date)
+      let groupSuffix = isGroup ? " (group)" : ""
       if message.isReaction, let reactionType = message.reactionType {
         let action = (message.isReactionAdd ?? true) ? "added" : "removed"
         let targetGUID = message.reactedToGUID ?? "unknown"
         StdoutWriter.writeLine(
-          "\(timestamp) [\(direction)] \(message.sender) \(action) \(reactionType.emoji) reaction to \(targetGUID)"
+          "\(timestamp) [\(direction)] \(message.sender) \(action) \(reactionType.emoji) reaction to \(targetGUID)\(groupSuffix)"
         )
         continue
       }
-      StdoutWriter.writeLine("\(timestamp) [\(direction)] \(message.sender): \(message.text)")
+      StdoutWriter.writeLine(
+        "\(timestamp) [\(direction)] \(message.sender): \(message.text)\(groupSuffix)")
       if message.attachmentsCount > 0 {
         if showAttachments {
           let metas = try store.attachments(for: message.rowID)

--- a/Sources/imsg/OutputModels.swift
+++ b/Sources/imsg/OutputModels.swift
@@ -7,13 +7,21 @@ struct ChatPayload: Codable {
   let identifier: String
   let service: String
   let lastMessageAt: String
+  let guid: String?
+  let displayName: String?
+  let isGroup: Bool
+  let participants: [String]?
 
-  init(chat: Chat) {
+  init(chat: Chat, participants: [String]? = nil) {
     self.id = chat.id
     self.name = chat.name
     self.identifier = chat.identifier
     self.service = chat.service
     self.lastMessageAt = CLIISO8601.format(chat.lastMessageAt)
+    self.guid = chat.guid
+    self.displayName = chat.displayName
+    self.isGroup = isGroupHandle(identifier: chat.identifier, guid: chat.guid ?? "")
+    self.participants = participants
   }
 
   enum CodingKeys: String, CodingKey {
@@ -22,6 +30,10 @@ struct ChatPayload: Codable {
     case identifier
     case service
     case lastMessageAt = "last_message_at"
+    case guid
+    case displayName = "display_name"
+    case isGroup = "is_group"
+    case participants
   }
 }
 
@@ -49,7 +61,20 @@ struct MessagePayload: Codable {
   let isReactionAdd: Bool?
   let reactedToGUID: String?
 
-  init(message: Message, attachments: [AttachmentMeta], reactions: [Reaction] = []) {
+  // Chat / group metadata (populated when callers supply chat context)
+  let chatIdentifier: String?
+  let chatGuid: String?
+  let chatName: String?
+  let participants: [String]?
+  let isGroup: Bool?
+
+  init(
+    message: Message,
+    attachments: [AttachmentMeta],
+    reactions: [Reaction] = [],
+    chatInfo: ChatInfo? = nil,
+    participants: [String]? = nil
+  ) {
     self.id = message.rowID
     self.chatID = message.chatID
     self.guid = message.guid
@@ -77,6 +102,21 @@ struct MessagePayload: Codable {
       self.isReactionAdd = nil
       self.reactedToGUID = nil
     }
+
+    // Chat / group metadata. When chatInfo is omitted, all fields stay nil
+    // which preserves the existing JSON shape for callers that don't populate it
+    // (notably the RPC `messagePayload` dictionary builder, which overlays its
+    // own `chat_identifier`, `chat_guid`, `chat_name`, `participants`, `is_group`
+    // keys on top of asDictionary()).
+    self.chatIdentifier = chatInfo?.identifier
+    self.chatGuid = chatInfo?.guid
+    self.chatName = chatInfo?.name
+    self.participants = participants
+    if let chatInfo {
+      self.isGroup = isGroupHandle(identifier: chatInfo.identifier, guid: chatInfo.guid)
+    } else {
+      self.isGroup = nil
+    }
   }
 
   enum CodingKeys: String, CodingKey {
@@ -97,6 +137,11 @@ struct MessagePayload: Codable {
     case reactionEmoji = "reaction_emoji"
     case isReactionAdd = "is_reaction_add"
     case reactedToGUID = "reacted_to_guid"
+    case chatIdentifier = "chat_identifier"
+    case chatGuid = "chat_guid"
+    case chatName = "chat_name"
+    case participants
+    case isGroup = "is_group"
   }
 }
 
@@ -136,6 +181,36 @@ struct ReactionPayload: Codable {
     case sender
     case isFromMe = "is_from_me"
     case createdAt = "created_at"
+  }
+}
+
+struct GroupPayload: Codable {
+  let id: Int64
+  let identifier: String
+  let guid: String
+  let name: String
+  let service: String
+  let isGroup: Bool
+  let participants: [String]
+
+  init(chatInfo: ChatInfo, participants: [String]) {
+    self.id = chatInfo.id
+    self.identifier = chatInfo.identifier
+    self.guid = chatInfo.guid
+    self.name = chatInfo.name
+    self.service = chatInfo.service
+    self.isGroup = isGroupHandle(identifier: chatInfo.identifier, guid: chatInfo.guid)
+    self.participants = participants
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case id
+    case identifier
+    case guid
+    case name
+    case service
+    case isGroup = "is_group"
+    case participants
   }
 }
 

--- a/Sources/imsg/RPCPayloads.swift
+++ b/Sources/imsg/RPCPayloads.swift
@@ -66,10 +66,6 @@ func reactionPayload(_ reaction: Reaction) -> [String: Any] {
   ]
 }
 
-func isGroupHandle(identifier: String, guid: String) -> Bool {
-  return guid.contains(";+;") || identifier.contains(";+;")
-}
-
 func stringParam(_ value: Any?) -> String? {
   if let value = value as? String { return value }
   if let number = value as? NSNumber { return number.stringValue }

--- a/Sources/imsg/RPCServer+Support.swift
+++ b/Sources/imsg/RPCServer+Support.swift
@@ -95,29 +95,3 @@ actor SubscriptionStore {
     tasks.removeAll()
   }
 }
-
-actor ChatCache {
-  private let store: MessageStore
-  private var infoCache: [Int64: ChatInfo] = [:]
-  private var participantsCache: [Int64: [String]] = [:]
-
-  init(store: MessageStore) {
-    self.store = store
-  }
-
-  func info(chatID: Int64) throws -> ChatInfo? {
-    if let cached = infoCache[chatID] { return cached }
-    if let info = try store.chatInfo(chatID: chatID) {
-      infoCache[chatID] = info
-      return info
-    }
-    return nil
-  }
-
-  func participants(chatID: Int64) throws -> [String] {
-    if let cached = participantsCache[chatID] { return cached }
-    let participants = try store.participants(chatID: chatID)
-    participantsCache[chatID] = participants
-    return participants
-  }
-}

--- a/Tests/IMsgCoreTests/GroupDetectionTests.swift
+++ b/Tests/IMsgCoreTests/GroupDetectionTests.swift
@@ -1,0 +1,21 @@
+import Foundation
+import Testing
+
+@testable import IMsgCore
+
+@Test
+func isGroupHandleRecognizesGroupMarker() {
+  #expect(isGroupHandle(identifier: "iMessage;+;chat1234567890", guid: "") == true)
+  #expect(isGroupHandle(identifier: "", guid: "iMessage;+;chat1234567890") == true)
+  #expect(isGroupHandle(identifier: "SMS;+;chatABCDEF", guid: "") == true)
+}
+
+@Test
+func isGroupHandleRejectsDirectAndEmpty() {
+  // SERVICE;-;TARGET is a direct chat, not a group — deliberately excluded.
+  #expect(isGroupHandle(identifier: "iMessage;-;+15551234567", guid: "") == false)
+  #expect(isGroupHandle(identifier: "", guid: "iMessage;-;+15551234567") == false)
+  #expect(isGroupHandle(identifier: "+15551234567", guid: "") == false)
+  #expect(isGroupHandle(identifier: "user@icloud.com", guid: "") == false)
+  #expect(isGroupHandle(identifier: "", guid: "") == false)
+}

--- a/Tests/imsgTests/ChatHistorySendCommandTests.swift
+++ b/Tests/imsgTests/ChatHistorySendCommandTests.swift
@@ -14,9 +14,28 @@ func chatsCommandRunsWithJsonOutput() async throws {
     flags: ["jsonOutput"]
   )
   let runtime = RuntimeOptions(parsedValues: values)
-  _ = try await StdoutCapture.capture {
+  let (output, _) = try await StdoutCapture.capture {
     try await ChatsCommand.spec.run(values, runtime)
   }
+  #expect(output.contains("\"is_group\":true"))
+  #expect(output.contains("\"guid\":\"iMessage;+;chat123\""))
+  #expect(output.contains("\"display_name\":\"Test Chat\""))
+  #expect(output.contains("\"participants\":[\"+123\",\"+456\"]"))
+}
+
+@Test
+func chatsCommandPlainOutputMarksGroups() async throws {
+  let path = try CommandTestDatabase.makePath()
+  let values = ParsedValues(
+    positional: [],
+    options: ["db": [path], "limit": ["5"]],
+    flags: []
+  )
+  let runtime = RuntimeOptions(parsedValues: values)
+  let (output, _) = try await StdoutCapture.capture {
+    try await ChatsCommand.spec.run(values, runtime)
+  }
+  #expect(output.contains("[1 group]"))
 }
 
 @Test
@@ -28,9 +47,31 @@ func historyCommandRunsWithChatID() async throws {
     flags: ["jsonOutput"]
   )
   let runtime = RuntimeOptions(parsedValues: values)
-  _ = try await StdoutCapture.capture {
+  let (output, _) = try await StdoutCapture.capture {
     try await HistoryCommand.spec.run(values, runtime)
   }
+  #expect(output.contains("\"chat_identifier\":\"+123\""))
+  #expect(output.contains("\"chat_guid\":\"iMessage;+;chat123\""))
+  #expect(output.contains("\"chat_name\":\"Test Chat\""))
+  #expect(output.contains("\"is_group\":true"))
+  #expect(output.contains("\"participants\":[\"+123\",\"+456\"]"))
+}
+
+@Test
+func historyCommandPlainOutputPrintsGroupHeader() async throws {
+  let path = try CommandTestDatabase.makePath()
+  let values = ParsedValues(
+    positional: [],
+    options: ["db": [path], "chatID": ["1"], "limit": ["5"]],
+    flags: []
+  )
+  let runtime = RuntimeOptions(parsedValues: values)
+  let (output, _) = try await StdoutCapture.capture {
+    try await HistoryCommand.spec.run(values, runtime)
+  }
+  #expect(output.contains("# group chat: Test Chat"))
+  #expect(output.contains("+123"))
+  #expect(output.contains("+456"))
 }
 
 @Test

--- a/Tests/imsgTests/CommandTestDatabase.swift
+++ b/Tests/imsgTests/CommandTestDatabase.swift
@@ -12,7 +12,7 @@ enum CommandTestDatabase {
   static func makePath() throws -> String {
     let path = try makeDatabasePath()
     let db = try Connection(path)
-    try createSchema(db, includeChatHandleJoin: false)
+    try createSchema(db, includeChatHandleJoin: true)
     try seedBasicChat(db)
     return path
   }
@@ -102,7 +102,12 @@ enum CommandTestDatabase {
       VALUES (1, '+123', 'iMessage;+;chat123', 'Test Chat', 'iMessage')
       """
     )
-    try db.run("INSERT INTO handle(ROWID, id) VALUES (1, '+123')")
+    try db.run(
+      "INSERT INTO handle(ROWID, id) VALUES (1, '+123'), (2, '+456')"
+    )
+    try db.run(
+      "INSERT INTO chat_handle_join(chat_id, handle_id) VALUES (1, 1), (1, 2)"
+    )
     try db.run(
       """
       INSERT INTO message(ROWID, handle_id, text, date, is_from_me, service)

--- a/Tests/imsgTests/GroupCommandTests.swift
+++ b/Tests/imsgTests/GroupCommandTests.swift
@@ -1,0 +1,86 @@
+import Commander
+import Foundation
+import Testing
+
+@testable import IMsgCore
+@testable import imsg
+
+@Test
+func groupCommandRequiresChatID() async {
+  let values = ParsedValues(
+    positional: [],
+    options: [:],
+    flags: []
+  )
+  let runtime = RuntimeOptions(parsedValues: values)
+  do {
+    try await GroupCommand.spec.run(values, runtime)
+    #expect(Bool(false))
+  } catch let error as ParsedValuesError {
+    #expect(error.description.contains("Missing required option"))
+  } catch {
+    #expect(Bool(false))
+  }
+}
+
+@Test
+func groupCommandThrowsOnUnknownChatID() async throws {
+  let path = try CommandTestDatabase.makePath()
+  let values = ParsedValues(
+    positional: [],
+    options: ["db": [path], "chatID": ["9999"]],
+    flags: []
+  )
+  let runtime = RuntimeOptions(parsedValues: values)
+  do {
+    try await GroupCommand.spec.run(values, runtime)
+    #expect(Bool(false))
+  } catch let error as IMsgError {
+    #expect(String(describing: error).contains("9999"))
+  } catch {
+    #expect(Bool(false))
+  }
+}
+
+@Test
+func groupCommandPrintsPlainTextForGroup() async throws {
+  let path = try CommandTestDatabase.makePath()
+  let values = ParsedValues(
+    positional: [],
+    options: ["db": [path], "chatID": ["1"]],
+    flags: []
+  )
+  let runtime = RuntimeOptions(parsedValues: values)
+  let (output, _) = try await StdoutCapture.capture {
+    try await GroupCommand.spec.run(values, runtime)
+  }
+  #expect(output.contains("id: 1"))
+  #expect(output.contains("identifier: +123"))
+  #expect(output.contains("guid: iMessage;+;chat123"))
+  #expect(output.contains("name: Test Chat"))
+  #expect(output.contains("service: iMessage"))
+  #expect(output.contains("is_group: true"))
+  #expect(output.contains("- +123"))
+  #expect(output.contains("- +456"))
+}
+
+@Test
+func groupCommandEmitsJsonPayload() async throws {
+  let path = try CommandTestDatabase.makePath()
+  let values = ParsedValues(
+    positional: [],
+    options: ["db": [path], "chatID": ["1"]],
+    flags: ["jsonOutput"]
+  )
+  let runtime = RuntimeOptions(parsedValues: values)
+  let (output, _) = try await StdoutCapture.capture {
+    try await GroupCommand.spec.run(values, runtime)
+  }
+  #expect(output.contains("\"id\":1"))
+  #expect(output.contains("\"identifier\":\"+123\""))
+  #expect(output.contains("\"guid\":\"iMessage;+;chat123\""))
+  #expect(output.contains("\"name\":\"Test Chat\""))
+  #expect(output.contains("\"service\":\"iMessage\""))
+  #expect(output.contains("\"is_group\":true"))
+  #expect(output.contains("\"participants\":[\"+123\",\"+456\"]"))
+}

--- a/Tests/imsgTests/WatchCommandTests.swift
+++ b/Tests/imsgTests/WatchCommandTests.swift
@@ -176,6 +176,74 @@ func watchCommandFlushesPlainOutput() async throws {
 }
 
 @Test
+func watchCommandEmitsGroupMetadataInJson() async throws {
+  let values = ParsedValues(
+    positional: [],
+    options: ["db": [":memory:"], "debounce": ["1ms"]],
+    flags: ["jsonOutput"]
+  )
+  let runtime = RuntimeOptions(parsedValues: values)
+  let store = try CommandTestDatabase.makeStoreForRPC()
+  let message = Message(
+    rowID: 5,
+    chatID: 1,
+    sender: "+123",
+    text: "hi group",
+    date: Date(),
+    isFromMe: false,
+    service: "iMessage",
+    handleID: nil,
+    attachmentsCount: 0,
+    guid: "watch-group-guid"
+  )
+  let (output, _) = try await StdoutCapture.capture {
+    try await WatchCommand.run(
+      values: values,
+      runtime: runtime,
+      storeFactory: { _ in store },
+      streamProvider: singleMessageStreamProvider(message)
+    )
+  }
+  #expect(output.contains("\"is_group\":true"))
+  #expect(output.contains("\"chat_identifier\":\"iMessage;+;chat123\""))
+  #expect(output.contains("\"chat_name\":\"Group Chat\""))
+  #expect(output.contains("+123"))
+  #expect(output.contains("me@icloud.com"))
+}
+
+@Test
+func watchCommandAppendsGroupSuffixInPlainOutput() async throws {
+  let values = ParsedValues(
+    positional: [],
+    options: ["db": [":memory:"], "debounce": ["1ms"]],
+    flags: []
+  )
+  let runtime = RuntimeOptions(parsedValues: values)
+  let store = try CommandTestDatabase.makeStoreForRPC()
+  let message = Message(
+    rowID: 6,
+    chatID: 1,
+    sender: "+123",
+    text: "hello",
+    date: Date(),
+    isFromMe: false,
+    service: "iMessage",
+    handleID: nil,
+    attachmentsCount: 0,
+    guid: "watch-group-plain-guid"
+  )
+  let (output, _) = try await StdoutCapture.capture {
+    try await WatchCommand.run(
+      values: values,
+      runtime: runtime,
+      storeFactory: { _ in store },
+      streamProvider: singleMessageStreamProvider(message)
+    )
+  }
+  #expect(output.contains("hello (group)"))
+}
+
+@Test
 func watchCommandFlushesJsonOutput() async throws {
   let values = ParsedValues(
     positional: [],

--- a/docs/groups.md
+++ b/docs/groups.md
@@ -1,9 +1,11 @@
 # Groups
 
 ## What counts as a group
-- `chat.chat_identifier` or `chat.guid` with `;+;` or `;-;` in the handle.
-- Example: `iMessage;+;chat1234567890` (group handle).
-- Direct chats typically use a single handle (phone/email) without `;+;` or `;-;`.
+- `chat.chat_identifier` or `chat.guid` contains `;+;` (for example
+  `iMessage;+;chat1234567890`). That's what `IMsgCore.isGroupHandle(...)` checks.
+- `SERVICE;-;TARGET` is a direct 1:1 chat (e.g. `iMessage;-;+15551234567`) and
+  is deliberately **not** flagged as a group.
+- Direct chats typically use a single handle (phone/email) with no `;+;`.
 
 ## Where the identifiers live
 - `chat.ROWID` -> `chat_id` (stable within one DB).
@@ -20,14 +22,34 @@
 - Attachments supported same as direct sends.
 
 ## Inbound metadata (JSON)
+Both the direct CLI (`imsg chats`, `imsg history`, `imsg watch`) `--json`
+output and the JSON-RPC surface (`imsg rpc`) include:
 - `chat_id`
 - `chat_identifier`
 - `chat_guid`
 - `chat_name`
-- `participants` (array of handles)
+- `participants` (array of handles — see note below)
 - `is_group`
 
 `chat_id` is preferred for routing within one machine/DB.
+
+### `participants` excludes the local user
+`participants` is sourced from Messages.app's `chat_handle_join` table, which
+only stores **external** handles. The local user ("me") is implicit: their
+authorship is signaled by `is_from_me=1` on the message, not by a row in
+`chat_handle_join`. A 3-person group chat where you are one of the members
+reports only 2 handles in `participants`.
+
+If a consumer needs the full roster, add the local user's handle on top. The
+specific handle the user is routing through can be read from
+`destination_caller_id` on any of their sent messages in the chat
+(`is_from_me=1`) — useful when a Mac receives both iMessage and forwarded SMS
+on different handles for the same Apple ID.
+
+## Focused group lookup
+- `imsg group --chat-id <rowid>` — prints id, identifier, guid, name, service,
+  `is_group`, and participants for one chat. Works on direct chats too
+  (`is_group: false` in that case). Supports `--json`.
 
 ## Notes
 - Group send uses chat handle, not `buddy`.


### PR DESCRIPTION
## Summary

Brings group-chat metadata parity between the direct CLI (`imsg chats`, `imsg history`, `imsg watch`) and the existing JSON-RPC surface, and adds a focused `imsg group --chat-id N [--json]` command for looking up a chat's identity + participants. All additions are optional JSON fields — no existing keys are renamed or removed.

## Motivation

The RPC path (`imsg rpc`) already returns `is_group`, `chat_identifier`, `chat_guid`, `chat_name`, and `participants` via helpers in `RPCPayloads.swift`. The direct CLI `--json` output does not. Downstream consumers that parse `imsg chats --json` or stream from `imsg watch --json` currently can't distinguish groups from 1:1s, pull a group's display name, or enumerate participants without switching to RPC. This change closes that gap using the existing `MessageStore.chatInfo` / `participants` helpers.

## What's new

### `imsg chats --json`

Adds `guid`, `display_name`, `is_group`, `participants`.

```json
{"id":1234,"display_name":"Family","guid":"any;+;chat1234567890123456789","name":"Family","last_message_at":"2026-01-15T10:00:00.000Z","service":"SMS","is_group":true,"participants":["+16125551100","+16125551101","+16125551102","+16125551103"],"identifier":"chat1234567890123456789"}
```

### `imsg history --json` and `imsg watch --json`

Adds `chat_identifier`, `chat_guid`, `chat_name`, `participants`, `is_group` on every message payload.

```json
{"sender":"+16125551111","is_from_me":true,"text":"...","chat_name":"","chat_guid":"any;+;abc123def456abc123def456abc123de","chat_id":42,"is_group":true,"chat_identifier":"abc123def456abc123def456abc123de","participants":["+16125552222","jimbo@example.com"],"destination_caller_id":"+16125551111", ...}
```

### `imsg group --chat-id <N> [--json]`

New read-only subcommand that prints id, identifier, guid, name, service, is_group, and participants. Works for direct chats too (`is_group: false`).

```
id: 42
identifier: abc123def456abc123def456abc123de
guid: any;+;abc123def456abc123def456abc123de
name:
service: iMessage
is_group: true
participants:
  - +16125552222
  - jimbo@example.com
```

### Plain-text output

Minimal group indicators, chosen to avoid breaking parsers that key off the existing `^\d{4}-` timestamp prefix:

- `imsg chats` — group rows render as `[<id> group]` instead of `[<id>]`.
- `imsg history` — a single header line `# group chat: <name> (participants: ...)` prints before the messages when the chat is a group. Per-message line format unchanged.
- `imsg watch` — appends ` (group)` to the end of the per-message line. Timestamp prefix unchanged.

## Internals

- `isGroupHandle(identifier:guid:)` moved into `IMsgCore` (new `GroupDetection.swift`) so the CLI and RPC paths share one detection helper. Semantics unchanged (`;+;` only; `;-;` is not a group, matching the existing test expectation).
- `actor ChatCache` extracted from `RPCServer+Support.swift` into its own file and reused by `imsg watch` to amortize per-chat `chatInfo` / `participants` lookups across a stream. RPC behavior unchanged.
- `Chat` gained optional `guid` and `displayName` via defaulted initializer params — additive, source-compatible.
- `MessageStore` detects `chat` and `chat_handle_join` table presence at init (new `hasChatTable` / `hasChatHandleJoinTable` flags, same pattern as the existing `hasReactionColumns` flag) and gates `chatInfo` / `participants` on them. Keeps minimal-schema test fixtures working.

## Notes worth a second look

- **`docs/groups.md` correction**: the prior doc stated that `SERVICE;-;TARGET` also marks a group. That contradicts the authoritative test at `Tests/imsgTests/RPCPayloadsTests.swift:10` which asserts `iMessage;-;chat999` is **not** a group, and it's inconsistent with Messages.app's own convention (`-` = direct, `+` = group). Updated the doc to match the code.
- **`participants` excludes the local user**, because `chat_handle_join` only stores external handles. This is inherited from Messages.app's schema, not new behavior — but it was never documented. Added an explicit note in `docs/groups.md` and the CHANGELOG entry so downstream consumers don't build rosters under a wrong assumption. `destination_caller_id` (already exposed per message) is the signal for which local handle routes the chat.
- **New public IMsgCore surface**: `isGroupHandle(identifier:guid:)` is now a public top-level function in IMsgCore. Library consumers gain one symbol.

## Non-breaking

- No existing JSON keys renamed or removed.
- Nil optionals are omitted by Swift's default encoder, so the CLI JSON shape for consumers that don't care about group metadata is byte-identical to before when `chatInfo` isn't populated.
- RPC JSON output is unchanged — the RPC dictionary path at `RPCPayloads.swift:25` already overlays its own keys on top of `MessagePayload.asDictionary()`.
- `Chat`'s memberwise init still works positionally and by keyword, thanks to defaulted new params.

## Testing

- `make test`: **107 tests pass** (baseline on `main` was 97; this PR adds 10 new). No existing test removed or weakened.
- `swift format lint --recursive Sources Tests`: clean.
- `swiftlint` not run — not installed locally; happy to add an output from wherever the CI runner has it.
- End-to-end smoke on a live `~/Library/Messages/chat.db`:
  - `imsg chats --json` returned real groups across iMessage, SMS, and RCS with all new fields present.
  - `imsg group --chat-id N --json` on a real group — `GroupPayload` shape clean.
  - `imsg send --chat-id N --text "..."` to a real group — AppleScript resolved the GUID via the existing `ChatTargetResolver` path and delivered successfully.
  - `imsg history --chat-id N --limit 2 --json` on the same group — the just-sent message carried `is_from_me:true`, `is_group:true`, `chat_identifier`, `chat_guid`, `chat_name`, `participants`, and the existing `destination_caller_id`.

## Commits

Landed as 4 logical commits to keep review and bisect straightforward:

1. `refactor: move isGroupHandle into IMsgCore; extract ChatCache actor`
2. `feat: expose group metadata in CLI JSON for chats/history/watch`
3. `feat: add imsg group command`
4. `docs: document CLI group metadata; clarify participants excludes self`