### PR TITLE
feat: expose message.send_status over rpc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### JSON-RPC
 - fix: return chat GUID, message GUID, and service identity from JSON-RPC send/create responses when observable (#119, thanks @svetly).
 - feat: expose `handles.check` for bridge-backed iMessage handle availability checks (#120, thanks @svetly).
+- feat: expose `message.send_status` to query outbound message delivery state by GUID (#121, thanks @svetly).
 
 ## 0.9.0 - 2026-05-16
 

--- a/README.md
+++ b/README.md
@@ -176,8 +176,9 @@ It is intended for agents and long-running integrations that want a single
 process for chats, history, send, and watch.
 
 Read methods: `chats.list`, `messages.history`, `watch.subscribe`,
-`watch.unsubscribe`. Mutating: `send`. Bridge introspection: `handles.check`.
-See [docs/rpc.md](docs/rpc.md) for request and response shapes.
+`watch.unsubscribe`, `message.send_status`. Mutating: `send`. Bridge
+introspection: `handles.check`. See [docs/rpc.md](docs/rpc.md) for request
+and response shapes.
 
 ## Attachments
 

--- a/Sources/IMsgCore/MessageStore+Messages.swift
+++ b/Sources/IMsgCore/MessageStore+Messages.swift
@@ -331,6 +331,41 @@ extension MessageStore {
     }
   }
 
+  public func messageSendStatus(guid: String) throws -> MessageSendStatus? {
+    let trimmed = guid.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return nil }
+
+    return try withConnection { db in
+      let columns = MessageStore.tableColumns(connection: db, table: "message")
+      func column(_ name: String, defaultValue: String) -> String {
+        columns.contains(name.lowercased()) ? "m.\(name)" : defaultValue
+      }
+
+      let sql = """
+        SELECT m.ROWID AS message_rowid,
+               \(column("guid", defaultValue: "''")) AS guid,
+               \(column("service", defaultValue: "''")) AS service,
+               \(column("error", defaultValue: "0")) AS error,
+               \(column("date_delivered", defaultValue: "0")) AS date_delivered,
+               \(column("date_read", defaultValue: "0")) AS date_read,
+               \(column("is_sent", defaultValue: "0")) AS is_sent,
+               \(column("is_delivered", defaultValue: "0")) AS is_delivered,
+               \(column("is_finished", defaultValue: "0")) AS is_finished,
+               \(column("is_delayed", defaultValue: "0")) AS is_delayed,
+               \(column("is_prepared", defaultValue: "0")) AS is_prepared,
+               \(column("is_pending_satellite_send", defaultValue: "0")) AS is_pending_satellite_send,
+               \(column("was_downgraded", defaultValue: "0")) AS was_downgraded
+        FROM message m
+        WHERE \(column("guid", defaultValue: "''")) = ?
+        ORDER BY m.ROWID DESC
+        LIMIT 1
+        """
+      let rows = try db.prepareRowIterator(sql, bindings: [trimmed])
+      guard let row = try rows.failableNext() else { return nil }
+      return try decodeMessageSendStatus(row)
+    }
+  }
+
   func decodeMessageRow(
     _ row: Row,
     columns: MessageRowColumns,
@@ -379,6 +414,26 @@ extension MessageStore {
       associatedType: associatedType,
       attachments: attachments,
       threadOriginatorGUID: threadOriginatorGUID
+    )
+  }
+
+  func decodeMessageSendStatus(_ row: Row) throws -> MessageSendStatus {
+    let deliveredRaw = try int64Value(row, "date_delivered")
+    let readRaw = try int64Value(row, "date_read")
+    return MessageSendStatus(
+      rowID: try int64Value(row, "message_rowid") ?? 0,
+      guid: try stringValue(row, "guid"),
+      service: try stringValue(row, "service"),
+      error: try intValue(row, "error") ?? 0,
+      dateDelivered: deliveredRaw.flatMap { $0 > 0 ? appleDate(from: $0) : nil },
+      dateRead: readRaw.flatMap { $0 > 0 ? appleDate(from: $0) : nil },
+      isSent: (try intValue(row, "is_sent") ?? 0) != 0,
+      isDelivered: (try intValue(row, "is_delivered") ?? 0) != 0,
+      isFinished: (try intValue(row, "is_finished") ?? 0) != 0,
+      isDelayed: (try intValue(row, "is_delayed") ?? 0) != 0,
+      isPrepared: (try intValue(row, "is_prepared") ?? 0) != 0,
+      isPendingSatelliteSend: (try intValue(row, "is_pending_satellite_send") ?? 0) != 0,
+      wasDowngraded: (try intValue(row, "was_downgraded") ?? 0) != 0
     )
   }
 }

