### PR TITLE
Expose message.send_status RPC

### DIFF
--- a/Sources/IMsgCore/MessageStore+Messages.swift
+++ b/Sources/IMsgCore/MessageStore+Messages.swift
@@ -328,6 +328,41 @@ extension MessageStore {
     }
   }
 
+  public func messageSendStatus(guid: String) throws -> MessageSendStatus? {
+    let trimmed = guid.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return nil }
+
+    return try withConnection { db in
+      let columns = MessageStore.tableColumns(connection: db, table: "message")
+      func column(_ name: String, defaultValue: String) -> String {
+        columns.contains(name.lowercased()) ? "m.\(name)" : defaultValue
+      }
+
+      let sql = """
+        SELECT m.ROWID AS message_rowid,
+               \(column("guid", defaultValue: "''")) AS guid,
+               \(column("service", defaultValue: "''")) AS service,
+               \(column("error", defaultValue: "0")) AS error,
+               \(column("date_delivered", defaultValue: "0")) AS date_delivered,
+               \(column("date_read", defaultValue: "0")) AS date_read,
+               \(column("is_sent", defaultValue: "0")) AS is_sent,
+               \(column("is_delivered", defaultValue: "0")) AS is_delivered,
+               \(column("is_finished", defaultValue: "0")) AS is_finished,
+               \(column("is_delayed", defaultValue: "0")) AS is_delayed,
+               \(column("is_prepared", defaultValue: "0")) AS is_prepared,
+               \(column("is_pending_satellite_send", defaultValue: "0")) AS is_pending_satellite_send,
+               \(column("was_downgraded", defaultValue: "0")) AS was_downgraded
+        FROM message m
+        WHERE \(column("guid", defaultValue: "''")) = ?
+        ORDER BY m.ROWID DESC
+        LIMIT 1
+        """
+      let rows = try db.prepareRowIterator(sql, bindings: [trimmed])
+      guard let row = try rows.failableNext() else { return nil }
+      return try decodeMessageSendStatus(row)
+    }
+  }
+
   func decodeMessageRow(
     _ row: Row,
     columns: MessageRowColumns,
@@ -376,6 +411,26 @@ extension MessageStore {
       associatedType: associatedType,
       attachments: attachments,
       threadOriginatorGUID: threadOriginatorGUID
+    )
+  }
+
+  func decodeMessageSendStatus(_ row: Row) throws -> MessageSendStatus {
+    let deliveredRaw = try int64Value(row, "date_delivered")
+    let readRaw = try int64Value(row, "date_read")
+    return MessageSendStatus(
+      rowID: try int64Value(row, "message_rowid") ?? 0,
+      guid: try stringValue(row, "guid"),
+      service: try stringValue(row, "service"),
+      error: try intValue(row, "error") ?? 0,
+      dateDelivered: deliveredRaw.flatMap { $0 > 0 ? appleDate(from: $0) : nil },
+      dateRead: readRaw.flatMap { $0 > 0 ? appleDate(from: $0) : nil },
+      isSent: (try intValue(row, "is_sent") ?? 0) != 0,
+      isDelivered: (try intValue(row, "is_delivered") ?? 0) != 0,
+      isFinished: (try intValue(row, "is_finished") ?? 0) != 0,
+      isDelayed: (try intValue(row, "is_delayed") ?? 0) != 0,
+      isPrepared: (try intValue(row, "is_prepared") ?? 0) != 0,
+      isPendingSatelliteSend: (try intValue(row, "is_pending_satellite_send") ?? 0) != 0,
+      wasDowngraded: (try intValue(row, "was_downgraded") ?? 0) != 0
     )
   }
 }

--- a/Sources/IMsgCore/Models.swift
+++ b/Sources/IMsgCore/Models.swift
@@ -406,6 +406,66 @@ public struct Message: Sendable, Equatable {
   }
 }
 
