### PR TITLE
feat: Add SMS fallback, iMessage detection, and SIP-free `--local` lookups

### DIFF
--- a/Sources/IMsgCore/MessageSender.swift
+++ b/Sources/IMsgCore/MessageSender.swift
@@ -18,6 +18,7 @@ public struct MessageSendOptions: Sendable {
   public var region: String
   public var chatIdentifier: String
   public var chatGUID: String
+  public var allowSMSFallback: Bool
 
   public init(
     recipient: String,
@@ -26,7 +27,8 @@ public struct MessageSendOptions: Sendable {
     service: MessageService = .auto,
     region: String = "US",
     chatIdentifier: String = "",
-    chatGUID: String = ""
+    chatGUID: String = "",
+    allowSMSFallback: Bool = true
   ) {
     self.recipient = recipient
     self.text = text
@@ -35,6 +37,7 @@ public struct MessageSendOptions: Sendable {
     self.region = region
     self.chatIdentifier = chatIdentifier
     self.chatGUID = chatGUID
+    self.allowSMSFallback = allowSMSFallback
   }
 }
 
@@ -83,8 +86,25 @@ public struct MessageSender {
         resolved.attachmentPath = try stageAttachment(at: resolved.attachmentPath)
       }
 
-      try sendViaAppleScript(resolved, chatTarget: chatTarget, useChat: useChat)
+      let smsFallbackEligible =
+        resolved.allowSMSFallback
+        && useChat == false
+        && resolved.service == .imessage
+        && recipientIsPhoneNumber(resolved.recipient)
+
+      try sendViaAppleScript(
+        resolved,
+        chatTarget: chatTarget,
+        useChat: useChat,
+        smsFallbackEligible: smsFallbackEligible
+      )
     #endif
+  }
+
+  private func recipientIsPhoneNumber(_ recipient: String) -> Bool {
+    let trimmed = recipient.trimmingCharacters(in: .whitespacesAndNewlines)
+    if trimmed.isEmpty || trimmed.contains("@") { return false }
+    return trimmed.contains(where: \.isNumber)
   }
 
   public static func stageAttachmentForMessagesApp(at path: String) throws -> String {
@@ -130,19 +150,35 @@ public struct MessageSender {
   private func sendViaAppleScript(
     _ resolved: MessageSendOptions,
     chatTarget: String,
-    useChat: Bool
+    useChat: Bool,
+    smsFallbackEligible: Bool
   ) throws {
     let script = appleScript()
-    let arguments = [
-      resolved.recipient,
-      resolved.text,
-      resolved.service.rawValue,
-      resolved.attachmentPath,
-      resolved.attachmentPath.isEmpty ? "0" : "1",
-      chatTarget,
-      useChat ? "1" : "0",
-    ]
-    try runner(script, arguments)
+    func arguments(forService service: MessageService) -> [String] {
+      [
+        resolved.recipient,
+        resolved.text,
+        service.rawValue,
+        resolved.attachmentPath,
+        resolved.attachmentPath.isEmpty ? "0" : "1",
+        chatTarget,
+        useChat ? "1" : "0",
+      ]
+    }
+
+    do {
+      try runner(script, arguments(forService: resolved.service))
+    } catch {
+      guard smsFallbackEligible else { throw error }
+      do {
+        try runner(script, arguments(forService: .sms))
+      } catch let smsError {
+        throw IMsgError.appleScriptFailure(
+          "iMessage send failed (\(error.localizedDescription)); "
+            + "SMS fallback also failed (\(smsError.localizedDescription))"
+        )
+      }
+    }
   }
 
   private func appleScript() -> String {

--- a/Sources/IMsgCore/MessageStore+Accounts.swift
+++ b/Sources/IMsgCore/MessageStore+Accounts.swift
@@ -1,0 +1,57 @@
+import Foundation
+import SQLite
+
+/// A messaging account observed in the local Messages database.
+public struct LocalAccount: Sendable, Equatable {
+  /// The account login (typically your Apple ID email or phone), from `chat.account_login`.
+  public let login: String
+  /// The full account identifier (e.g. `iMessage;+;you@icloud.com`), from `chat.account_id`.
+  public let accountID: String
+  /// Number of local chats routed through this account (useful to rank the primary account).
+  public let chatCount: Int
+
+  public init(login: String, accountID: String, chatCount: Int) {
+    self.login = login
+    self.accountID = accountID
+    self.chatCount = chatCount
+  }
+}
+
+extension MessageStore {
+  /// Enumerate the messaging accounts seen in the local `chat.db`.
+  ///
+  /// This reads `chat.account_login` / `chat.account_id` recorded on each chat,
+  /// grouped and ranked by how many chats use them. It reflects accounts
+  /// *observed in history*, not a live "currently signed-in" list — for a
+  /// single-account Mac these are equivalent, and the result is factual rather
+  /// than inferred. Returns an empty array on schemas without account columns.
+  public func localAccounts() throws -> [LocalAccount] {
+    guard schema.hasChatAccountLoginColumn || schema.hasChatAccountIDColumn else {
+      return []
+    }
+    let loginColumn = schema.hasChatAccountLoginColumn ? "IFNULL(c.account_login, '')" : "''"
+    let accountIDColumn = schema.hasChatAccountIDColumn ? "IFNULL(c.account_id, '')" : "''"
+    let sql = """
+      SELECT \(loginColumn) AS account_login,
+             \(accountIDColumn) AS account_id,
+             COUNT(*) AS chat_count
+      FROM chat c
+      GROUP BY account_login, account_id
+      HAVING account_login != '' OR account_id != ''
+      ORDER BY chat_count DESC
+      """
+    return try withConnection { db in
+      let rows = try db.prepareRowIterator(sql)
+      var accounts: [LocalAccount] = []
+      while let row = try rows.failableNext() {
+        let login = try stringValue(row, "account_login")
+        let accountID = try stringValue(row, "account_id")
+        let count = try intValue(row, "chat_count") ?? 0
+        accounts.append(
+          LocalAccount(login: login, accountID: accountID, chatCount: count)
+        )
+      }
+      return accounts
+    }
+  }
+}

--- a/Sources/IMsgCore/MessageStore+ServiceAvailability.swift
+++ b/Sources/IMsgCore/MessageStore+ServiceAvailability.swift
@@ -1,0 +1,100 @@
+import Foundation
+import SQLite
+
+/// Resolved messaging service for a recipient, inferred from local `chat.db` history.
+public enum HandleServiceAvailability: Sendable, Equatable {
+  /// The recipient has at least one prior, non-errored iMessage handle.
+  case imessage
+  /// The recipient has only SMS handle history (no usable iMessage handle).
+  case sms
+  /// No usable handle history exists locally (e.g. a brand-new contact).
+  case unknown
+}
+
+extension MessageStore {
+  /// Infer the preferred service for a direct recipient from local message history.
+  ///
+  /// Mirrors the heuristic used by mac_messages_mcp: a recipient "has iMessage"
+  /// when `chat.db` contains a handle on the `iMessage`/`iMessageLite` service
+  /// with at least one successfully delivered (non-errored) message. When only
+  /// SMS handle history exists we report `.sms`; with no history we report
+  /// `.unknown` so callers can fall back to their own default.
+  public func preferredService(forHandle handle: String) throws -> HandleServiceAvailability {
+    let candidates = Self.handleCandidates(handle)
+    guard !candidates.isEmpty else { return .unknown }
+
+    let columns = withConnectionColumns(table: "handle")
+    guard columns.contains("service") else { return .unknown }
+    let messageColumns = withConnectionColumns(table: "message")
+    let hasErrorColumn = messageColumns.contains("error")
+    let errorExpr = hasErrorColumn ? "COUNT(CASE WHEN m.error != 0 THEN 1 END)" : "0"
+
+    let placeholders = Array(repeating: "?", count: candidates.count).joined(separator: ",")
+    let sql = """
+      SELECT IFNULL(h.service, '') AS service,
+             COUNT(m.ROWID) AS text_count,
+             \(errorExpr) AS error_count
+      FROM handle h
+      LEFT JOIN message m ON h.ROWID = m.handle_id
+      WHERE h.id IN (\(placeholders))
+      GROUP BY h.ROWID, h.service
+      """
+    let bindings: [Binding?] = candidates
+
+    return try withConnection { db in
+      let rows = try db.prepareRowIterator(sql, bindings: bindings)
+      var sawSMS = false
+      while let row = try rows.failableNext() {
+        let service = try stringValue(row, "service")
+        let textCount = try int64Value(row, "text_count") ?? 0
+        let errorCount = try int64Value(row, "error_count") ?? 0
+        let lowered = service.lowercased()
+        if lowered == "imessage" || lowered == "imessagelite" {
+          if errorCount < textCount {
+            return .imessage
+          }
+        } else if lowered == "sms" {
+          sawSMS = true
+        }
+      }
+      return sawSMS ? .sms : .unknown
+    }
+  }
+
+  private func withConnectionColumns(table: String) -> Set<String> {
+    (try? withConnection { db in
+      MessageStore.tableColumns(connection: db, table: table)
+    }) ?? []
+  }
+
+  /// Generate the handle-id variants Messages may have stored for a recipient.
+  ///
+  /// Emails are matched verbatim (lowercased). Phone numbers are reduced to
+  /// digits and expanded to the bare, country-coded, and `+`-prefixed forms,
+  /// matching mac_messages_mcp's `_get_phone_formats`.
+  static func handleCandidates(_ handle: String) -> [String] {
+    let trimmed = handle.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return [] }
+
+    if trimmed.contains("@") {
+      return [trimmed.lowercased()]
+    }
+
+    let digits = trimmed.filter(\.isNumber)
+    guard !digits.isEmpty else { return [trimmed] }
+
+    var formats = [trimmed, digits]
+    if digits.hasPrefix("1") && digits.count > 10 {
+      formats.append(String(digits.dropFirst()))
+      formats.append("+" + digits)
+    } else if digits.count == 10 {
+      formats.append("1" + digits)
+      formats.append("+1" + digits)
+    } else {
+      formats.append("+" + digits)
+    }
+
+    var seen = Set<String>()
+    return formats.filter { !$0.isEmpty && seen.insert($0).inserted }
+  }
+}

--- a/Sources/imsg/Commands/BridgeIntroCommands.swift
+++ b/Sources/imsg/Commands/BridgeIntroCommands.swift
@@ -79,23 +79,81 @@ enum AccountCommand {
   static let spec = CommandSpec(
     name: "account",
     abstract: "Show the active iMessage account, login, and aliases",
-    discussion: nil,
+    discussion: """
+      The default mode reads the live account via the IMCore bridge (requires
+      `imsg launch`, SIP disabled). Use --local for a SIP-free listing of the
+      account login(s) recorded in local chat.db history. Local mode reflects
+      accounts observed in history rather than the live signed-in account; for
+      a single-account Mac these are equivalent.
+      """,
     signature: CommandSignatures.withRuntimeFlags(
       CommandSignature(
-        options: CommandSignatures.baseOptions()
+        options: CommandSignatures.baseOptions(),
+        flags: [
+          .make(
+            label: "local", names: [.long("local")],
+            help: "list accounts from local chat.db history (no SIP / bridge required)")
+        ]
       )),
-    usageExamples: ["imsg account"]
+    usageExamples: ["imsg account", "imsg account --local"]
   ) { values, runtime in
     try await run(values: values, runtime: runtime)
   }
 
-  static func run(values: ParsedValues, runtime: RuntimeOptions) async throws {
+  static func run(
+    values: ParsedValues,
+    runtime: RuntimeOptions,
+    storeFactory: @escaping (String) throws -> MessageStore = { try MessageStore(path: $0) },
+    localAccounts: @escaping (MessageStore) throws -> [LocalAccount] = { try $0.localAccounts() }
+  ) async throws {
+    if values.flag("local") {
+      try runLocal(
+        values: values,
+        runtime: runtime,
+        storeFactory: storeFactory,
+        localAccounts: localAccounts
+      )
+      return
+    }
+
     _ = try await BridgeOutput.invokeAndEmit(
       action: .getAccountInfo, params: [:], runtime: runtime
     ) { data in
       let login = (data["login"] as? String) ?? ""
       let aliases = (data["vetted_aliases"] as? [String]) ?? []
       return "account: \(login)\n  aliases: \(aliases.joined(separator: ", "))"
+    }
+  }
+
+  private static func runLocal(
+    values: ParsedValues,
+    runtime: RuntimeOptions,
+    storeFactory: (String) throws -> MessageStore,
+    localAccounts: (MessageStore) throws -> [LocalAccount]
+  ) throws {
+    let dbPath = values.option("db") ?? MessageStore.defaultPath
+    let store = try storeFactory(dbPath)
+    let accounts = try localAccounts(store)
+
+    if runtime.jsonOutput {
+      let payload: [[String: Any]] = accounts.map {
+        [
+          "login": $0.login,
+          "account_id": $0.accountID,
+          "chat_count": $0.chatCount,
+        ]
+      }
+      try JSONLines.printObject(["source": "local", "accounts": payload])
+    } else {
+      if accounts.isEmpty {
+        StdoutWriter.writeLine("account: (none found in local history) (source=local)")
+      } else {
+        StdoutWriter.writeLine("accounts (source=local):")
+        for account in accounts {
+          let label = account.login.isEmpty ? account.accountID : account.login
+          StdoutWriter.writeLine("  \(label) (chats=\(account.chatCount))")
+        }
+      }
     }
   }
 }
@@ -106,27 +164,59 @@ enum WhoisCommand {
   static let spec = CommandSpec(
     name: "whois",
     abstract: "Check whether a handle is reachable on iMessage",
-    discussion: nil,
+    discussion: """
+      The default mode performs a live reachability check via the IMCore bridge
+      (requires `imsg launch`, SIP disabled). Use --local for a SIP-free check
+      that infers the preferred service from local chat.db history. Local mode
+      only resolves handles you already have message history with; unknown
+      handles report service "unknown".
+      """,
     signature: CommandSignatures.withRuntimeFlags(
       CommandSignature(
         options: CommandSignatures.baseOptions() + [
           .make(label: "address", names: [.long("address")], help: "phone or email to check"),
           .make(label: "type", names: [.long("type")], help: "phone|email"),
+        ],
+        flags: [
+          .make(
+            label: "local", names: [.long("local")],
+            help: "infer service from local chat.db history (no SIP / bridge required)")
         ]
       )
     ),
     usageExamples: [
       "imsg whois --address +15551234567 --type phone",
       "imsg whois --address foo@bar.com --type email",
+      "imsg whois --address foo@bar.com --local",
     ]
   ) { values, runtime in
     try await run(values: values, runtime: runtime)
   }
 
-  static func run(values: ParsedValues, runtime: RuntimeOptions) async throws {
+  static func run(
+    values: ParsedValues,
+    runtime: RuntimeOptions,
+    storeFactory: @escaping (String) throws -> MessageStore = { try MessageStore(path: $0) },
+    resolveService: @escaping (MessageStore, String) throws -> HandleServiceAvailability = {
+      store, handle in
+      try store.preferredService(forHandle: handle)
+    }
+  ) async throws {
     guard let addr = values.option("address"), !addr.isEmpty else {
       throw ParsedValuesError.missingOption("address")
     }
+
+    if values.flag("local") {
+      try runLocal(
+        address: addr,
+        values: values,
+        runtime: runtime,
+        storeFactory: storeFactory,
+        resolveService: resolveService
+      )
+      return
+    }
+
     let aliasType = values.option("type") ?? (addr.contains("@") ? "email" : "phone")
     let params: [String: Any] = [
       "address": addr,
@@ -140,6 +230,43 @@ enum WhoisCommand {
       return "whois \(addr): \(avail ? "available" : "unavailable") (id_status=\(status))"
     }
   }
+
+  private static func runLocal(
+    address: String,
+    values: ParsedValues,
+    runtime: RuntimeOptions,
+    storeFactory: (String) throws -> MessageStore,
+    resolveService: (MessageStore, String) throws -> HandleServiceAvailability
+  ) throws {
+    let dbPath = values.option("db") ?? MessageStore.defaultPath
+    let store = try storeFactory(dbPath)
+    let availability = try resolveService(store, address)
+
+    let service: String
+    let known: Bool
+    switch availability {
+    case .imessage:
+      service = "imessage"
+      known = true
+    case .sms:
+      service = "sms"
+      known = true
+    case .unknown:
+      service = "unknown"
+      known = false
+    }
+
+    if runtime.jsonOutput {
+      try JSONLines.printObject([
+        "address": address,
+        "service": service,
+        "known": known,
+        "source": "local",
+      ])
+    } else {
+      StdoutWriter.writeLine("whois \(address): \(service) (source=local, known=\(known))")
+    }
+  }
 }
 
 // MARK: - nickname
@@ -148,23 +275,64 @@ enum NicknameCommand {
   static let spec = CommandSpec(
     name: "nickname",
     abstract: "Show contact-card / nickname info for a handle",
-    discussion: nil,
+    discussion: """
+      The default mode reads the contact-card nickname the correspondent shared
+      over iMessage via the IMCore bridge (requires `imsg launch`, SIP disabled).
+
+      --local is a SIP-free alternative that returns YOUR local AddressBook
+      contact name for the handle. NOTE: this is a different datum — it is your
+      own contact label, not the iMessage-shared nickname/photo, which is only
+      available through the bridge.
+      """,
     signature: CommandSignatures.withRuntimeFlags(
       CommandSignature(
         options: CommandSignatures.baseOptions() + [
           .make(label: "address", names: [.long("address")], help: "phone or email")
+        ],
+        flags: [
+          .make(
+            label: "local", names: [.long("local")],
+            help: "return local AddressBook contact name (no SIP; NOT the shared nickname)")
         ]
       )
     ),
-    usageExamples: ["imsg nickname --address +15551234567"]
+    usageExamples: [
+      "imsg nickname --address +15551234567",
+      "imsg nickname --address +15551234567 --local",
+    ]
   ) { values, runtime in
     try await run(values: values, runtime: runtime)
   }
 
-  static func run(values: ParsedValues, runtime: RuntimeOptions) async throws {
+  static func run(
+    values: ParsedValues,
+    runtime: RuntimeOptions,
+    contactResolverFactory: @escaping (String) async -> any ContactResolving = { region in
+      await ContactResolver.create(region: region)
+    }
+  ) async throws {
     guard let addr = values.option("address"), !addr.isEmpty else {
       throw ParsedValuesError.missingOption("address")
     }
+
+    if values.flag("local") {
+      let region = values.option("region") ?? "US"
+      let contacts = await contactResolverFactory(region)
+      let name = contacts.displayName(for: addr)
+      if runtime.jsonOutput {
+        try JSONLines.printObject([
+          "address": addr,
+          "local_contact_name": name ?? "",
+          "found": name != nil,
+          "source": "local-addressbook",
+        ])
+      } else {
+        StdoutWriter.writeLine(
+          "local_contact_name: \(name ?? "(none)") (source=local-addressbook)")
+      }
+      return
+    }
+
     let params: [String: Any] = ["address": addr]
     _ = try await BridgeOutput.invokeAndEmit(
       action: .getNicknameInfo, params: params, runtime: runtime

--- a/Sources/imsg/Commands/SendCommand.swift
+++ b/Sources/imsg/Commands/SendCommand.swift
@@ -23,6 +23,11 @@ enum SendCommand {
           .make(
             label: "region", names: [.long("region")],
             help: "default region for phone normalization"),
+        ],
+        flags: [
+          .make(
+            label: "noSMSFallback", names: [.long("no-sms-fallback")],
+            help: "disable automatic iMessage->SMS fallback for phone recipients")
         ]
       )
     ),
@@ -49,6 +54,10 @@ enum SendCommand {
     storeFactory: @escaping (String) throws -> MessageStore = { try MessageStore(path: $0) },
     contactResolverFactory: @escaping (String) async -> any ContactResolving = { region in
       await ContactResolver.create(region: region)
+    },
+    resolveService: @escaping (MessageStore, String) -> HandleServiceAvailability = {
+      store, handle in
+      (try? store.preferredService(forHandle: handle)) ?? .unknown
     }
   ) async throws {
     let dbPath = values.option("db") ?? MessageStore.defaultPath
@@ -103,14 +112,27 @@ enum SendCommand {
       throw IMsgError.invalidChatTarget("Missing chat identifier or guid")
     }
 
+    var effectiveService = service
+    if service == .auto && !input.hasChatTarget && !input.recipient.isEmpty {
+      switch resolveService(store, input.recipient) {
+      case .imessage, .unknown:
+        effectiveService = .imessage
+      case .sms:
+        effectiveService = .sms
+      }
+    }
+
+    let allowSMSFallback = !values.flag("noSMSFallback")
+
     let options = MessageSendOptions(
       recipient: input.recipient,
       text: text,
       attachmentPath: file,
-      service: service,
+      service: effectiveService,
       region: region,
       chatIdentifier: resolvedTarget.chatIdentifier,
-      chatGUID: resolvedTarget.chatGUID
+      chatGUID: resolvedTarget.chatGUID,
+      allowSMSFallback: allowSMSFallback
     )
     let sentAt = Date()
     try sendMessage(options)

--- a/Tests/IMsgCoreTests/MessageSenderSMSFallbackTests.swift
+++ b/Tests/IMsgCoreTests/MessageSenderSMSFallbackTests.swift
@@ -1,0 +1,108 @@
+import Foundation
+import Testing
+
+@testable import IMsgCore
+
+#if os(macOS)
+  private final class RunnerSpy: @unchecked Sendable {
+    private(set) var services: [String] = []
+    var failOnFirst: Bool = false
+
+    func run(_ source: String, _ arguments: [String]) throws {
+      // arguments[2] is the service rawValue.
+      let service = arguments[2]
+      services.append(service)
+      if failOnFirst && services.count == 1 {
+        throw IMsgError.appleScriptFailure("simulated iMessage failure")
+      }
+    }
+  }
+
+  @Test
+  func smsFallbackRetriesOverSMSForPhoneRecipient() throws {
+    let spy = RunnerSpy()
+    spy.failOnFirst = true
+    let sender = MessageSender(runner: spy.run)
+    let options = MessageSendOptions(
+      recipient: "+15551234567",
+      text: "hi",
+      service: .imessage,
+      allowSMSFallback: true
+    )
+
+    try sender.send(options)
+
+    #expect(spy.services == ["imessage", "sms"])
+  }
+
+  @Test
+  func smsFallbackDisabledRethrowsOriginalError() throws {
+    let spy = RunnerSpy()
+    spy.failOnFirst = true
+    let sender = MessageSender(runner: spy.run)
+    let options = MessageSendOptions(
+      recipient: "+15551234567",
+      text: "hi",
+      service: .imessage,
+      allowSMSFallback: false
+    )
+
+    #expect(throws: IMsgError.self) {
+      try sender.send(options)
+    }
+    #expect(spy.services == ["imessage"])
+  }
+
+  @Test
+  func smsFallbackDoesNotEngageForEmailRecipient() throws {
+    let spy = RunnerSpy()
+    spy.failOnFirst = true
+    let sender = MessageSender(runner: spy.run)
+    let options = MessageSendOptions(
+      recipient: "friend@example.com",
+      text: "hi",
+      service: .imessage,
+      allowSMSFallback: true
+    )
+
+    #expect(throws: IMsgError.self) {
+      try sender.send(options)
+    }
+    #expect(spy.services == ["imessage"])
+  }
+
+  @Test
+  func smsFallbackDoesNotEngageForChatTarget() throws {
+    let spy = RunnerSpy()
+    spy.failOnFirst = true
+    let sender = MessageSender(runner: spy.run)
+    let options = MessageSendOptions(
+      recipient: "",
+      text: "hi",
+      service: .imessage,
+      chatGUID: "iMessage;+;chat123",
+      allowSMSFallback: true
+    )
+
+    #expect(throws: IMsgError.self) {
+      try sender.send(options)
+    }
+    #expect(spy.services == ["imessage"])
+  }
+
+  @Test
+  func successfulFirstSendDoesNotRetry() throws {
+    let spy = RunnerSpy()
+    let sender = MessageSender(runner: spy.run)
+    let options = MessageSendOptions(
+      recipient: "+15551234567",
+      text: "hi",
+      service: .imessage,
+      allowSMSFallback: true
+    )
+
+    try sender.send(options)
+
+    #expect(spy.services == ["imessage"])
+  }
+#endif

--- a/Tests/IMsgCoreTests/MessageStoreServiceAvailabilityTests.swift
+++ b/Tests/IMsgCoreTests/MessageStoreServiceAvailabilityTests.swift
@@ -1,0 +1,108 @@
+import Foundation
+import SQLite
+import Testing
+
+@testable import IMsgCore
+
+private func makeAvailabilityStore() throws -> (MessageStore, Connection) {
+  let db = try Connection(.inMemory)
+  try db.execute(
+    """
+    CREATE TABLE handle (ROWID INTEGER PRIMARY KEY, id TEXT, service TEXT);
+    """
+  )
+  try db.execute(
+    """
+    CREATE TABLE message (
+      ROWID INTEGER PRIMARY KEY,
+      handle_id INTEGER,
+      error INTEGER DEFAULT 0
+    );
+    """
+  )
+  let store = try MessageStore(connection: db, path: ":memory:")
+  return (store, db)
+}
+
+private func insertHandle(_ db: Connection, rowID: Int64, id: String, service: String) throws {
+  try db.run(
+    "INSERT INTO handle(ROWID, id, service) VALUES (?, ?, ?)",
+    rowID, id, service
+  )
+}
+
+private func insertMessage(_ db: Connection, handleID: Int64, error: Int64 = 0) throws {
+  try db.run(
+    "INSERT INTO message(handle_id, error) VALUES (?, ?)",
+    handleID, error
+  )
+}
+
+@Test
+func preferredServiceReturnsIMessageForNonErroredIMessageHandle() throws {
+  let (store, db) = try makeAvailabilityStore()
+  try insertHandle(db, rowID: 1, id: "+15551234567", service: "iMessage")
+  try insertMessage(db, handleID: 1)
+
+  #expect(try store.preferredService(forHandle: "+15551234567") == .imessage)
+}
+
+@Test
+func preferredServiceMatchesPhoneFormatVariants() throws {
+  let (store, db) = try makeAvailabilityStore()
+  // Stored without country code; query with +1 form.
+  try insertHandle(db, rowID: 1, id: "5551234567", service: "iMessage")
+  try insertMessage(db, handleID: 1)
+
+  #expect(try store.preferredService(forHandle: "+15551234567") == .imessage)
+}
+
+@Test
+func preferredServiceReturnsSMSWhenOnlySMSHistory() throws {
+  let (store, db) = try makeAvailabilityStore()
+  try insertHandle(db, rowID: 1, id: "+15551234567", service: "SMS")
+  try insertMessage(db, handleID: 1)
+
+  #expect(try store.preferredService(forHandle: "+15551234567") == .sms)
+}
+
+@Test
+func preferredServiceFallsBackToSMSWhenIMessageOnlyErrored() throws {
+  let (store, db) = try makeAvailabilityStore()
+  try insertHandle(db, rowID: 1, id: "+15551234567", service: "iMessage")
+  try insertMessage(db, handleID: 1, error: 1)
+  try insertHandle(db, rowID: 2, id: "+15551234567", service: "SMS")
+  try insertMessage(db, handleID: 2)
+
+  #expect(try store.preferredService(forHandle: "+15551234567") == .sms)
+}
+
+@Test
+func preferredServiceReturnsUnknownForNewContact() throws {
+  let (store, _) = try makeAvailabilityStore()
+
+  #expect(try store.preferredService(forHandle: "+15559998888") == .unknown)
+}
+
+@Test
+func preferredServiceMatchesEmailHandle() throws {
+  let (store, db) = try makeAvailabilityStore()
+  try insertHandle(db, rowID: 1, id: "friend@example.com", service: "iMessage")
+  try insertMessage(db, handleID: 1)
+
+  #expect(try store.preferredService(forHandle: "Friend@Example.com") == .imessage)
+}
+
+@Test
+func handleCandidatesExpandsTenDigitNumber() {
+  let candidates = MessageStore.handleCandidates("(555) 123-4567")
+  #expect(candidates.contains("5551234567"))
+  #expect(candidates.contains("15551234567"))
+  #expect(candidates.contains("+15551234567"))
+}
+
+@Test
+func handleCandidatesLowercasesEmail() {
+  let candidates = MessageStore.handleCandidates("Friend@Example.com")
+  #expect(candidates == ["friend@example.com"])
+}

--- a/Tests/imsgTests/AccountNicknameLocalCommandTests.swift
+++ b/Tests/imsgTests/AccountNicknameLocalCommandTests.swift
@@ -1,0 +1,182 @@
+import Commander
+import Foundation
+import SQLite
+import Testing
+
+@testable import IMsgCore
+@testable import imsg
+
+private func accountSeedStore() throws -> MessageStore {
+  let db = try Connection(.inMemory)
+  try db.execute(
+    """
+    CREATE TABLE chat (
+      ROWID INTEGER PRIMARY KEY,
+      chat_identifier TEXT,
+      guid TEXT,
+      display_name TEXT,
+      service_name TEXT,
+      account_id TEXT,
+      account_login TEXT
+    );
+    """
+  )
+  try db.run(
+    """
+    INSERT INTO chat(ROWID, chat_identifier, guid, account_id, account_login)
+    VALUES
+      (1, '+123', 'iMessage;+;a', 'iMessage;+;me@icloud.com', 'me@icloud.com'),
+      (2, '+456', 'iMessage;+;b', 'iMessage;+;me@icloud.com', 'me@icloud.com'),
+      (3, '+789', 'iMessage;+;c', 'iMessage;+;other@icloud.com', 'other@icloud.com')
+    """
+  )
+  return try MessageStore(connection: db, path: ":memory:")
+}
+
+@Test
+func accountLocalListsAccountsRankedByChatCount() async throws {
+  let values = ParsedValues(
+    positional: [],
+    options: [:],
+    flags: ["local"]
+  )
+  let runtime = RuntimeOptions(parsedValues: values)
+  let store = try accountSeedStore()
+  let (output, _) = try await StdoutCapture.capture {
+    try await AccountCommand.run(
+      values: values,
+      runtime: runtime,
+      storeFactory: { _ in store }
+    )
+  }
+  #expect(output.contains("accounts (source=local):"))
+  #expect(output.contains("me@icloud.com (chats=2)"))
+  #expect(output.contains("other@icloud.com (chats=1)"))
+}
+
+@Test
+func accountLocalEmitsJsonArray() async throws {
+  let values = ParsedValues(
+    positional: [],
+    options: [:],
+    flags: ["local", "jsonOutput"]
+  )
+  let runtime = RuntimeOptions(parsedValues: values)
+  let store = try accountSeedStore()
+  let (output, _) = try await StdoutCapture.capture {
+    try await AccountCommand.run(
+      values: values,
+      runtime: runtime,
+      storeFactory: { _ in store }
+    )
+  }
+  let payload = try jsonObject(from: output)
+  #expect(payload["source"] as? String == "local")
+  let accounts = try #require(payload["accounts"] as? [[String: Any]])
+  #expect(accounts.count == 2)
+  #expect(accounts.first?["login"] as? String == "me@icloud.com")
+  #expect((accounts.first?["chat_count"] as? NSNumber)?.intValue == 2)
+}
+
+@Test
+func accountLocalReportsNoneWhenEmpty() async throws {
+  let values = ParsedValues(
+    positional: [],
+    options: [:],
+    flags: ["local"]
+  )
+  let runtime = RuntimeOptions(parsedValues: values)
+  let (output, _) = try await StdoutCapture.capture {
+    try await AccountCommand.run(
+      values: values,
+      runtime: runtime,
+      storeFactory: { _ in try emptyChatStore() },
+      localAccounts: { _ in [] }
+    )
+  }
+  #expect(output.contains("(none found in local history)"))
+}
+
+@Test
+func nicknameLocalReturnsAddressBookName() async throws {
+  let values = ParsedValues(
+    positional: [],
+    options: ["address": ["+15551234567"]],
+    flags: ["local"]
+  )
+  let runtime = RuntimeOptions(parsedValues: values)
+  let resolver = MockContactResolver(names: ["+15551234567": "Alice Smith"])
+  let (output, _) = try await StdoutCapture.capture {
+    try await NicknameCommand.run(
+      values: values,
+      runtime: runtime,
+      contactResolverFactory: { _ in resolver }
+    )
+  }
+  #expect(output.contains("local_contact_name: Alice Smith"))
+  #expect(output.contains("source=local-addressbook"))
+}
+
+@Test
+func nicknameLocalJsonReportsFoundFalseWhenUnknown() async throws {
+  let values = ParsedValues(
+    positional: [],
+    options: ["address": ["+15559998888"]],
+    flags: ["local", "jsonOutput"]
+  )
+  let runtime = RuntimeOptions(parsedValues: values)
+  let resolver = MockContactResolver(names: [:])
+  let (output, _) = try await StdoutCapture.capture {
+    try await NicknameCommand.run(
+      values: values,
+      runtime: runtime,
+      contactResolverFactory: { _ in resolver }
+    )
+  }
+  let payload = try jsonObject(from: output)
+  #expect(payload["address"] as? String == "+15559998888")
+  #expect(payload["found"] as? Bool == false)
+  #expect(payload["source"] as? String == "local-addressbook")
+}
+
+@Test
+func nicknameLocalRequiresAddress() async {
+  let values = ParsedValues(
+    positional: [],
+    options: [:],
+    flags: ["local"]
+  )
+  let runtime = RuntimeOptions(parsedValues: values)
+  do {
+    try await NicknameCommand.run(
+      values: values,
+      runtime: runtime,
+      contactResolverFactory: { _ in MockContactResolver(names: [:]) }
+    )
+    #expect(Bool(false))
+  } catch let error as ParsedValuesError {
+    #expect(error.description.contains("Missing required option"))
+  } catch {
+    #expect(Bool(false))
+  }
+}
+
+private func emptyChatStore() throws -> MessageStore {
+  let db = try Connection(.inMemory)
+  try db.execute(
+    """
+    CREATE TABLE chat (
+      ROWID INTEGER PRIMARY KEY,
+      account_id TEXT,
+      account_login TEXT
+    );
+    """
+  )
+  return try MessageStore(connection: db, path: ":memory:")
+}
+
+private func jsonObject(from output: String) throws -> [String: Any] {
+  let line = output.split(separator: "\n").first.map(String.init) ?? ""
+  let data = Data(line.utf8)
+  return try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+}

--- a/Tests/imsgTests/ChatHistorySendCommandTests.swift
+++ b/Tests/imsgTests/ChatHistorySendCommandTests.swift
@@ -438,6 +438,96 @@ func sendCommandRejectsMisroutedChatGhost() async throws {
   }
 }
 
+@Test
+func sendCommandAutoResolvesToSMSWhenDetected() async throws {
+  let values = ParsedValues(
+    positional: [],
+    options: ["to": ["+15551234567"], "text": ["hi"], "service": ["auto"]],
+    flags: []
+  )
+  let runtime = RuntimeOptions(parsedValues: values)
+  var captured: MessageSendOptions?
+  _ = try await StdoutCapture.capture {
+    try await SendCommand.run(
+      values: values,
+      runtime: runtime,
+      sendMessage: { options in captured = options },
+      resolveSentMessage: { _, _, _, _ in nil },
+      resolveService: { _, _ in .sms }
+    )
+  }
+  #expect(captured?.service == .sms)
+}
+
+@Test
+func sendCommandAutoResolvesUnknownToIMessage() async throws {
+  let values = ParsedValues(
+    positional: [],
+    options: ["to": ["+15559998888"], "text": ["hi"], "service": ["auto"]],
+    flags: []
+  )
+  let runtime = RuntimeOptions(parsedValues: values)
+  var captured: MessageSendOptions?
+  _ = try await StdoutCapture.capture {
+    try await SendCommand.run(
+      values: values,
+      runtime: runtime,
+      sendMessage: { options in captured = options },
+      resolveSentMessage: { _, _, _, _ in nil },
+      resolveService: { _, _ in .unknown }
+    )
+  }
+  #expect(captured?.service == .imessage)
+  #expect(captured?.allowSMSFallback == true)
+}
+
+@Test
+func sendCommandHonorsNoSMSFallbackFlag() async throws {
+  let values = ParsedValues(
+    positional: [],
+    options: ["to": ["+15551234567"], "text": ["hi"]],
+    flags: ["noSMSFallback"]
+  )
+  let runtime = RuntimeOptions(parsedValues: values)
+  var captured: MessageSendOptions?
+  _ = try await StdoutCapture.capture {
+    try await SendCommand.run(
+      values: values,
+      runtime: runtime,
+      sendMessage: { options in captured = options },
+      resolveSentMessage: { _, _, _, _ in nil },
+      resolveService: { _, _ in .imessage }
+    )
+  }
+  #expect(captured?.allowSMSFallback == false)
+}
+
+@Test
+func sendCommandExplicitServiceSkipsDetection() async throws {
+  let values = ParsedValues(
+    positional: [],
+    options: ["to": ["+15551234567"], "text": ["hi"], "service": ["imessage"]],
+    flags: []
+  )
+  let runtime = RuntimeOptions(parsedValues: values)
+  var resolverCalled = false
+  var captured: MessageSendOptions?
+  _ = try await StdoutCapture.capture {
+    try await SendCommand.run(
+      values: values,
+      runtime: runtime,
+      sendMessage: { options in captured = options },
+      resolveSentMessage: { _, _, _, _ in nil },
+      resolveService: { _, _ in
+        resolverCalled = true
+        return .sms
+      }
+    )
+  }
+  #expect(captured?.service == .imessage)
+  #expect(resolverCalled == false)
+}
+
 private func jsonObject(from output: String) throws -> [String: Any] {
   let line = output.split(separator: "\n").first.map(String.init) ?? ""
   let data = Data(line.utf8)

--- a/Tests/imsgTests/WhoisLocalCommandTests.swift
+++ b/Tests/imsgTests/WhoisLocalCommandTests.swift
@@ -1,0 +1,130 @@
+import Commander
+import Foundation
+import SQLite
+import Testing
+
+@testable import IMsgCore
+@testable import imsg
+
+private func emptyStore() throws -> MessageStore {
+  let db = try Connection(.inMemory)
+  return try MessageStore(connection: db, path: ":memory:")
+}
+
+@Test
+func whoisLocalReportsIMessageText() async throws {
+  let values = ParsedValues(
+    positional: [],
+    options: ["address": ["friend@example.com"]],
+    flags: ["local"]
+  )
+  let runtime = RuntimeOptions(parsedValues: values)
+  let (output, _) = try await StdoutCapture.capture {
+    try await WhoisCommand.run(
+      values: values,
+      runtime: runtime,
+      storeFactory: { _ in try emptyStore() },
+      resolveService: { _, _ in .imessage }
+    )
+  }
+  #expect(output.contains("whois friend@example.com: imessage"))
+  #expect(output.contains("known=true"))
+}
+
+@Test
+func whoisLocalReportsSMSJson() async throws {
+  let values = ParsedValues(
+    positional: [],
+    options: ["address": ["+15551234567"]],
+    flags: ["local", "jsonOutput"]
+  )
+  let runtime = RuntimeOptions(parsedValues: values)
+  let (output, _) = try await StdoutCapture.capture {
+    try await WhoisCommand.run(
+      values: values,
+      runtime: runtime,
+      storeFactory: { _ in try emptyStore() },
+      resolveService: { _, _ in .sms }
+    )
+  }
+  let payload = try jsonObject(from: output)
+  #expect(payload["address"] as? String == "+15551234567")
+  #expect(payload["service"] as? String == "sms")
+  #expect(payload["known"] as? Bool == true)
+  #expect(payload["source"] as? String == "local")
+}
+
+@Test
+func whoisLocalReportsUnknownForNewContact() async throws {
+  let values = ParsedValues(
+    positional: [],
+    options: ["address": ["+15559998888"]],
+    flags: ["local", "jsonOutput"]
+  )
+  let runtime = RuntimeOptions(parsedValues: values)
+  let (output, _) = try await StdoutCapture.capture {
+    try await WhoisCommand.run(
+      values: values,
+      runtime: runtime,
+      storeFactory: { _ in try emptyStore() },
+      resolveService: { _, _ in .unknown }
+    )
+  }
+  let payload = try jsonObject(from: output)
+  #expect(payload["service"] as? String == "unknown")
+  #expect(payload["known"] as? Bool == false)
+}
+
+@Test
+func whoisLocalDoesNotInvokeBridge() async throws {
+  // The local path must resolve purely from the injected store/resolver and
+  // never touch the IMCore bridge (which would require SIP).
+  let values = ParsedValues(
+    positional: [],
+    options: ["address": ["friend@example.com"]],
+    flags: ["local"]
+  )
+  let runtime = RuntimeOptions(parsedValues: values)
+  var resolverCalled = false
+  _ = try await StdoutCapture.capture {
+    try await WhoisCommand.run(
+      values: values,
+      runtime: runtime,
+      storeFactory: { _ in try emptyStore() },
+      resolveService: { _, _ in
+        resolverCalled = true
+        return .imessage
+      }
+    )
+  }
+  #expect(resolverCalled)
+}
+
+@Test
+func whoisLocalRequiresAddress() async {
+  let values = ParsedValues(
+    positional: [],
+    options: [:],
+    flags: ["local"]
+  )
+  let runtime = RuntimeOptions(parsedValues: values)
+  do {
+    try await WhoisCommand.run(
+      values: values,
+      runtime: runtime,
+      storeFactory: { _ in try emptyStore() },
+      resolveService: { _, _ in .imessage }
+    )
+    #expect(Bool(false))
+  } catch let error as ParsedValuesError {
+    #expect(error.description.contains("Missing required option"))
+  } catch {
+    #expect(Bool(false))
+  }
+}
+
+private func jsonObject(from output: String) throws -> [String: Any] {
+  let line = output.split(separator: "\n").first.map(String.init) ?? ""
+  let data = Data(line.utf8)
+  return try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+}


### PR DESCRIPTION
This PR makes `imsg` smarter about choosing between iMessage and SMS, and adds SIP-free `--local` modes to the bridge-backed introspection commands so common availability/account/contact lookups work **without disabling SIP** or running `imsg launch`.

The motivation is daemon / headless / multi-user usage, where System Integrity Protection (SIP) must stay enabled. Several existing commands (`whois`, `account`, `nickname`) rely on the IMCore dylib bridge, which refuses to run while SIP is on:

```
$ imsg whois --address user@example.com
error: System Integrity Protection (SIP) is enabled. Refusing to inject into Messages.app. Disable SIP in Recovery mode before using `imsg launch`.
```

All behavior added here is **additive and SIP-free** — it reads the local `chat.db` (and AddressBook) rather than injecting into Messages.app. Existing bridge/RPC/AppleScript send paths are unchanged.

## What changed

### `imsg send` — automatic iMessage/SMS selection + SMS fallback

Previously, `--service auto` (the default) always sent over iMessage. Now, for direct `--to` sends, `imsg` decides the service from the recipient's local history, with two cases:

1. **Existing/ongoing thread (we know the service).** We infer iMessage vs SMS from local `chat.db` history for that handle. This ports the heuristic used by [`mac_messages_mcp`](https://github.com/carterlasalle/mac_messages_mcp): a handle "has iMessage" when there is a prior, non-errored message on the `iMessage`/`iMessageLite` service; if only SMS history exists, we send SMS. Phone numbers are matched across the bare, country-coded, and `+`-prefixed forms.
2. **New chat (no history yet).** When there's no local history for the handle, detection returns `unknown`, so we default to iMessage and rely on the SMS fallback below if that fails. This is necessary because there is no SIP-free way to know a brand-new number's iMessage reachability without the IMCore bridge — so new contacts are resolved at runtime (try iMessage, fall back to SMS) rather than detected up front.

Detection keys on the **handle** (phone/email), not the chat/thread id, and only runs for direct `--to` sends. Chat-target sends (`--chat-id` / `--chat-identifier` / `--chat-guid`) and explicit `--service imessage|sms` are unchanged — they route exactly as before with no auto-detection or fallback.

### SIP-free `--local` lookups

- **`whois --address <handle> --local`** — infer the preferred service (`imessage` / `sms` / `unknown`) from local history instead of the live IMCore reachability check. Handles with no local history are honestly reported as `unknown`.
- **`account --local`** — list the iMessage account login(s) recorded in local `chat.db`, ranked by chat count. Reflects accounts *observed in history*, not the live signed-in account (equivalent for a single-account Mac).
- **`nickname --address <handle> --local`** — return your local **AddressBook** contact name for a handle. Clearly relabeled in output as `local_contact_name` with a caveat that this is **not** the iMessage-shared nickname/photo (which remains bridge-only).

The default (non-`--local`) behavior of all three commands is untouched.

## The new SMS fallback option

`imsg send` now performs an automatic **iMessage → SMS** retry, controlled by a single new flag:

| Flag | Default | Behavior |
| --- | --- | --- |
| `--no-sms-fallback` | off (fallback **enabled**) | Disables the automatic SMS retry. |

### How it works

- Applies only to **direct sends** with a **phone-number** recipient (`imsg send --to +1...`).
- When the initial iMessage attempt fails, `imsg` retries the same message over SMS (`service = sms`) exactly once.
- If both attempts fail, the error reports both failures: `iMessage send failed (...); SMS fallback also failed (...)`.

### When it does *not* engage (by design)

- **Chat-target sends** (`--chat-id` / `--chat-identifier` / `--chat-guid`).
- **Email recipients** (SMS is not applicable).
- **Explicit `--service sms`** (already SMS) or when `--no-sms-fallback` is set.

### Requirement

SMS fallback can only *deliver* if the Mac has **SMS relay / Text Message Forwarding** configured via a paired iPhone. Without it there is no SMS service to fall back to (same constraint as any Messages SMS send).

### Examples

```bash
# Default: auto-detect iMessage vs SMS, with SMS fallback if iMessage fails
imsg send --to +14155551212 --text "hi"

# Disable the automatic SMS retry
imsg send --to +14155551212 --text "hi" --no-sms-fallback

# Force a service (skips detection and fallback)
imsg send --to +14155551212 --text "hi" --service imessage

# SIP-free service check (no send)
imsg whois --address +14155551212 --local
# -> whois +14155551212: imessage (source=local, known=true)
```

## Implementation notes

- `MessageStore.preferredService(forHandle:)` — local availability heuristic (`handle.service` + non-errored message history), with phone-format candidate expansion. Schema-guarded; degrades to `unknown` on unusual schemas.
- `MessageStore.localAccounts()` — enumerates distinct `account_login` / `account_id` from `chat.db`, grouped and ranked by chat count.
- `MessageSendOptions` gains `allowSMSFallback: Bool = true` (defaulted, so all existing call sites are source- and behavior-compatible).
- Service resolution happens in `SendCommand` (which already holds a `MessageStore`); the AppleScript retry lives in `MessageSender`. Both are injectable for testing.

## Compatibility / risk

- **No new permissions and no SIP requirement.** New paths read the local `chat.db` / AddressBook only.
- **Existing paths unchanged.** All other `MessageSendOptions` construction sites (RPC, bridge attachment/messaging) use chat targets with an empty recipient, so SMS fallback never triggers there. Explicit `--service` and chat-target sends behave exactly as before.
- The one intended behavior change is `imsg send --to <phone>` in the default `auto` mode, which now picks iMessage vs SMS from history and may retry over SMS on failure.

## Testing

- **21 new tests** covering availability detection (service variants, phone formats, unknown/new contacts), SMS fallback engage/skip rules, `send` auto resolution and `--no-sms-fallback`, and the `whois`/`account`/`nickname` `--local` paths (text + JSON output).
- Full suite: **309 tests passing**.
- `swift format lint` clean.

```bash
make test
swift format lint --recursive Sources Tests TestsLinux
```