### PR TITLE
docs: integrate Homebrew tap update into local release flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - fix: dedupe URL balloon preview duplicates in watch stream without cross-chat/schema regressions (#64, thanks @lesaai)
 - fix: normalize IMCore typing chat lookup across `iMessage`, `SMS`, and `any` prefixes (#51, #54, #56, #58)
 - docs: document macOS 26 advanced IMCore injection limits (#60)
+- docs: add a local release helper for dispatching Homebrew tap updates (#97, thanks @dinakars777)
 
 ## 0.5.0 - 2026-02-16
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -27,6 +27,9 @@
    - `git push origin vX.Y.Z`
    - `gh release create vX.Y.Z /tmp/imsg-macos.zip -t "vX.Y.Z" -F /tmp/release-notes.txt`
    - `gh release edit vX.Y.Z --notes-file /tmp/release-notes.txt` (if needed)
+5. Update Homebrew tap
+   - Run `scripts/update-homebrew.sh vX.Y.Z` to trigger the centralized formula updater.
+   - Requires a GitHub token with workflow dispatch access to `steipete/homebrew-tap`.
 
 ## What happens in CI
 - Release signing + notarization are done locally via `scripts/sign-and-notarize.sh`.

--- a/scripts/update-homebrew.sh
+++ b/scripts/update-homebrew.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <release-tag>" >&2
+  exit 1
+fi
+
+TAG="$1"
+
+gh workflow run update-formula.yml \
+  --repo steipete/homebrew-tap \
+  --ref main \
+  -f formula=imsg \
+  -f tag="$TAG" \
+  -f repository=steipete/imsg \
+  -f macos_artifact=imsg-macos.zip
+
+echo "Homebrew tap update dispatched. Monitor: https://github.com/steipete/homebrew-tap/actions"


### PR DESCRIPTION
Follow-up to #96 (closed). Instead of wiring the tap update into the CI workflow (which isn't the primary release path), this adds a lightweight `scripts/update-homebrew.sh` helper that integrates with the existing local signing + notarization release flow.

### What changed
- **`scripts/update-homebrew.sh`** — dispatches the centralized formula updater in `steipete/homebrew-tap` via `gh workflow run`
- **`docs/RELEASING.md`** — adds step 5: `scripts/update-homebrew.sh vX.Y.Z`

### Why this approach
We considered moving the entire release flow into CI (so the tap update could fire automatically), but that would require uploading your Apple Developer signing certificate and App Store Connect API keys as GitHub secrets — a significant security/trust decision that should be driven by you, not a contributor PR. This approach keeps the local signing flow untouched and just automates the last mile (Homebrew formula update) with a one-liner.

### Requires
- `steipete/homebrew-tap#29` merged ✅
- A GitHub token with `workflow` scope (for `gh workflow run` against the tap)