### PR TITLE
fix: transcode UTF-16LE BOM to UTF-8 in parseAttributedBody

### DIFF
--- a/Sources/IMsgCore/TypedStreamParser.swift
+++ b/Sources/IMsgCore/TypedStreamParser.swift
@@ -3,7 +3,18 @@ import Foundation
 enum TypedStreamParser {
   static func parseAttributedBody(_ data: Data) -> String {
     guard !data.isEmpty else { return "" }
+
+    // Detect UTF-16LE BOM (0xFF 0xFE) — macOS 26.x / SDK 26.x returns UTF-16LE encoding
+    // for message bodies with non-ASCII content via Messages framework CFString/CFAttributedString
     let bytes = [UInt8](data)
+    if bytes.count >= 2, bytes[0] == 0xFF, bytes[1] == 0xFE {
+      // UTF-16LE BOM detected — decode from UTF-16 Little Endian, skipping BOM
+      let utf16Bytes = Data(bytes.dropFirst(2))
+      if let text = String(data: utf16Bytes, encoding: .utf16LittleEndian) {
+        return text.trimmingLeadingControlCharacters()
+      }
+    }
+
     let start = [UInt8(0x01), UInt8(0x2b)]
     let end = [UInt8(0x86), UInt8(0x84)]
     var best = ""


### PR DESCRIPTION
## Summary
macOS 26.x / SDK 26.x changed how the Messages framework encodes non-ASCII text in CFString/CFAttributedString — it now returns UTF-16LE with BOM prefix instead of UTF-8. This caused `imsg history` plain-text output to display garbled bytes (UTF-16LE BOM `0xFF 0xFE`) before message text.

JSON output was unaffected because it uses a different serialization path.

## Fix
In `TypedStreamParser.parseAttributedBody()`, added UTF-16LE BOM detection at the start of data processing. When BOM is detected, bytes after the BOM are decoded as `.utf16LittleEndian`. Falls back to existing UTF-8 TypedStream parsing for normal messages.

## Root cause
- `imsg` v0.5.0 (built Feb 16 2026) assumes Messages framework returns UTF-8
- macOS 26.x beta/preview changed this to UTF-16LE for non-ASCII content
- Plain-text output path had no transcoding step

## Testing
- `imsg send --chat-id N --text "🌤️ test emoji"` → `imsg history --chat-id N --limit 3` — garbled prefix appears before fix
- After fix: message reads back clean

Fixes https://github.com/steipete/imsg/issues/91