### PR TITLE
ci: update Homebrew tap on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,3 +100,55 @@ jobs:
           fi
 
           gh release edit "$TAG" --notes-file "$notes_file"
+
+  update-homebrew-tap:
+    runs-on: ubuntu-latest
+    needs: release
+    steps:
+      - name: Dispatch tap formula update
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::error::Set HOMEBREW_TAP_TOKEN with workflow access to steipete/homebrew-tap"
+            exit 1
+          fi
+
+          RELEASE_TAG="${{ inputs.tag }}"
+          request_id="imsg-${RELEASE_TAG}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          expected_title="Update imsg for ${RELEASE_TAG} (${request_id})"
+
+          gh workflow run update-formula.yml \
+            --repo steipete/homebrew-tap \
+            --ref main \
+            -f formula=imsg \
+            -f tag="$RELEASE_TAG" \
+            -f repository=steipete/imsg \
+            -f macos_artifact="imsg-macos.zip" \
+            -f request_id="$request_id"
+
+          run_id=""
+          for _ in {1..30}; do
+            run_id=$(gh run list \
+              --repo steipete/homebrew-tap \
+              --workflow update-formula.yml \
+              --branch main \
+              --event workflow_dispatch \
+              --limit 20 \
+              --json databaseId,displayTitle \
+              --jq ".[] | select(.displayTitle == \"$expected_title\") | .databaseId" | head -n1)
+            if [ -n "$run_id" ]; then
+              break
+            fi
+            sleep 5
+          done
+
+          if [ -z "$run_id" ]; then
+            echo "::error::Could not find tap workflow run with title: $expected_title"
+            exit 1
+          fi
+
+          gh run watch "$run_id" \
+            --repo steipete/homebrew-tap \
+            --exit-status \
+            --interval 10


### PR DESCRIPTION
Adds an `update-homebrew-tap` job that dispatches the centralized formula updater in `steipete/homebrew-tap` after a successful release. Uses `gh run watch` for synchronous failure visibility.

Depends on steipete/homebrew-tap#29

**Required secret:** `HOMEBREW_TAP_TOKEN` with workflow dispatch access to `steipete/homebrew-tap`.