### PR TITLE
fix: apply message edits on macOS 14+ instead of silently no-opping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 - fix: support threaded attachment replies via `send-rich --file` and
   `send-attachment --reply-to`, including the macOS 26 attachment staging
   fallback (#113, #114, thanks @omarshahine).
+- fix: `edit` now applies on macOS 14+ instead of silently no-opping. The
+  edit handler passed the chat item (not its backing `IMMessageItem`) to
+  `editMessageItem:` and passed `backwardCompatabilityText:` as a plain
+  `NSString`; both are now corrected so the IMCore selector commits the edit.
 
 ## 0.8.2 - 2026-05-11
 

--- a/Sources/IMsgHelper/IMsgInjected.m
+++ b/Sources/IMsgHelper/IMsgInjected.m
@@ -2406,6 +2406,9 @@ static NSDictionary *handleEditMessage(NSInteger requestId, NSDictionary *params
     }
 
     NSAttributedString *newBody = buildPlainAttributed(newText, partIndex);
+    // backwardCompatabilityText: must be an NSAttributedString; passing a plain
+    // NSString makes editMessageItem: silently bail (no edit, no error).
+    NSAttributedString *bcBody = [[NSAttributedString alloc] initWithString:bcText];
 
     id item = findMessageItem(chat, messageGuid);
     if (!item) {
@@ -2416,17 +2419,22 @@ static NSDictionary *handleEditMessage(NSInteger requestId, NSDictionary *params
     @try {
         NSInteger localPartIndex = partIndex;
         if (gHasEditMessageItem) {
+            // editMessageItem: takes the IMMessageItem, not the chat item.
+            // findMessageItem returns an IMMessagePartChatItem; reach the
+            // backing item via -messageItem.
+            id messageItem = [item respondsToSelector:@selector(messageItem)]
+                ? [item performSelector:@selector(messageItem)] : item;
             SEL sel = @selector(editMessageItem:atPartIndex:withNewPartText:backwardCompatabilityText:);
             NSMethodSignature *sig = [chat methodSignatureForSelector:sel];
             NSInvocation *inv = [NSInvocation invocationWithMethodSignature:sig];
             [inv setSelector:sel];
             [inv setTarget:chat];
-            __unsafe_unretained id ci = item;
+            __unsafe_unretained id ci = messageItem;
             [inv setArgument:&ci atIndex:2];
             [inv setArgument:&localPartIndex atIndex:3];
             __unsafe_unretained NSAttributedString *newBodyArg = newBody;
             [inv setArgument:&newBodyArg atIndex:4];
-            __unsafe_unretained NSString *bcArg = bcText;
+            __unsafe_unretained NSAttributedString *bcArg = bcBody;
             [inv setArgument:&bcArg atIndex:5];
             [inv invoke];
         } else {
@@ -2449,7 +2457,7 @@ static NSDictionary *handleEditMessage(NSInteger requestId, NSDictionary *params
             [inv setArgument:&localPartIndex atIndex:3];
             __unsafe_unretained NSAttributedString *newBodyArg = newBody;
             [inv setArgument:&newBodyArg atIndex:4];
-            __unsafe_unretained NSString *bcArg = bcText;
+            __unsafe_unretained NSAttributedString *bcArg = bcBody;
             [inv setArgument:&bcArg atIndex:5];
             [inv invoke];
         }


### PR DESCRIPTION
## Summary

`imsg edit` (and the `edit-message` bridge action) has never applied an edit on macOS 14+. The call returns `{"queued": true}` but the message is never modified. `handleEditMessage` drove `-[IMChat editMessageItem:atPartIndex:withNewPartText: backwardCompatabilityText:]` with two wrong argument types:
1. **Wrong item type.** It passed the `IMMessagePartChatItem` from `findMessageItem` straight through; the selector expects the backing `IMMessageItem`. On macOS 15 this also throws `-[IMTextMessagePartChatItem body]: unrecognized selector` inside IMCore.
2. **Wrong text type.** It passed `backwardCompatabilityText:` as a plain `NSString`. The selector requires an `NSAttributedString`; given an `NSString` it returns cleanly **without committing the edit** — no exception, no error, `date_edited` stays `0`.
     
Fix: reach the `IMMessageItem` via `-messageItem`, and wrap the backwards-compat text in `NSAttributedString`. The macOS 13 `editMessage:` path gets the same attributed-text fix.
  
Confirmed by swizzling `-[IMChat editMessageItem:…]` inside Messages.app and diffing the arguments a UI-initiated edit passes vs. what the bridge passed — the only meaningful differences were the item type and the bc-text type. 
  
## Verify
  
Requires SIP disabled + `imsg launch` (dylib injected), macOS 14+.
  
    imsg send --chat-id <n> --text "before"
    imsg edit --chat "<chat-guid>" --message "<msg-guid>" --new-text "after"
      
Before: `{"queued": true}` but `imsg history` still shows "before" and `chat.db` `message.date_edited` is `0`.
After: the message shows "after" with an Edited marker; `date_edited` is set and `message_summary_info` grows.
  
Tested on macOS 15.7.7 (24G720), Apple Silicon.
  
## Checks
  
 - `make test` — 222/222 pass.
 - `make lint` — `swift format lint` clean.
  
## Notes
  
The bug dates to the BlueBubbles bridge port (`c56c24d`); edit has never worked on macOS 14+. No automated coverage is included — reproducing it needs an injected dylib in a live Messages.app with SIP disabled, outside the fixture-based suite.