### PR TITLE
fix: fail closed unresolved watch chats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Watch
 - fix: re-arm `watch`/RPC filesystem sources after SQLite rotates `chat.db-wal` or `chat.db-shm`, so busy iCloud-synced databases keep emitting inbound rows (#126).
+- fix: retry live watch rows whose chat metadata has not resolved yet, then drop them fail-closed instead of emitting `chat_id=0` direct-message-shaped payloads (#118).
 
 ## 0.9.0 - 2026-05-16
 

--- a/Sources/IMsgCore/MessageWatcher.swift
+++ b/Sources/IMsgCore/MessageWatcher.swift
@@ -53,6 +53,14 @@ public final class MessageWatcher: @unchecked Sendable {
 }
 
 private final class WatchState: @unchecked Sendable {
+  private static let unresolvedChatRetryLimit = 20
+
+  private enum MessageYieldDecision {
+    case yield
+    case retry
+    case skip
+  }
+
   private let store: MessageStore
   private let chatID: Int64?
   private let configuration: MessageWatcherConfiguration
@@ -76,6 +84,7 @@ private final class WatchState: @unchecked Sendable {
   #endif
   private var pending = false
   private var stopped = false
+  private var unresolvedChatAttempts: [Int64: Int] = [:]
 
   init(
     store: MessageStore,
@@ -234,6 +243,14 @@ private final class WatchState: @unchecked Sendable {
         includeReactions: configuration.includeReactions
       )
       for message in messages {
+        switch yieldDecision(for: message) {
+        case .yield:
+          break
+        case .retry:
+          return
+        case .skip:
+          continue
+        }
         continuation.yield(message)
         if message.rowID > cursor {
           cursor = message.rowID
@@ -242,5 +259,25 @@ private final class WatchState: @unchecked Sendable {
     } catch {
       continuation.finish(throwing: error)
     }
+  }
+
+  private func yieldDecision(for message: Message) -> MessageYieldDecision {
+    guard message.chatID <= 0 else {
+      unresolvedChatAttempts.removeValue(forKey: message.rowID)
+      return .yield
+    }
+
+    let attempts = (unresolvedChatAttempts[message.rowID] ?? 0) + 1
+    unresolvedChatAttempts[message.rowID] = attempts
+    if attempts <= Self.unresolvedChatRetryLimit {
+      schedulePoll()
+      return .retry
+    }
+
+    unresolvedChatAttempts.removeValue(forKey: message.rowID)
+    if message.rowID > cursor {
+      cursor = message.rowID
+    }
+    return .skip
   }
 }

--- a/Tests/IMsgCoreTests/MessageWatcherTests.swift
+++ b/Tests/IMsgCoreTests/MessageWatcherTests.swift
@@ -7,6 +7,8 @@ import Testing
 private struct WatcherTestStore {
   let store: MessageStore
   let insertMessage: (Int64, String) throws -> Void
+  let insertUnjoinedMessage: (Int64, String) throws -> Void
+  let joinMessage: (Int64, Int64) throws -> Void
 }
 
 private enum WatcherTestDatabase {
@@ -74,20 +76,40 @@ private enum WatcherTestDatabase {
     return WatcherTestStore(
       store: store,
       insertMessage: { rowID, text in
-        try store.withConnection { db in
-          try db.run(
-            """
-            INSERT INTO message(ROWID, handle_id, text, date, is_from_me, service)
-            VALUES (?, 1, ?, ?, 0, 'iMessage')
-            """,
-            rowID,
-            text,
-            appleEpoch(Date())
-          )
-          try db.run("INSERT INTO chat_message_join(chat_id, message_id) VALUES (1, ?)", rowID)
-        }
+        try insertMutableMessage(store: store, rowID: rowID, text: text)
+        try joinMutableMessage(store: store, rowID: rowID, chatID: 1)
+      },
+      insertUnjoinedMessage: { rowID, text in
+        try insertMutableMessage(store: store, rowID: rowID, text: text)
+      },
+      joinMessage: { rowID, chatID in
+        try joinMutableMessage(store: store, rowID: rowID, chatID: chatID)
       }
     )
+  }
+
+  private static func insertMutableMessage(store: MessageStore, rowID: Int64, text: String)
+    throws
+  {
+    _ = try store.withConnection { db in
+      try db.run(
+        """
+        INSERT INTO message(ROWID, handle_id, text, date, is_from_me, service)
+        VALUES (?, 1, ?, ?, 0, 'iMessage')
+        """,
+        rowID,
+        text,
+        appleEpoch(Date())
+      )
+    }
+  }
+
+  private static func joinMutableMessage(store: MessageStore, rowID: Int64, chatID: Int64)
+    throws
+  {
+    _ = try store.withConnection { db in
+      try db.run("INSERT INTO chat_message_join(chat_id, message_id) VALUES (?, ?)", chatID, rowID)
+    }
   }
 }
 
@@ -155,6 +177,59 @@ func messageWatcherFallbackPollYieldsMessagesWithoutFileEvents() async throws {
   let message = try await task.value
   #expect(message?.rowID == 2)
   #expect(message?.text == "fallback")
+}
+
+@Test
+func messageWatcherRetriesUnresolvedChatMetadata() async throws {
+  let fixture = try WatcherTestDatabase.makeMutableStore()
+  let watcher = MessageWatcher(store: fixture.store)
+  let stream = watcher.stream(
+    chatID: nil,
+    sinceRowID: 0,
+    configuration: MessageWatcherConfiguration(
+      debounceInterval: 0.01,
+      fallbackPollInterval: 0.01,
+      batchLimit: 10
+    )
+  )
+
+  let task = Task { try await nextMessage(from: stream) }
+
+  try await Task.sleep(nanoseconds: 20_000_000)
+  try fixture.insertUnjoinedMessage(2, "unresolved")
+  try await Task.sleep(nanoseconds: 30_000_000)
+  try fixture.joinMessage(2, 1)
+
+  let message = try await task.value
+  #expect(message?.rowID == 2)
+  #expect(message?.chatID == 1)
+  #expect(message?.text == "unresolved")
+}
+
+@Test
+func messageWatcherSkipsPersistentlyUnresolvedChatMetadata() async throws {
+  let fixture = try WatcherTestDatabase.makeMutableStore()
+  let watcher = MessageWatcher(store: fixture.store)
+  let stream = watcher.stream(
+    chatID: nil,
+    sinceRowID: 0,
+    configuration: MessageWatcherConfiguration(
+      debounceInterval: 0.001,
+      fallbackPollInterval: 0.01,
+      batchLimit: 10
+    )
+  )
+
+  let task = Task { try await nextMessage(from: stream) }
+
+  try await Task.sleep(nanoseconds: 20_000_000)
+  try fixture.insertUnjoinedMessage(2, "orphan")
+  try fixture.insertMessage(3, "after orphan")
+
+  let message = try await task.value
+  #expect(message?.rowID == 3)
+  #expect(message?.chatID == 1)
+  #expect(message?.text == "after orphan")
 }
 
 #if os(macOS)

--- a/docs/watch.md
+++ b/docs/watch.md
@@ -80,6 +80,9 @@ imsg watch --chat-id 42 --debounce 250ms --json
 ```
 
 When Messages writes a message, it often follows up with WAL flushes, attachment metadata updates, and `is_from_me` corrections within a few milliseconds. The debouncer collapses those into one stable emission per row.
+If a row appears before its chat metadata resolves, watch retries it briefly and
+then drops it fail-closed instead of emitting an empty `chat_id=0` payload that
+could look like a direct message.
 
 - CLI default: `250ms`.
 - RPC default: `500ms` (RPC's typical caller is an agent more sensitive to outbound echo races).


### PR DESCRIPTION
## Summary
- retry watch rows when all-chat polling sees a message before `chat_message_join` metadata exists
- stop the retry loop from advancing past that unresolved row until it resolves or exhausts the retry budget
- drop persistently unresolved rows fail-closed instead of emitting `chat_id=0` DM-shaped payloads

Fixes #118.

## Proof
- `swift test --filter 'MessageWatcherTests|RPCServerTests'`
- `make lint` (passes; existing warning-only lint debt remains)
- `/Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --mode local --parallel-tests "swift test --filter 'MessageWatcherTests|RPCServerTests'"` clean
