### PR TITLE
fix: return send identity in rpc responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.9.1 - Unreleased
 
+### JSON-RPC
+- fix: return chat GUID, message GUID, and service identity from JSON-RPC send/create responses when observable (#119, thanks @svetly).
+
 ## 0.9.0 - 2026-05-16
 
 ### JSON Output

--- a/Sources/IMsgCore/MessageStore+Messages.swift
+++ b/Sources/IMsgCore/MessageStore+Messages.swift
@@ -286,45 +286,48 @@ extension MessageStore {
 
     return try withConnection { db in
       let rows = try db.prepareRowIterator(query.sql, bindings: query.bindings)
-      guard let row = try rows.failableNext() else { return nil }
-      let decoded = try decodeMessageRow(
-        row,
-        columns: query.selection.columns,
-        fallbackChatID: query.fallbackChatID
-      )
-      let replyToGUID = replyToGUID(
-        associatedGuid: decoded.associatedGUID,
-        associatedType: decoded.associatedType
-      )
-      let threadOriginatorGUID =
-        decoded.threadOriginatorGUID.isEmpty ? nil : decoded.threadOriginatorGUID
-      var parentCache: ReplyParentCache = [:]
-      let parent = enrichedReplyContext(
-        db,
-        replyToGUID: replyToGUID,
-        threadOriginatorGUID: threadOriginatorGUID,
-        cache: &parentCache
-      )
-      return Message(
-        rowID: decoded.rowID,
-        chatID: decoded.chatID,
-        sender: decoded.sender,
-        text: decoded.text,
-        date: decoded.date,
-        isFromMe: decoded.isFromMe,
-        service: decoded.service,
-        handleID: decoded.handleID,
-        attachmentsCount: decoded.attachments,
-        guid: decoded.guid,
-        routing: Message.RoutingMetadata(
+      while let row = try rows.failableNext() {
+        let decoded = try decodeMessageRow(
+          row,
+          columns: query.selection.columns,
+          fallbackChatID: query.fallbackChatID
+        )
+        guard decoded.text == text else { continue }
+        let replyToGUID = replyToGUID(
+          associatedGuid: decoded.associatedGUID,
+          associatedType: decoded.associatedType
+        )
+        let threadOriginatorGUID =
+          decoded.threadOriginatorGUID.isEmpty ? nil : decoded.threadOriginatorGUID
+        var parentCache: ReplyParentCache = [:]
+        let parent = enrichedReplyContext(
+          db,
           replyToGUID: replyToGUID,
           threadOriginatorGUID: threadOriginatorGUID,
-          destinationCallerID: decoded.destinationCallerID.isEmpty
-            ? nil : decoded.destinationCallerID,
-          replyToText: parent?.text,
-          replyToSender: parent?.sender
+          cache: &parentCache
         )
-      )
+        return Message(
+          rowID: decoded.rowID,
+          chatID: decoded.chatID,
+          sender: decoded.sender,
+          text: decoded.text,
+          date: decoded.date,
+          isFromMe: decoded.isFromMe,
+          service: decoded.service,
+          handleID: decoded.handleID,
+          attachmentsCount: decoded.attachments,
+          guid: decoded.guid,
+          routing: Message.RoutingMetadata(
+            replyToGUID: replyToGUID,
+            threadOriginatorGUID: threadOriginatorGUID,
+            destinationCallerID: decoded.destinationCallerID.isEmpty
+              ? nil : decoded.destinationCallerID,
+            replyToText: parent?.text,
+            replyToSender: parent?.sender
+          )
+        )
+      }
+      return nil
     }
   }
 

--- a/Sources/IMsgCore/MessageStore+Queries.swift
+++ b/Sources/IMsgCore/MessageStore+Queries.swift
@@ -107,21 +107,25 @@ struct LatestSentMessageQuery {
 
   init(store: MessageStore, text: String, chatID: ChatID?, since date: Date) {
     self.selection = MessageRowSelection(store: store, includeChatID: true)
+    let bodyColumn = store.schema.hasAttributedBody ? "m.attributedBody" : "NULL"
     var sql = """
       SELECT \(selection.selectList)
       FROM message m
       LEFT JOIN chat_message_join cmj ON m.ROWID = cmj.message_id
       LEFT JOIN handle h ON m.handle_id = h.ROWID
       WHERE m.is_from_me = 1
-        AND IFNULL(m.text, '') = ?
         AND m.date >= ?
+        AND (
+          IFNULL(m.text, '') = ?
+          OR (IFNULL(m.text, '') = '' AND \(bodyColumn) IS NOT NULL)
+        )
       """
-    var bindings: [Binding?] = [text, MessageStore.appleEpoch(date)]
+    var bindings: [Binding?] = [MessageStore.appleEpoch(date), text]
     if let chatID {
       sql += " AND cmj.chat_id = ?"
       bindings.append(chatID.rawValue)
     }
-    sql += " ORDER BY m.date DESC, m.ROWID DESC LIMIT 1"
+    sql += " ORDER BY m.date DESC, m.ROWID DESC"
 
     self.sql = sql
     self.bindings = bindings

--- a/Sources/IMsgHelper/IMsgInjected.m
+++ b/Sources/IMsgHelper/IMsgInjected.m
@@ -244,6 +244,7 @@ static void probeSelectors(void) {
 @interface IMHandleRegistrar : NSObject
 + (instancetype)sharedInstance;
 - (id)IMHandleWithID:(NSString *)handleID;
+- (id)getIMHandlesForID:(NSString *)handleID;
 @end
 
 @interface IMChatRegistry : NSObject
@@ -390,6 +391,71 @@ static NSDictionary* errorResponse(NSInteger requestId, NSString *error) {
         @"error": error ?: @"Unknown error",
         @"timestamp": [[NSISO8601DateFormatter new] stringFromDate:[NSDate date]]
     };
+}
+
+static NSString *serviceNameForChat(IMChat *chat, NSString *chatGuid) {
+    NSString *serviceName = nil;
+    if ([chat respondsToSelector:@selector(account)]) {
+        id account = [chat performSelector:@selector(account)];
+        if ([account respondsToSelector:@selector(serviceName)]) {
+            serviceName = [account performSelector:@selector(serviceName)];
+        }
+    }
+    if (serviceName.length) return serviceName;
+    if ([chatGuid hasPrefix:@"SMS;"]) return @"SMS";
+    if ([chatGuid hasPrefix:@"iMessage;"]) return @"iMessage";
+    return nil;
+}
+
+static NSArray *handlesFromCandidate(id candidate) {
+    NSMutableArray *handles = [NSMutableArray array];
+    if ([candidate isKindOfClass:[NSArray class]]) {
+        [handles addObjectsFromArray:candidate];
+    } else if ([candidate isKindOfClass:[NSSet class]]) {
+        [handles addObjectsFromArray:[candidate allObjects]];
+    } else if (candidate) {
+        [handles addObject:candidate];
+    }
+    return handles;
+}
+
+static id handleMatchingService(NSArray *handles, NSString *preferredService) {
+    for (id handle in handles) {
+        if (![handle respondsToSelector:@selector(serviceName)]) continue;
+        NSString *serviceName = [handle performSelector:@selector(serviceName)];
+        if ([serviceName isKindOfClass:[NSString class]] &&
+            [serviceName caseInsensitiveCompare:preferredService ?: @""] == NSOrderedSame) {
+            return handle;
+        }
+    }
+    return nil;
+}
+
+static id vendIMHandle(id registrar, NSString *address, NSString *preferredService, BOOL allowFallback) {
+    if (!registrar || ![address isKindOfClass:[NSString class]] || address.length == 0) {
+        return nil;
+    }
+
+    NSMutableArray *fallbackHandles = [NSMutableArray array];
+    @try {
+        if ([registrar respondsToSelector:@selector(IMHandleWithID:)]) {
+            NSArray *handles = handlesFromCandidate([registrar performSelector:@selector(IMHandleWithID:)
+                                                                       withObject:address]);
+            id handle = handleMatchingService(handles, preferredService);
+            if (handle) return handle;
+            [fallbackHandles addObjectsFromArray:handles];
+        }
+        if ([registrar respondsToSelector:@selector(getIMHandlesForID:)]) {
+            NSArray *handles = handlesFromCandidate([registrar performSelector:@selector(getIMHandlesForID:)
+                                                                       withObject:address]);
+            id handle = handleMatchingService(handles, preferredService);
+            if (handle) return handle;
+            [fallbackHandles addObjectsFromArray:handles];
+        }
+    } @catch (__unused NSException *ex) {
+        return nil;
+    }
+    return allowFallback ? fallbackHandles.firstObject : nil;
 }
 
 #pragma mark - Chat Resolution
@@ -1786,11 +1852,14 @@ static NSDictionary *handleSendMessage(NSInteger requestId, NSDictionary *params
 
         // Best-effort messageGuid; not always available immediately.
         NSString *guid = lastSentMessageGuid(chat);
-        return successResponse(requestId, @{
+        NSMutableDictionary *response = [@{
             @"chatGuid": chatGuid,
             @"messageGuid": guid ?: @"",
             @"queued": @(ddScan)
-        });
+        } mutableCopy];
+        NSString *serviceName = serviceNameForChat(chat, chatGuid);
+        if (serviceName.length) response[@"service"] = serviceName;
+        return successResponse(requestId, response);
     } @catch (NSException *exception) {
         return errorResponse(requestId,
             [NSString stringWithFormat:@"send-message failed: %@", exception.reason]);
@@ -2845,16 +2914,28 @@ static NSDictionary *handleCreateChat(NSInteger requestId, NSDictionary *params)
     NSArray *addresses = params[@"addresses"];
     NSString *initialMessage = params[@"message"];
     NSString *displayName = params[@"displayName"] ?: params[@"name"];
-    NSString *service = params[@"service"] ?: @"iMessage";
+    NSString *requestedService = params[@"service"] ?: @"iMessage";
+    NSString *preferredService = @"iMessage";
+    NSString *responseService = @"iMessage";
+    BOOL allowHandleFallback = YES;
 
     if (![addresses isKindOfClass:[NSArray class]] || addresses.count == 0) {
         return errorResponse(requestId, @"Missing addresses array");
     }
-    if ([service caseInsensitiveCompare:@"iMessage"] != NSOrderedSame) {
+    if ([requestedService caseInsensitiveCompare:@"iMessage"] == NSOrderedSame) {
+        preferredService = @"iMessage";
+        responseService = @"iMessage";
+    } else if ([requestedService caseInsensitiveCompare:@"auto"] == NSOrderedSame) {
+        preferredService = @"iMessage";
+        responseService = @"iMessage";
+    } else if ([requestedService caseInsensitiveCompare:@"sms"] == NSOrderedSame) {
+        preferredService = @"SMS";
+        responseService = @"SMS";
+        allowHandleFallback = NO;
+    } else {
         return errorResponse(requestId, [NSString stringWithFormat:
-            @"Unsupported chat-create service: %@", service]);
+            @"Unsupported chat-create service: %@", requestedService]);
     }
-    service = @"iMessage";
 
     Class hrClass = NSClassFromString(@"IMHandleRegistrar");
     id hr = hrClass ? [hrClass performSelector:@selector(sharedInstance)] : nil;
@@ -2863,7 +2944,7 @@ static NSDictionary *handleCreateChat(NSInteger requestId, NSDictionary *params)
     NSMutableArray *handles = [NSMutableArray array];
     for (NSString *addr in addresses) {
         if (![addr isKindOfClass:[NSString class]]) continue;
-        id h = [hr performSelector:@selector(IMHandleWithID:) withObject:addr];
+        id h = vendIMHandle(hr, addr, preferredService, allowHandleFallback);
         if (h) [handles addObject:h];
     }
     if (handles.count == 0) {
@@ -2901,9 +2982,11 @@ static NSDictionary *handleCreateChat(NSInteger requestId, NSDictionary *params)
 
     NSString *guid = [chat respondsToSelector:@selector(guid)]
         ? [chat performSelector:@selector(guid)] : @"";
+    NSString *observedService = serviceNameForChat(chat, guid);
+    if (observedService.length) responseService = observedService;
     return successResponse(requestId, @{
         @"chatGuid": guid ?: @"",
-        @"service": service,
+        @"service": responseService,
         @"messageGuid": messageGuid ?: @"",
         @"participants": addresses
     });

--- a/Sources/imsg/RPCServer+ChatHandlers.swift
+++ b/Sources/imsg/RPCServer+ChatHandlers.swift
@@ -27,6 +27,12 @@ extension RPCServer {
     if let guid = data["chatGuid"] as? String, !guid.isEmpty {
       result["chat_guid"] = guid
     }
+    if let messageGUID = data["messageGuid"] as? String, !messageGUID.isEmpty {
+      result["message_guid"] = messageGUID
+    }
+    if let service = data["service"] as? String, !service.isEmpty {
+      result["service"] = service
+    }
     respond(id: id, result: result)
   }
 

--- a/Sources/imsg/RPCServer+Handlers.swift
+++ b/Sources/imsg/RPCServer+Handlers.swift
@@ -245,6 +245,12 @@ extension RPCServer {
         if let guid = data["messageGuid"] as? String, !guid.isEmpty {
           result["guid"] = guid
         }
+        if let chatGuid = data["chatGuid"] as? String, !chatGuid.isEmpty {
+          result["chat_guid"] = chatGuid
+        }
+        if let service = data["service"] as? String, !service.isEmpty {
+          result["service"] = service
+        }
         respond(id: id, result: result)
         return
       } catch let err as RPCError {
@@ -280,6 +286,36 @@ extension RPCServer {
       if !sentMessage.guid.isEmpty {
         result["guid"] = sentMessage.guid
       }
+    }
+    var responseChatInfo: ChatInfo?
+    if let sentMessage {
+      responseChatInfo = try? await cache.info(chatID: sentMessage.chatID)
+    }
+    if responseChatInfo == nil, let verificationChatID {
+      responseChatInfo = try? await cache.info(chatID: verificationChatID)
+    }
+    if responseChatInfo == nil {
+      responseChatInfo = directChatInfo
+    }
+    if let chatInfo = responseChatInfo {
+      if !chatInfo.guid.isEmpty {
+        result["chat_guid"] = chatInfo.guid
+      }
+      if !chatInfo.service.isEmpty {
+        result["service"] = chatInfo.service
+      }
+    }
+    if result["chat_guid"] == nil {
+      let resolvedChatGUID =
+        !resolvedTarget.chatGUID.isEmpty ? resolvedTarget.chatGUID : (directChatInfo?.guid ?? "")
+      if !resolvedChatGUID.isEmpty {
+        result["chat_guid"] = resolvedChatGUID
+      }
+    }
+    if result["service"] == nil,
+      let directService = directChatInfo?.service, !directService.isEmpty
+    {
+      result["service"] = directService
     }
     respond(id: id, result: result)
   }

--- a/Tests/IMsgCoreTests/MessageStoreSentMessageTests.swift
+++ b/Tests/IMsgCoreTests/MessageStoreSentMessageTests.swift
@@ -93,6 +93,66 @@ func latestSentMessageFallsBackToNewestOutgoingTextWithoutChatFilter() throws {
 }
 
 @Test
+func latestSentMessageMatchesAttributedBodyText() throws {
+  let db = try makeSentMessageDatabase()
+  let now = Date()
+  let text = "body fallback"
+  try insertAttributedSentMessageFixture(
+    db,
+    rowID: 10,
+    chatID: 1,
+    text: text,
+    guid: "body-guid",
+    date: now
+  )
+  let store = try MessageStore(connection: db, path: ":memory:")
+
+  let message = try store.latestSentMessage(
+    matchingText: text,
+    chatID: 1,
+    since: now.addingTimeInterval(-1)
+  )
+
+  #expect(message?.rowID == 10)
+  #expect(message?.guid == "body-guid")
+  #expect(message?.text == text)
+}
+
+@Test
+func latestSentMessagePrefersNewestDecodedAttributedBodyMatch() throws {
+  let db = try makeSentMessageDatabase()
+  let now = Date()
+  let text = "repeat"
+  try insertSentMessageFixture(
+    db,
+    rowID: 10,
+    chatID: 1,
+    text: text,
+    guid: "older-plain-guid",
+    date: now.addingTimeInterval(-1),
+    isFromMe: true
+  )
+  try insertAttributedSentMessageFixture(
+    db,
+    rowID: 11,
+    chatID: 1,
+    text: text,
+    guid: "newer-body-guid",
+    date: now
+  )
+  let store = try MessageStore(connection: db, path: ":memory:")
+
+  let message = try store.latestSentMessage(
+    matchingText: text,
+    chatID: 1,
+    since: now.addingTimeInterval(-2)
+  )
+
+  #expect(message?.rowID == 11)
+  #expect(message?.guid == "newer-body-guid")
+}
+
+@Test
 func chatInfoMatchingTargetHandlesAnyGroupPolarityMismatch() throws {
   let db = try makeSentMessageDatabase()
   try db.run(
@@ -143,6 +203,7 @@ private func makeSentMessageDatabase() throws -> Connection {
       ROWID INTEGER PRIMARY KEY,
       handle_id INTEGER,
       text TEXT,
+      attributedBody BLOB,
       guid TEXT,
       associated_message_guid TEXT,
       associated_message_type INTEGER,
@@ -200,6 +261,31 @@ private func insertSentMessageFixture(
     guid,
     TestDatabase.appleEpoch(date),
     isFromMe ? 1 : 0
+  )
+  try db.run("INSERT INTO chat_message_join(chat_id, message_id) VALUES (?, ?)", chatID, rowID)
+}
+
+private func insertAttributedSentMessageFixture(
+  _ db: Connection,
+  rowID: Int64,
+  chatID: Int64,
+  text: String,
+  guid: String,
+  date: Date
+) throws {
+  let bodyBytes = [UInt8(0x01), UInt8(0x2b)] + Array(text.utf8) + [0x86, 0x84]
+  try db.run(
+    """
+    INSERT INTO message(
+      ROWID, handle_id, text, attributedBody, guid, associated_message_guid,
+      associated_message_type, date, is_from_me, service
+    )
+    VALUES (?, 1, NULL, ?, ?, NULL, 0, ?, 1, 'iMessage')
+    """,
+    rowID,
+    Blob(bytes: bodyBytes),
+    guid,
+    TestDatabase.appleEpoch(date)
   )
   try db.run("INSERT INTO chat_message_join(chat_id, message_id) VALUES (?, ?)", chatID, rowID)
 }

--- a/Tests/imsgTests/RPCServerBridgeTests.swift
+++ b/Tests/imsgTests/RPCServerBridgeTests.swift
@@ -21,7 +21,7 @@ func rpcSendUsesBridgeWhenReadyAndExistingDirectChatResolves() async throws {
     invokeBridge: { action, params in
       capturedAction = action
       capturedParams = params
-      return ["messageGuid": "bridge-guid"]
+      return ["messageGuid": "bridge-guid", "chatGuid": "iMessage;-;+123", "service": "iMessage"]
     },
     isBridgeReady: { true }
   )
@@ -36,6 +36,8 @@ func rpcSendUsesBridgeWhenReadyAndExistingDirectChatResolves() async throws {
   let result = output.responses.first?["result"] as? [String: Any]
   #expect(result?["transport"] as? String == "bridge")
   #expect(result?["guid"] as? String == "bridge-guid")
+  #expect(result?["chat_guid"] as? String == "iMessage;-;+123")
+  #expect(result?["service"] as? String == "iMessage")
 }
 
 @Test
@@ -60,6 +62,8 @@ func rpcSendFallsBackToAppleScriptWhenAutoBridgeFails() async throws {
   #expect(captured?.recipient == "+123")
   let result = output.responses.first?["result"] as? [String: Any]
   #expect(result?["transport"] as? String == "applescript")
+  #expect(result?["chat_guid"] as? String == "iMessage;-;+123")
+  #expect(result?["service"] as? String == "iMessage")
 }
 
 @Test

--- a/Tests/imsgTests/RPCServerTests.swift
+++ b/Tests/imsgTests/RPCServerTests.swift
@@ -84,6 +84,44 @@ func rpcMessagesHistoryIncludesChatFields() async throws {
 }
 
 @Test
+func rpcChatsCreateForwardsBridgeIdentityFields() async throws {
+  let store = try CommandTestDatabase.makeStoreForRPC()
+  let output = TestRPCOutput()
+  var capturedAction: BridgeAction?
+  var capturedParams: [String: Any] = [:]
+  let server = RPCServer(
+    store: store,
+    verbose: false,
+    output: output,
+    invokeBridge: { action, params in
+      capturedAction = action
+      capturedParams = params
+      return [
+        "chatGuid": "iMessage;+;chat987",
+        "messageGuid": "created-message-guid",
+        "service": "iMessage",
+      ]
+    }
+  )
+
+  let line =
+    #"{"jsonrpc":"2.0","id":"create","method":"chats.create","params":{"#
+    + #""addresses":["+123","+456"],"service":"auto","name":"Group","text":"hello"}}"#
+  await server.handleLineForTesting(line)
+
+  #expect(capturedAction == .createChat)
+  #expect(capturedParams["addresses"] as? [String] == ["+123", "+456"])
+  #expect(capturedParams["service"] as? String == "auto")
+  #expect(capturedParams["displayName"] as? String == "Group")
+  #expect(capturedParams["message"] as? String == "hello")
+  let result = output.responses.first?["result"] as? [String: Any]
+  #expect(result?["ok"] as? Bool == true)
+  #expect(result?["chat_guid"] as? String == "iMessage;+;chat987")
+  #expect(result?["message_guid"] as? String == "created-message-guid")
+  #expect(result?["service"] as? String == "iMessage")
+}
+
+@Test
 func rpcMessagesHistoryReportsConvertedAttachmentsWhenRequested() async throws {
   let source = FileManager.default.temporaryDirectory
     .appendingPathComponent(UUID().uuidString)
@@ -216,6 +254,8 @@ func rpcSendReturnsSentMessageIdentifiersWhenResolved() async throws {
   #expect(result?["ok"] as? Bool == true)
   #expect(int64Value(result?["id"]) == 1_979)
   #expect(result?["guid"] as? String == "8DF1B3D7")
+  #expect(result?["chat_guid"] as? String == "iMessage;+;chat123")
+  #expect(result?["service"] as? String == "iMessage")
 }
 
 @Test
@@ -237,6 +277,8 @@ func rpcSendKeepsOkResponseWhenSentMessageIsNotResolved() async throws {
   #expect(result?["ok"] as? Bool == true)
   #expect(result?["id"] == nil)
   #expect(result?["guid"] == nil)
+  #expect(result?["chat_guid"] as? String == "iMessage;+;chat123")
+  #expect(result?["service"] as? String == "iMessage")
 }
 
 @Test


### PR DESCRIPTION
Recreates #119 locally because pushing fixups to the contributor branch was denied, despite the PR reporting maintainer edits were allowed.

What changed:
- returns `chat_guid`, `guid` / `message_guid`, and `service` from bridge-backed send/create responses when the bridge reports them
- enriches AppleScript JSON-RPC send responses with resolved chat GUID and service metadata when observable
- lets latest sent-message verification match attributed-body-only outgoing rows without returning stale repeated-text rows
- makes explicit SMS chat creation require an SMS handle instead of silently falling back to an iMessage handle
- adds focused regression coverage and a changelog entry

Proof:
- `swift test --filter 'MessageStoreSentMessageTests|RPCServerTests|RPCServerBridgeTests'`
- `make lint` (passes with existing file-length warnings)
- `make build-dylib` (passes with existing `unarchiveObjectWithData:` deprecation warning)
- `autoreview --mode branch --base origin/main` clean

Co-authored-by: Svet <svetly@gmail.com>