+public enum MessageSendState: String, Sendable, Equatable {
+  case pending
+  case sent
+  case delivered
+  case failed
+}
+
+public struct MessageSendStatus: Sendable, Equatable {
+  public let rowID: Int64
+  public let guid: String
+  public let service: String
+  public let error: Int
+  public let dateDelivered: Date?
+  public let dateRead: Date?
+  public let isSent: Bool
+  public let isDelivered: Bool
+  public let isFinished: Bool
+  public let isDelayed: Bool
+  public let isPrepared: Bool
+  public let isPendingSatelliteSend: Bool
+  public let wasDowngraded: Bool
+
+  public var state: MessageSendState {
+    if error != 0 { return .failed }
+    if isDelivered || dateDelivered != nil { return .delivered }
+    if isSent { return .sent }
+    return .pending
+  }
+
+  public init(
+    rowID: Int64,
+    guid: String,
+    service: String,
+    error: Int,
+    dateDelivered: Date?,
+    dateRead: Date?,
+    isSent: Bool,
+    isDelivered: Bool,
+    isFinished: Bool,
+    isDelayed: Bool,
+    isPrepared: Bool,
+    isPendingSatelliteSend: Bool,
+    wasDowngraded: Bool
+  ) {
+    self.rowID = rowID
+    self.guid = guid
+    self.service = service
+    self.error = error
+    self.dateDelivered = dateDelivered
+    self.dateRead = dateRead
+    self.isSent = isSent
+    self.isDelivered = isDelivered
+    self.isFinished = isFinished
+    self.isDelayed = isDelayed
+    self.isPrepared = isPrepared
+    self.isPendingSatelliteSend = isPendingSatelliteSend
+    self.wasDowngraded = wasDowngraded
+  }
+}
+
 public struct AttachmentMeta: Sendable, Equatable {
   public let filename: String
   public let transferName: String

--- a/Sources/imsg/RPCServer+MessageStatusHandlers.swift
+++ b/Sources/imsg/RPCServer+MessageStatusHandlers.swift
@@ -1,0 +1,54 @@
+import Foundation
+import IMsgCore
+
+extension RPCServer {
+  func handleMessageSendStatus(params: [String: Any], id: Any?) async throws {
+    let guid = (stringParam(params["guid"]) ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !guid.isEmpty else {
+      throw RPCError.invalidParams("guid is required")
+    }
+
+    let checkedAt = Date()
+    guard let status = try store.messageSendStatus(guid: guid) else {
+      respond(
+        id: id,
+        result: [
+          "ok": true,
+          "guid": guid,
+          "send_state": MessageSendState.pending.rawValue,
+          "service": NSNull(),
+          "checked_at": CLIISO8601.format(checkedAt),
+          "status_fields": NSNull(),
+        ])
+      return
+    }
+
+    var result: [String: Any] = [
+      "ok": true,
+      "guid": status.guid,
+      "send_state": status.state.rawValue,
+      "service": status.service.isEmpty ? NSNull() : status.service,
+      "checked_at": CLIISO8601.format(checkedAt),
+      "status_fields": messageSendStatusFields(status),
+    ]
+    if let deliveredAt = status.dateDelivered {
+      result["delivered_at"] = CLIISO8601.format(deliveredAt)
+    }
+    respond(id: id, result: result)
+  }
+
+  private func messageSendStatusFields(_ status: MessageSendStatus) -> [String: Any] {
+    return [
+      "is_sent": status.isSent,
+      "is_delivered": status.isDelivered,
+      "is_finished": status.isFinished,
+      "error": status.error,
+      "date_delivered": status.dateDelivered.map { CLIISO8601.format($0) } ?? NSNull(),
+      "date_read": status.dateRead.map { CLIISO8601.format($0) } ?? NSNull(),
+      "is_delayed": status.isDelayed,
+      "is_prepared": status.isPrepared,
+      "is_pending_satellite_send": status.isPendingSatelliteSend,
+      "was_downgraded": status.wasDowngraded,
+    ]
+  }
+}

--- a/Sources/imsg/RPCServer.swift
+++ b/Sources/imsg/RPCServer.swift
@@ -44,6 +44,7 @@ let kSupportedRPCMethods: [String] = [
   "message.unsend",
   "message.delete",
   "message.notifyAnyways",
+  "message.send_status",
   "group.rename",
   "group.setIcon",
   "group.addParticipant",
@@ -162,6 +163,8 @@ final class RPCServer {
         try await handleMessageDelete(params: params, id: id)
       case "message.notifyAnyways":
         try await handleMessageNotifyAnyways(params: params, id: id)
+      case "message.send_status":
+        try await handleMessageSendStatus(params: params, id: id)
       case "chats.create":
         try await handleChatsCreate(id: id, params: params)
       case "chats.delete":

--- a/Tests/IMsgCoreTests/MessageStoreSentMessageTests.swift
+++ b/Tests/IMsgCoreTests/MessageStoreSentMessageTests.swift
@@ -135,6 +135,63 @@ func latestUnjoinedSentMessageRowIDMatchesAnyGroupTargetVariants() throws {
   #expect(rowID == 20)
 }
 
+@Test
+func messageSendStatusMapsFailedSentDeliveredAndPendingRows() throws {
+  let db = try makeSentMessageDatabase()
+  let deliveredAt = Date()
+  try insertSentMessageFixture(
+    db,
+    rowID: 30,
+    chatID: 1,
+    text: "failed",
+    guid: "failed-guid",
+    date: deliveredAt,
+    isFromMe: true,
+    error: 22,
+    isSent: false
+  )
+  try insertSentMessageFixture(
+    db,
+    rowID: 31,
+    chatID: 1,
+    text: "sent",
+    guid: "sent-guid",
+    date: deliveredAt,
+    isFromMe: true,
+    isSent: true
+  )
+  try insertSentMessageFixture(
+    db,
+    rowID: 32,
+    chatID: 1,
+    text: "delivered",
+    guid: "delivered-guid",
+    date: deliveredAt,
+    isFromMe: true,
+    isSent: true,
+    isDelivered: true,
+    dateDelivered: deliveredAt
+  )
+  try insertSentMessageFixture(
+    db,
+    rowID: 33,
+    chatID: 1,
+    text: "pending",
+    guid: "pending-guid",
+    date: deliveredAt,
+    isFromMe: true
+  )
+  let store = try MessageStore(connection: db, path: ":memory:")
+
+  #expect(try store.messageSendStatus(guid: "failed-guid")?.state == .failed)
+  #expect(try store.messageSendStatus(guid: "sent-guid")?.state == .sent)
+  let delivered = try store.messageSendStatus(guid: "delivered-guid")
+  #expect(delivered?.state == .delivered)
+  #expect(delivered?.dateDelivered != nil)
+  #expect(try store.messageSendStatus(guid: "pending-guid")?.state == .pending)
+  #expect(try store.messageSendStatus(guid: "missing-guid") == nil)
+}
+
 private func makeSentMessageDatabase() throws -> Connection {
   let db = try Connection(.inMemory)
   try db.execute(
@@ -147,8 +204,18 @@ private func makeSentMessageDatabase() throws -> Connection {
       associated_message_guid TEXT,
       associated_message_type INTEGER,
       date INTEGER,
+      date_delivered INTEGER,
+      date_read INTEGER,
       is_from_me INTEGER,
-      service TEXT
+      service TEXT,
+      error INTEGER DEFAULT 0,
+      is_sent INTEGER DEFAULT 0,
+      is_delivered INTEGER DEFAULT 0,
+      is_finished INTEGER DEFAULT 0,
+      is_delayed INTEGER DEFAULT 0,
+      is_prepared INTEGER DEFAULT 0,
+      is_pending_satellite_send INTEGER DEFAULT 0,
+      was_downgraded INTEGER DEFAULT 0
     );
     """
   )
@@ -185,21 +252,29 @@ private func insertSentMessageFixture(
   text: String,
   guid: String,
   date: Date,
-  isFromMe: Bool
+  isFromMe: Bool,
+  error: Int = 0,
+  isSent: Bool = false,
+  isDelivered: Bool = false,
+  dateDelivered: Date? = nil
 ) throws {
   try db.run(
     """
     INSERT INTO message(
       ROWID, handle_id, text, guid, associated_message_guid, associated_message_type,
-      date, is_from_me, service
+      date, date_delivered, is_from_me, service, error, is_sent, is_delivered, is_finished
     )
-    VALUES (?, 1, ?, ?, NULL, 0, ?, ?, 'iMessage')
+    VALUES (?, 1, ?, ?, NULL, 0, ?, ?, ?, 'iMessage', ?, ?, ?, 1)
     """,
     rowID,
     text,
     guid,
     TestDatabase.appleEpoch(date),
-    isFromMe ? 1 : 0
+    dateDelivered.map { TestDatabase.appleEpoch($0) } ?? 0,
+    isFromMe ? 1 : 0,
+    error,
+    isSent ? 1 : 0,
+    isDelivered ? 1 : 0
   )
   try db.run("INSERT INTO chat_message_join(chat_id, message_id) VALUES (?, ?)", chatID, rowID)
 }

--- a/Tests/imsgTests/RPCBridgeMessageHandlersTests.swift
+++ b/Tests/imsgTests/RPCBridgeMessageHandlersTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 
 @testable import IMsgCore
@@ -15,6 +16,7 @@ func rpcStatusAdvertisesBridgeMessageMethods() {
     "message.unsend",
     "message.delete",
     "message.notifyAnyways",
+    "message.send_status",
   ] {
     #expect(methods.contains(method))
   }

--- a/Tests/imsgTests/RPCServerTests.swift
+++ b/Tests/imsgTests/RPCServerTests.swift
@@ -84,6 +84,92 @@ func rpcMessagesHistoryIncludesChatFields() async throws {
 }
 
 @Test
+func rpcMessageSendStatusReturnsNormalizedStatus() async throws {
+  let store = try CommandTestDatabase.makeStoreForRPC()
+  try store.withConnection { db in
+    try db.run("ALTER TABLE message ADD COLUMN guid TEXT")
+    try db.run("ALTER TABLE message ADD COLUMN error INTEGER")
+    try db.run("ALTER TABLE message ADD COLUMN date_delivered INTEGER")
+    try db.run("ALTER TABLE message ADD COLUMN date_read INTEGER")
+    try db.run("ALTER TABLE message ADD COLUMN is_sent INTEGER")
+    try db.run("ALTER TABLE message ADD COLUMN is_delivered INTEGER")
+    try db.run("ALTER TABLE message ADD COLUMN is_finished INTEGER")
+    try db.run("ALTER TABLE message ADD COLUMN is_delayed INTEGER")
+    try db.run("ALTER TABLE message ADD COLUMN is_prepared INTEGER")
+    try db.run("ALTER TABLE message ADD COLUMN is_pending_satellite_send INTEGER")
+    try db.run("ALTER TABLE message ADD COLUMN was_downgraded INTEGER")
+    try db.run(
+      """
+      UPDATE message
+      SET guid = 'delivered-guid',
+          error = 0,
+          date_delivered = ?,
+          date_read = 0,
+          is_sent = 1,
+          is_delivered = 1,
+          is_finished = 1,
+          is_delayed = 0,
+          is_prepared = 0,
+          is_pending_satellite_send = 0,
+          was_downgraded = 0
+      WHERE ROWID = 5
+      """,
+      CommandTestDatabase.appleEpoch(Date(timeIntervalSince1970: 1_779_348_870))
+    )
+  }
+  let output = TestRPCOutput()
+  let server = RPCServer(store: store, verbose: false, output: output)
+
+  let line =
+    #"{"jsonrpc":"2.0","id":"send-status","method":"message.send_status","params":{"guid":"delivered-guid"}}"#
+  await server.handleLineForTesting(line)
+
+  let result = output.responses.first?["result"] as? [String: Any]
+  #expect(result?["ok"] as? Bool == true)
+  #expect(result?["guid"] as? String == "delivered-guid")
+  #expect(result?["send_state"] as? String == "delivered")
+  #expect(result?["service"] as? String == "iMessage")
+  #expect(result?["checked_at"] as? String != nil)
+  #expect(result?["delivered_at"] as? String != nil)
+  let fields = result?["status_fields"] as? [String: Any]
+  #expect(fields?["is_sent"] as? Bool == true)
+  #expect(fields?["is_delivered"] as? Bool == true)
+  #expect(int64Value(fields?["error"]) == 0)
+  #expect(fields?["date_delivered"] as? String != nil)
+}
+
+@Test
+func rpcMessageSendStatusMissingRowReturnsPending() async throws {
+  let store = try CommandTestDatabase.makeStoreForRPC()
+  let output = TestRPCOutput()
+  let server = RPCServer(store: store, verbose: false, output: output)
+
+  let line =
+    #"{"jsonrpc":"2.0","id":"send-status","method":"message.send_status","params":{"guid":"missing-guid"}}"#
+  await server.handleLineForTesting(line)
+
+  let result = output.responses.first?["result"] as? [String: Any]
+  #expect(result?["ok"] as? Bool == true)
+  #expect(result?["guid"] as? String == "missing-guid")
+  #expect(result?["send_state"] as? String == "pending")
+  #expect(result?["service"] is NSNull)
+  #expect(result?["checked_at"] as? String != nil)
+  #expect(result?["status_fields"] is NSNull)
+}
+
+@Test
+func rpcMessageSendStatusRejectsMissingGuid() async throws {
+  let store = try CommandTestDatabase.makeStoreForRPC()
+  let output = TestRPCOutput()
+  let server = RPCServer(store: store, verbose: false, output: output)
+
+  let line = #"{"jsonrpc":"2.0","id":"send-status","method":"message.send_status","params":{}}"#
+  await server.handleLineForTesting(line)
+
+  let error = output.errors.first?["error"] as? [String: Any]
+  #expect(int64Value(error?["code"]) == -32602)
+}
+
 func rpcMessagesHistoryReportsConvertedAttachmentsWhenRequested() async throws {
   let source = FileManager.default.temporaryDirectory
     .appendingPathComponent(UUID().uuidString)


### PR DESCRIPTION
Adds a dedicated `message.send_status` JSON-RPC method for querying outbound message state by GUID.

## Changes

- Add `MessageSendState` and `MessageSendStatus`
- Add `MessageStore.messageSendStatus(guid:)`
- Expose and dispatch `message.send_status`
- Normalize DB state to `pending`, `sent`, `delivered`, or `failed`
- Include selected DB status fields under `status_fields`
- Add focused store/RPC tests

## Notes

This adds a read-only status lookup. Existing send RPC response shapes are unchanged.