--- a/Sources/IMsgCore/Models.swift
+++ b/Sources/IMsgCore/Models.swift
@@ -406,6 +406,66 @@ public struct Message: Sendable, Equatable {
   }
 }
 
+public enum MessageSendState: String, Sendable, Equatable {
+  case pending
+  case sent
+  case delivered
+  case failed
+}
+
+public struct MessageSendStatus: Sendable, Equatable {
+  public let rowID: Int64
+  public let guid: String
+  public let service: String
+  public let error: Int
+  public let dateDelivered: Date?
+  public let dateRead: Date?
+  public let isSent: Bool
+  public let isDelivered: Bool
+  public let isFinished: Bool
+  public let isDelayed: Bool
+  public let isPrepared: Bool
+  public let isPendingSatelliteSend: Bool
+  public let wasDowngraded: Bool
+
+  public var state: MessageSendState {
+    if error != 0 { return .failed }
+    if isDelivered || dateDelivered != nil { return .delivered }
+    if isSent { return .sent }
+    return .pending
+  }
+
+  public init(
+    rowID: Int64,
+    guid: String,
+    service: String,
+    error: Int,
+    dateDelivered: Date?,
+    dateRead: Date?,
+    isSent: Bool,
+    isDelivered: Bool,
+    isFinished: Bool,
+    isDelayed: Bool,
+    isPrepared: Bool,
+    isPendingSatelliteSend: Bool,
+    wasDowngraded: Bool
+  ) {
+    self.rowID = rowID
+    self.guid = guid
+    self.service = service
+    self.error = error
+    self.dateDelivered = dateDelivered
+    self.dateRead = dateRead
+    self.isSent = isSent
+    self.isDelivered = isDelivered
+    self.isFinished = isFinished
+    self.isDelayed = isDelayed
+    self.isPrepared = isPrepared
+    self.isPendingSatelliteSend = isPendingSatelliteSend
+    self.wasDowngraded = wasDowngraded
+  }
+}
+
 public struct AttachmentMeta: Sendable, Equatable {
   public let filename: String
   public let transferName: String

--- a/Sources/imsg/RPCServer+MessageStatusHandlers.swift
+++ b/Sources/imsg/RPCServer+MessageStatusHandlers.swift
@@ -1,0 +1,54 @@
+import Foundation
+import IMsgCore
+
+extension RPCServer {
+  func handleMessageSendStatus(params: [String: Any], id: Any?) async throws {
+    let guid = (stringParam(params["guid"]) ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !guid.isEmpty else {
+      throw RPCError.invalidParams("guid is required")
+    }
+
+    let checkedAt = Date()
+    guard let status = try store.messageSendStatus(guid: guid) else {
+      respond(
+        id: id,
+        result: [
+          "ok": true,
+          "guid": guid,
+          "send_state": MessageSendState.pending.rawValue,
+          "service": NSNull(),
+          "checked_at": CLIISO8601.format(checkedAt),
+          "status_fields": NSNull(),
+        ])
+      return
+    }
+
+    var result: [String: Any] = [
+      "ok": true,
+      "guid": status.guid,
+      "send_state": status.state.rawValue,
+      "service": status.service.isEmpty ? NSNull() : status.service,
+      "checked_at": CLIISO8601.format(checkedAt),
+      "status_fields": messageSendStatusFields(status),
+    ]
+    if let deliveredAt = status.dateDelivered {
+      result["delivered_at"] = CLIISO8601.format(deliveredAt)
+    }
+    respond(id: id, result: result)
+  }
+
+  private func messageSendStatusFields(_ status: MessageSendStatus) -> [String: Any] {
+    return [
+      "is_sent": status.isSent,
+      "is_delivered": status.isDelivered,
+      "is_finished": status.isFinished,
+      "error": status.error,
+      "date_delivered": status.dateDelivered.map { CLIISO8601.format($0) } ?? NSNull(),
+      "date_read": status.dateRead.map { CLIISO8601.format($0) } ?? NSNull(),
+      "is_delayed": status.isDelayed,
+      "is_prepared": status.isPrepared,
+      "is_pending_satellite_send": status.isPendingSatelliteSend,
+      "was_downgraded": status.wasDowngraded,
+    ]
+  }
+}

--- a/Sources/imsg/RPCServer.swift
+++ b/Sources/imsg/RPCServer.swift
@@ -44,6 +44,7 @@ let kSupportedRPCMethods: [String] = [
   "message.unsend",
   "message.delete",
   "message.notifyAnyways",
+  "message.send_status",
   "group.rename",
   "group.setIcon",
   "group.addParticipant",
@@ -163,6 +164,8 @@ final class RPCServer {
         try await handleMessageDelete(params: params, id: id)
       case "message.notifyAnyways":
         try await handleMessageNotifyAnyways(params: params, id: id)
+      case "message.send_status":
+        try await handleMessageSendStatus(params: params, id: id)
       case "chats.create":
         try await handleChatsCreate(id: id, params: params)
       case "chats.delete":

--- a/Tests/IMsgCoreTests/MessageStoreSentMessageTests.swift
+++ b/Tests/IMsgCoreTests/MessageStoreSentMessageTests.swift
@@ -195,6 +195,63 @@ func latestUnjoinedSentMessageRowIDMatchesAnyGroupTargetVariants() throws {
   #expect(rowID == 20)
 }
 
+@Test
+func messageSendStatusMapsFailedSentDeliveredAndPendingRows() throws {
+  let db = try makeSentMessageDatabase()
+  let deliveredAt = Date()
+  try insertSentMessageFixture(
+    db,
+    rowID: 30,
+    chatID: 1,
+    text: "failed",
+    guid: "failed-guid",
+    date: deliveredAt,
+    isFromMe: true,
+    error: 22,
+    isSent: false
+  )
+  try insertSentMessageFixture(
+    db,
+    rowID: 31,
+    chatID: 1,
+    text: "sent",
+    guid: "sent-guid",
+    date: deliveredAt,
+    isFromMe: true,
+    isSent: true
+  )
+  try insertSentMessageFixture(
+    db,
+    rowID: 32,
+    chatID: 1,
+    text: "delivered",
+    guid: "delivered-guid",
+    date: deliveredAt,
+    isFromMe: true,
+    isSent: true,
+    isDelivered: true,
+    dateDelivered: deliveredAt
+  )
+  try insertSentMessageFixture(
+    db,
+    rowID: 33,
+    chatID: 1,
+    text: "pending",
+    guid: "pending-guid",
+    date: deliveredAt,
+    isFromMe: true
+  )
+  let store = try MessageStore(connection: db, path: ":memory:")
+
+  #expect(try store.messageSendStatus(guid: "failed-guid")?.state == .failed)
+  #expect(try store.messageSendStatus(guid: "sent-guid")?.state == .sent)
+  let delivered = try store.messageSendStatus(guid: "delivered-guid")
+  #expect(delivered?.state == .delivered)
+  #expect(delivered?.dateDelivered != nil)
+  #expect(try store.messageSendStatus(guid: "pending-guid")?.state == .pending)
+  #expect(try store.messageSendStatus(guid: "missing-guid") == nil)
+}
+
 private func makeSentMessageDatabase() throws -> Connection {
   let db = try Connection(.inMemory)
   try db.execute(
@@ -208,8 +265,18 @@ private func makeSentMessageDatabase() throws -> Connection {
       associated_message_guid TEXT,
       associated_message_type INTEGER,
       date INTEGER,
+      date_delivered INTEGER,
+      date_read INTEGER,
       is_from_me INTEGER,
-      service TEXT
+      service TEXT,
+      error INTEGER DEFAULT 0,
+      is_sent INTEGER DEFAULT 0,
+      is_delivered INTEGER DEFAULT 0,
+      is_finished INTEGER DEFAULT 0,
+      is_delayed INTEGER DEFAULT 0,
+      is_prepared INTEGER DEFAULT 0,
+      is_pending_satellite_send INTEGER DEFAULT 0,
+      was_downgraded INTEGER DEFAULT 0
     );
     """
   )
@@ -246,21 +313,29 @@ private func insertSentMessageFixture(
   text: String,
   guid: String,
   date: Date,
-  isFromMe: Bool
+  isFromMe: Bool,
+  error: Int = 0,
+  isSent: Bool = false,
+  isDelivered: Bool = false,
+  dateDelivered: Date? = nil
 ) throws {
   try db.run(
     """
     INSERT INTO message(
       ROWID, handle_id, text, guid, associated_message_guid, associated_message_type,
-      date, is_from_me, service
+      date, date_delivered, is_from_me, service, error, is_sent, is_delivered, is_finished
     )
-    VALUES (?, 1, ?, ?, NULL, 0, ?, ?, 'iMessage')
+    VALUES (?, 1, ?, ?, NULL, 0, ?, ?, ?, 'iMessage', ?, ?, ?, 1)
     """,
     rowID,
     text,
     guid,
     TestDatabase.appleEpoch(date),
-    isFromMe ? 1 : 0
+    dateDelivered.map { TestDatabase.appleEpoch($0) } ?? 0,
+    isFromMe ? 1 : 0,
+    error,
+    isSent ? 1 : 0,
+    isDelivered ? 1 : 0
   )
   try db.run("INSERT INTO chat_message_join(chat_id, message_id) VALUES (?, ?)", chatID, rowID)
 }

--- a/Tests/imsgTests/RPCBridgeMessageHandlersTests.swift
+++ b/Tests/imsgTests/RPCBridgeMessageHandlersTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 
 @testable import IMsgCore
@@ -15,6 +16,7 @@ func rpcStatusAdvertisesBridgeMessageMethods() {
     "message.unsend",
     "message.delete",
     "message.notifyAnyways",
+    "message.send_status",
   ] {
     #expect(methods.contains(method))
   }

--- a/Tests/imsgTests/RPCMessageSendStatusTests.swift
+++ b/Tests/imsgTests/RPCMessageSendStatusTests.swift
@@ -15,7 +15,7 @@ private func sendStatusInt64Value(_ value: Any?) -> Int64? {
 func rpcMessageSendStatusReturnsNormalizedStatus() async throws {
   let store = try CommandTestDatabase.makeStoreForRPC()
   try addSendStatusColumns(to: store)
-  try store.withConnection { db in
+  _ = try store.withConnection { db in
     try db.run(
       """
       UPDATE message

--- a/Tests/imsgTests/RPCMessageSendStatusTests.swift
+++ b/Tests/imsgTests/RPCMessageSendStatusTests.swift
@@ -1,0 +1,105 @@
+import Foundation
+import Testing
+
+@testable import IMsgCore
+@testable import imsg
+
+private func sendStatusInt64Value(_ value: Any?) -> Int64? {
+  if let value = value as? Int64 { return value }
+  if let value = value as? Int { return Int64(value) }
+  if let value = value as? NSNumber { return value.int64Value }
+  return nil
+}
+
+@Test
+func rpcMessageSendStatusReturnsNormalizedStatus() async throws {
+  let store = try CommandTestDatabase.makeStoreForRPC()
+  try addSendStatusColumns(to: store)
+  try store.withConnection { db in
+    try db.run(
+      """
+      UPDATE message
+      SET guid = 'delivered-guid',
+          error = 0,
+          date_delivered = ?,
+          date_read = 0,
+          is_sent = 1,
+          is_delivered = 1,
+          is_finished = 1,
+          is_delayed = 0,
+          is_prepared = 0,
+          is_pending_satellite_send = 0,
+          was_downgraded = 0
+      WHERE ROWID = 5
+      """,
+      CommandTestDatabase.appleEpoch(Date(timeIntervalSince1970: 1_779_348_870))
+    )
+  }
+  let output = TestRPCOutput()
+  let server = RPCServer(store: store, verbose: false, output: output)
+
+  let line =
+    #"{"jsonrpc":"2.0","id":"send-status","method":"message.send_status","params":{"guid":"delivered-guid"}}"#
+  await server.handleLineForTesting(line)
+
+  let result = output.responses.first?["result"] as? [String: Any]
+  #expect(result?["ok"] as? Bool == true)
+  #expect(result?["guid"] as? String == "delivered-guid")
+  #expect(result?["send_state"] as? String == "delivered")
+  #expect(result?["service"] as? String == "iMessage")
+  #expect(result?["checked_at"] as? String != nil)
+  #expect(result?["delivered_at"] as? String != nil)
+  let fields = result?["status_fields"] as? [String: Any]
+  #expect(fields?["is_sent"] as? Bool == true)
+  #expect(fields?["is_delivered"] as? Bool == true)
+  #expect(sendStatusInt64Value(fields?["error"]) == 0)
+  #expect(fields?["date_delivered"] as? String != nil)
+}
+
+@Test
+func rpcMessageSendStatusMissingRowReturnsPending() async throws {
+  let store = try CommandTestDatabase.makeStoreForRPC()
+  let output = TestRPCOutput()
+  let server = RPCServer(store: store, verbose: false, output: output)
+
+  let line =
+    #"{"jsonrpc":"2.0","id":"send-status","method":"message.send_status","params":{"guid":"missing-guid"}}"#
+  await server.handleLineForTesting(line)
+
+  let result = output.responses.first?["result"] as? [String: Any]
+  #expect(result?["ok"] as? Bool == true)
+  #expect(result?["guid"] as? String == "missing-guid")
+  #expect(result?["send_state"] as? String == "pending")
+  #expect(result?["service"] is NSNull)
+  #expect(result?["checked_at"] as? String != nil)
+  #expect(result?["status_fields"] is NSNull)
+}
+
+@Test
+func rpcMessageSendStatusRejectsMissingGuid() async throws {
+  let store = try CommandTestDatabase.makeStoreForRPC()
+  let output = TestRPCOutput()
+  let server = RPCServer(store: store, verbose: false, output: output)
+
+  let line = #"{"jsonrpc":"2.0","id":"send-status","method":"message.send_status","params":{}}"#
+  await server.handleLineForTesting(line)
+
+  let error = output.errors.first?["error"] as? [String: Any]
+  #expect(sendStatusInt64Value(error?["code"]) == -32602)
+}
+
+private func addSendStatusColumns(to store: MessageStore) throws {
+  try store.withConnection { db in
+    try db.run("ALTER TABLE message ADD COLUMN guid TEXT")
+    try db.run("ALTER TABLE message ADD COLUMN error INTEGER")
+    try db.run("ALTER TABLE message ADD COLUMN date_delivered INTEGER")
+    try db.run("ALTER TABLE message ADD COLUMN date_read INTEGER")
+    try db.run("ALTER TABLE message ADD COLUMN is_sent INTEGER")
+    try db.run("ALTER TABLE message ADD COLUMN is_delivered INTEGER")
+    try db.run("ALTER TABLE message ADD COLUMN is_finished INTEGER")
+    try db.run("ALTER TABLE message ADD COLUMN is_delayed INTEGER")
+    try db.run("ALTER TABLE message ADD COLUMN is_prepared INTEGER")
+    try db.run("ALTER TABLE message ADD COLUMN is_pending_satellite_send INTEGER")
+    try db.run("ALTER TABLE message ADD COLUMN was_downgraded INTEGER")
+  }
+}

--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -124,6 +124,40 @@ Result:
 
 For chat-target sends, `send` also performs the [Tahoe ghost-row check](send.md#tahoe-ghost-row-protection): if Messages writes an empty unjoined SMS row instead of delivering, the call returns an error rather than `{"ok": true}`.
 
+### `message.send_status`
+
+Params:
+
+- `guid` (string, required) — outgoing message GUID.
+
+Result:
+
+```json
+{
+  "ok": true,
+  "guid": "8DF...",
+  "send_state": "delivered",
+  "service": "iMessage",
+  "checked_at": "2026-05-28T20:43:00Z",
+  "delivered_at": "2026-05-28T20:42:58Z",
+  "status_fields": {
+    "is_sent": true,
+    "is_delivered": true,
+    "is_finished": true,
+    "error": 0,
+    "date_delivered": "2026-05-28T20:42:58Z",
+    "date_read": null,
+    "is_delayed": false,
+    "is_prepared": false,
+    "is_pending_satellite_send": false,
+    "was_downgraded": false
+  }
+}
+```
+
+`send_state` is normalized to `pending`, `sent`, `delivered`, or `failed`.
+Missing rows return `pending` with `status_fields: null`.
+
 ### Bridge Message Actions
 
 These methods require the IMCore bridge and target an existing chat with `chat_id`, `chat_identifier`, or `chat_guid`.


### PR DESCRIPTION
Recreates #121 on top of current main after #119 and #120 landed through maintainer replacement PRs.

What changed:
- exposes `message.send_status` over JSON-RPC
- looks up outbound message status by GUID with defensive handling for older message schemas
- normalizes state to `pending`, `sent`, `delivered`, or `failed`
- returns selected raw DB status fields under `status_fields`
- splits focused RPC tests into their own file to keep lint clean
- documents the method and adds changelog/README coverage

Proof:
- `swift test --filter 'RPCMessageSendStatusTests|MessageStoreSentMessageTests|RPCServerTests|RPCBridgeMessageHandlersTests'`
- `make lint` (passes with existing warnings only)
- `autoreview --mode branch --base main` clean

Co-authored-by: Svet <svetly@gmail.com>
