### PR TITLE
fix: rearm watch sidecars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 - feat: expose `message.send_status` to query outbound message delivery state by GUID (#121, thanks @svetly).
 - feat: add native Apple Messages poll decoding and bridge-backed `imsg poll send` / `poll.send` support, including threaded poll replies and vote readback (#125, thanks @veteranbv).
 
+### Watch
+- fix: re-arm `watch`/RPC filesystem sources after SQLite rotates `chat.db-wal` or `chat.db-shm`, so busy iCloud-synced databases keep emitting inbound rows (#126).
+
 ## 0.9.0 - 2026-05-16
 
 ### JSON Output

--- a/Sources/IMsgCore/MessageWatcher.swift
+++ b/Sources/IMsgCore/MessageWatcher.swift
@@ -61,7 +61,18 @@ private final class WatchState: @unchecked Sendable {
 
   private var cursor: Int64
   #if os(macOS)
-    private var sources: [DispatchSourceFileSystemObject] = []
+    private struct FileWatchIdentity: Equatable {
+      let device: UInt64
+      let inode: UInt64
+    }
+
+    private struct FileWatchRegistration {
+      let source: DispatchSourceFileSystemObject
+      let identity: FileWatchIdentity
+    }
+
+    private var fileSources: [String: FileWatchRegistration] = [:]
+    private var directorySource: DispatchSourceFileSystemObject?
   #endif
   private var pending = false
   private var stopped = false
@@ -86,23 +97,15 @@ private final class WatchState: @unchecked Sendable {
         if self.cursor == 0 {
           self.cursor = try self.store.maxRowID()
         }
+        #if os(macOS)
+          self.refreshFileSources()
+          self.installDirectorySource()
+        #endif
         self.poll()
+        self.scheduleFallbackPoll()
       } catch {
         self.continuation.finish(throwing: error)
       }
-    }
-
-    #if os(macOS)
-      let paths = [store.path, store.path + "-wal", store.path + "-shm"]
-      for path in paths {
-        if let source = makeSource(path: path) {
-          sources.append(source)
-        }
-      }
-    #endif
-
-    queue.async {
-      self.scheduleFallbackPoll()
     }
   }
 
@@ -110,15 +113,72 @@ private final class WatchState: @unchecked Sendable {
     queue.async {
       self.stopped = true
       #if os(macOS)
-        for source in self.sources {
-          source.cancel()
+        for registration in self.fileSources.values {
+          registration.source.cancel()
         }
-        self.sources.removeAll()
+        self.fileSources.removeAll()
+        self.directorySource?.cancel()
+        self.directorySource = nil
       #endif
     }
   }
 
   #if os(macOS)
+    private var watchedFilePaths: [String] {
+      [store.path, store.path + "-wal", store.path + "-shm"]
+    }
+
+    private var watchDirectoryPath: String? {
+      guard store.path.hasPrefix("/") else { return nil }
+      let directoryPath = URL(fileURLWithPath: store.path).deletingLastPathComponent().path
+      var isDirectory: ObjCBool = false
+      guard
+        !directoryPath.isEmpty,
+        FileManager.default.fileExists(atPath: directoryPath, isDirectory: &isDirectory),
+        isDirectory.boolValue
+      else {
+        return nil
+      }
+      return directoryPath
+    }
+
+    private func refreshFileSources() {
+      if stopped { return }
+
+      for path in watchedFilePaths {
+        guard let currentIdentity = fileIdentity(path: path) else {
+          if let registration = fileSources.removeValue(forKey: path) {
+            registration.source.cancel()
+          }
+          continue
+        }
+
+        if let registration = fileSources[path] {
+          if registration.identity == currentIdentity {
+            continue
+          }
+          registration.source.cancel()
+          fileSources[path] = nil
+        }
+
+        if let source = makeSource(path: path) {
+          fileSources[path] = FileWatchRegistration(source: source, identity: currentIdentity)
+        }
+      }
+    }
+
+    private func installDirectorySource() {
+      guard directorySource == nil, let path = watchDirectoryPath else { return }
+      guard let source = makeSource(path: path) else { return }
+      directorySource = source
+    }
+
+    private func fileIdentity(path: String) -> FileWatchIdentity? {
+      var info = stat()
+      guard stat(path, &info) == 0 else { return nil }
+      return FileWatchIdentity(device: UInt64(info.st_dev), inode: UInt64(info.st_ino))
+    }
+
     private func makeSource(path: String) -> DispatchSourceFileSystemObject? {
       let fd = open(path, O_EVTONLY)
       guard fd >= 0 else { return nil }
@@ -128,6 +188,7 @@ private final class WatchState: @unchecked Sendable {
         queue: queue
       )
       source.setEventHandler { [weak self] in
+        self?.refreshFileSources()
         self?.schedulePoll()
       }
       source.setCancelHandler {
@@ -155,6 +216,9 @@ private final class WatchState: @unchecked Sendable {
     guard let interval = configuration.fallbackPollInterval, interval > 0 else { return }
     queue.asyncAfter(deadline: .now() + interval) { [weak self] in
       guard let self, !self.stopped else { return }
+      #if os(macOS)
+        self.refreshFileSources()
+      #endif
       self.poll()
       self.scheduleFallbackPoll()
     }

--- a/Tests/IMsgCoreTests/MessageWatcherTests.swift
+++ b/Tests/IMsgCoreTests/MessageWatcherTests.swift
@@ -49,7 +49,7 @@ private enum WatcherTestDatabase {
       connection: db, path: ":memory:", hasAttributedBody: false, hasReactionColumns: false)
   }
 
-  static func makeMutableStore() throws -> WatcherTestStore {
+  static func makeMutableStore(path: String = ":memory:") throws -> WatcherTestStore {
     let db = try Connection(.inMemory)
     try db.execute(
       """
@@ -70,7 +70,7 @@ private enum WatcherTestDatabase {
     try db.run("INSERT INTO handle(ROWID, id) VALUES (1, '+123')")
 
     let store = try MessageStore(
-      connection: db, path: ":memory:", hasAttributedBody: false, hasReactionColumns: false)
+      connection: db, path: path, hasAttributedBody: false, hasReactionColumns: false)
     return WatcherTestStore(
       store: store,
       insertMessage: { rowID, text in
@@ -88,6 +88,26 @@ private enum WatcherTestDatabase {
         }
       }
     )
+  }
+}
+
+private func nextMessage(
+  from stream: AsyncThrowingStream<Message, Error>,
+  timeoutNanoseconds: UInt64 = 2_000_000_000
+) async throws -> Message? {
+  try await withThrowingTaskGroup(of: Message?.self) { group in
+    group.addTask {
+      var iterator = stream.makeAsyncIterator()
+      return try await iterator.next()
+    }
+    group.addTask {
+      try await Task.sleep(nanoseconds: timeoutNanoseconds)
+      return nil
+    }
+
+    let message = try await group.next() ?? nil
+    group.cancelAll()
+    return message
   }
 }
 
@@ -136,3 +156,57 @@ func messageWatcherFallbackPollYieldsMessagesWithoutFileEvents() async throws {
   #expect(message?.rowID == 2)
   #expect(message?.text == "fallback")
 }
+
+#if os(macOS)
+  @Test
+  func messageWatcherRearmsSidecarAfterRotation() async throws {
+    let tempDirectory = FileManager.default.temporaryDirectory.appendingPathComponent(
+      "imsg-watch-\(UUID().uuidString)",
+      isDirectory: true
+    )
+    try FileManager.default.createDirectory(
+      at: tempDirectory,
+      withIntermediateDirectories: true
+    )
+    defer {
+      try? FileManager.default.removeItem(at: tempDirectory)
+    }
+
+    let dbURL = tempDirectory.appendingPathComponent("chat.db")
+    let walURL = URL(fileURLWithPath: dbURL.path + "-wal")
+    let shmURL = URL(fileURLWithPath: dbURL.path + "-shm")
+    FileManager.default.createFile(atPath: dbURL.path, contents: Data())
+    FileManager.default.createFile(atPath: walURL.path, contents: Data())
+    FileManager.default.createFile(atPath: shmURL.path, contents: Data())
+
+    let fixture = try WatcherTestDatabase.makeMutableStore(path: dbURL.path)
+    let watcher = MessageWatcher(store: fixture.store)
+    let stream = watcher.stream(
+      chatID: nil,
+      sinceRowID: 0,
+      configuration: MessageWatcherConfiguration(
+        debounceInterval: 0.01,
+        fallbackPollInterval: nil,
+        batchLimit: 10
+      )
+    )
+
+    try await Task.sleep(nanoseconds: 100_000_000)
+    try FileManager.default.moveItem(
+      at: walURL,
+      to: tempDirectory.appendingPathComponent("chat.db-wal.old")
+    )
+    FileManager.default.createFile(atPath: walURL.path, contents: Data())
+    try await Task.sleep(nanoseconds: 100_000_000)
+
+    try fixture.insertMessage(2, "rotated")
+    let walHandle = try FileHandle(forWritingTo: walURL)
+    try walHandle.seekToEnd()
+    try walHandle.write(contentsOf: Data("x".utf8))
+    try walHandle.close()
+
+    let message = try await nextMessage(from: stream, timeoutNanoseconds: 3_000_000_000)
+    #expect(message?.rowID == 2)
+    #expect(message?.text == "rotated")
+  }
+#endif

--- a/docs/watch.md
+++ b/docs/watch.md
@@ -95,14 +95,19 @@ The watcher listens for `kqueue` filesystem events on:
 - `~/Library/Messages/chat.db`
 - `~/Library/Messages/chat.db-wal`
 - `~/Library/Messages/chat.db-shm`
+- `~/Library/Messages/`
 
 Whenever any of those files change, the watcher checks for new rows past the cursor.
+The directory watch lets it detect WAL sidecar creation, deletion, and replacement after
+SQLite checkpoints.
 
 ## Polling fallback
 
 macOS sometimes drops or coalesces filesystem events — especially under heavy I/O, after sleep/wake, or when Messages rotates the WAL sidecars. Without intervention, a watch session can go silent while the database keeps changing.
 
 `imsg watch` runs a low-frequency poll alongside the event watcher. If the cursor falls behind the actual rowid, the poller catches up and emits the missed rows. You don't configure this — it's always on.
+Each fallback poll also refreshes the file watches, so a rotated `chat.db-wal` or
+`chat.db-shm` is reopened without needing an external `touch chat.db`.
 
 This is the fix for the long-standing "watch goes silent after a while" class of bug. See `CHANGELOG.md` 0.6.0 entry.
 


### PR DESCRIPTION
## Summary
- re-arm watcher file sources when `chat.db`, `chat.db-wal`, or `chat.db-shm` is replaced or disappears
- add a parent-directory source so WAL/SHM creation after checkpoint rotation refreshes watched paths
- document the directory watch and fallback re-arm behavior

Fixes #126.

## Proof
- `swift test --filter MessageWatcherTests`
- `swift test --filter 'MessageWatcherTests|RPCServerTests|RPCBridgeMessageHandlersTests'`
- `make lint` (passes; existing warning-only lint debt remains)
- `/Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --mode local --parallel-tests "swift test --filter MessageWatcherTests"` clean
- `make test` still fails locally on existing Full Disk Access dependent live Messages DB send-command tests; the new watcher regression passes inside that run
