### PR TITLE
feat: add local service detection and reliable SMS fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 0.10.1 - Unreleased
 
+### Send
+- feat: add SIP-free local iMessage/SMS service detection for direct `send --service auto`, with text-only iMessage-to-SMS fallback that never overrides explicit `--service` choices (#132, thanks @ranaroussi).
+
+### Local Lookups
+- feat: add `--local` modes for `account`, `whois`, and `nickname` so common introspection can read local history or Contacts without launching the IMCore bridge (#132, thanks @ranaroussi).
+
 ## 0.10.0 - 2026-05-28
 
 ### Watch

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Automation):
 - `imsg history --chat-id <id> [--limit 50] [--attachments] [--convert-attachments] [--participants <handles>] [--start <iso>] [--end <iso>] [--json]`
 - `imsg watch [--chat-id <id>] [--since-rowid <id>] [--debounce <duration>] [--attachments] [--convert-attachments] [--reactions] [--participants <handles>] [--start <iso>] [--end <iso>] [--json]`
 - `imsg search --query <text> [--match contains|exact] [--limit 50] [--json]`
-- `imsg send (--to <handle-or-contact-name> | --chat-id <id> | --chat-identifier <id> | --chat-guid <guid>) [--text <text>] [--file <path>] [--service imessage|sms|auto] [--region US] [--json]`
+- `imsg send (--to <handle-or-contact-name> | --chat-id <id> | --chat-identifier <id> | --chat-guid <guid>) [--text <text>] [--file <path>] [--service imessage|sms|auto] [--no-sms-fallback] [--region US] [--json]`
 - `imsg react --chat-id <id> --reaction love|like|dislike|laugh|emphasis|question`
 - `imsg rpc`
 - `imsg completions bash|zsh|fish|llm`
@@ -344,9 +344,12 @@ Introspection:
 
 ```bash
 imsg account                                            # active iMessage account + aliases
+imsg account --local                                   # accounts observed in local history
 imsg whois --address +15551234567 --type phone
+imsg whois --address +15551234567 --local
 imsg whois --address foo@bar.com --type email
 imsg nickname --address +15551234567
+imsg nickname --address +15551234567 --local
 ```
 
 Live events (typing indicators surfaced through the dylib):

--- a/Sources/IMsgCore/MessageSender.swift
+++ b/Sources/IMsgCore/MessageSender.swift
@@ -18,6 +18,7 @@ public struct MessageSendOptions: Sendable {
   public var region: String
   public var chatIdentifier: String
   public var chatGUID: String
+  public var allowSMSFallback: Bool
 
   public init(
     recipient: String,
@@ -26,7 +27,8 @@ public struct MessageSendOptions: Sendable {
     service: MessageService = .auto,
     region: String = "US",
     chatIdentifier: String = "",
-    chatGUID: String = ""
+    chatGUID: String = "",
+    allowSMSFallback: Bool = true
   ) {
     self.recipient = recipient
     self.text = text
@@ -35,6 +37,7 @@ public struct MessageSendOptions: Sendable {
     self.region = region
     self.chatIdentifier = chatIdentifier
     self.chatGUID = chatGUID
+    self.allowSMSFallback = allowSMSFallback
   }
 }
 
@@ -83,8 +86,25 @@ public struct MessageSender {
         resolved.attachmentPath = try stageAttachment(at: resolved.attachmentPath)
       }
 
-      try sendViaAppleScript(resolved, chatTarget: chatTarget, useChat: useChat)
+      let smsFallbackEligible =
+        resolved.allowSMSFallback
+        && useChat == false
+        && resolved.service == .imessage
+        && recipientIsPhoneNumber(resolved.recipient)
+
+      try sendViaAppleScript(
+        resolved,
+        chatTarget: chatTarget,
+        useChat: useChat,
+        smsFallbackEligible: smsFallbackEligible
+      )
     #endif
+  }
+
+  private func recipientIsPhoneNumber(_ recipient: String) -> Bool {
+    let trimmed = recipient.trimmingCharacters(in: .whitespacesAndNewlines)
+    if trimmed.isEmpty || trimmed.contains("@") { return false }
+    return trimmed.contains(where: \.isNumber)
   }
 
   public static func stageAttachmentForMessagesApp(at path: String) throws -> String {
@@ -130,19 +150,35 @@ public struct MessageSender {
   private func sendViaAppleScript(
     _ resolved: MessageSendOptions,
     chatTarget: String,
-    useChat: Bool
+    useChat: Bool,
+    smsFallbackEligible: Bool
   ) throws {
     let script = appleScript()
-    let arguments = [
-      resolved.recipient,
-      resolved.text,
-      resolved.service.rawValue,
-      resolved.attachmentPath,
-      resolved.attachmentPath.isEmpty ? "0" : "1",
-      chatTarget,
-      useChat ? "1" : "0",
-    ]
-    try runner(script, arguments)
+    func arguments(forService service: MessageService) -> [String] {
+      [
+        resolved.recipient,
+        resolved.text,
+        service.rawValue,
+        resolved.attachmentPath,
+        resolved.attachmentPath.isEmpty ? "0" : "1",
+        chatTarget,
+        useChat ? "1" : "0",
+      ]
+    }
+
+    do {
+      try runner(script, arguments(forService: resolved.service))
+    } catch {
+      guard smsFallbackEligible else { throw error }
+      do {
+        try runner(script, arguments(forService: .sms))
+      } catch let smsError {
+        throw IMsgError.appleScriptFailure(
+          "iMessage send failed (\(error.localizedDescription)); "
+            + "SMS fallback also failed (\(smsError.localizedDescription))"
+        )
+      }
+    }
   }
 
   private func appleScript() -> String {

--- a/Sources/IMsgCore/MessageSender.swift
+++ b/Sources/IMsgCore/MessageSender.swift
@@ -74,6 +74,7 @@ public struct MessageSender {
         "Sending requires Messages.app automation and is only supported on macOS.")
     #else
       var resolved = options
+      let requestedService = resolved.service
       let chatTarget = resolveChatTarget(&resolved)
       let useChat = !chatTarget.isEmpty
       if useChat == false {
@@ -88,8 +89,11 @@ public struct MessageSender {
 
       let smsFallbackEligible =
         resolved.allowSMSFallback
+        && requestedService == .auto
         && useChat == false
         && resolved.service == .imessage
+        && resolved.attachmentPath.isEmpty
+        && !resolved.text.isEmpty
         && recipientIsPhoneNumber(resolved.recipient)
 
       try sendViaAppleScript(

--- a/Sources/IMsgCore/MessageStore+Accounts.swift
+++ b/Sources/IMsgCore/MessageStore+Accounts.swift
@@ -1,0 +1,57 @@
+import Foundation
+import SQLite
+
+/// A messaging account observed in the local Messages database.
+public struct LocalAccount: Sendable, Equatable {
+  /// The account login (typically your Apple ID email or phone), from `chat.account_login`.
+  public let login: String
+  /// The full account identifier (e.g. `iMessage;+;you@icloud.com`), from `chat.account_id`.
+  public let accountID: String
+  /// Number of local chats routed through this account (useful to rank the primary account).
+  public let chatCount: Int
+
+  public init(login: String, accountID: String, chatCount: Int) {
+    self.login = login
+    self.accountID = accountID
+    self.chatCount = chatCount
+  }
+}
+
+extension MessageStore {
+  /// Enumerate the messaging accounts seen in the local `chat.db`.
+  ///
+  /// This reads `chat.account_login` / `chat.account_id` recorded on each chat,
+  /// grouped and ranked by how many chats use them. It reflects accounts
+  /// *observed in history*, not a live "currently signed-in" list — for a
+  /// single-account Mac these are equivalent, and the result is factual rather
+  /// than inferred. Returns an empty array on schemas without account columns.
+  public func localAccounts() throws -> [LocalAccount] {
+    guard schema.hasChatAccountLoginColumn || schema.hasChatAccountIDColumn else {
+      return []
+    }
+    let loginColumn = schema.hasChatAccountLoginColumn ? "IFNULL(c.account_login, '')" : "''"
+    let accountIDColumn = schema.hasChatAccountIDColumn ? "IFNULL(c.account_id, '')" : "''"
+    let sql = """
+      SELECT \(loginColumn) AS account_login,
+             \(accountIDColumn) AS account_id,
+             COUNT(*) AS chat_count
+      FROM chat c
+      GROUP BY account_login, account_id
+      HAVING account_login != '' OR account_id != ''
+      ORDER BY chat_count DESC
+      """
+    return try withConnection { db in
+      let rows = try db.prepareRowIterator(sql)
+      var accounts: [LocalAccount] = []
+      while let row = try rows.failableNext() {
+        let login = try stringValue(row, "account_login")
+        let accountID = try stringValue(row, "account_id")
+        let count = try intValue(row, "chat_count") ?? 0
+        accounts.append(
+          LocalAccount(login: login, accountID: accountID, chatCount: count)
+        )
+      }
+      return accounts
+    }
+  }
+}

--- a/Sources/IMsgCore/MessageStore+SentMessages.swift
+++ b/Sources/IMsgCore/MessageStore+SentMessages.swift
@@ -2,6 +2,40 @@ import Foundation
 import SQLite
 
 extension MessageStore {
+  public func chatInfo(matchingExactTarget target: String) throws -> ChatInfo? {
+    let trimmed = target.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return nil }
+
+    let accountIDColumn = schema.hasChatAccountIDColumn ? "IFNULL(c.account_id, '')" : "''"
+    let accountLoginColumn = schema.hasChatAccountLoginColumn ? "IFNULL(c.account_login, '')" : "''"
+    let lastAddressedHandleColumn =
+      schema.hasChatLastAddressedHandleColumn ? "IFNULL(c.last_addressed_handle, '')" : "''"
+    let sql = """
+      SELECT c.ROWID AS chat_rowid, IFNULL(c.chat_identifier, '') AS identifier, IFNULL(c.guid, '') AS guid,
+             IFNULL(c.display_name, c.chat_identifier) AS name, IFNULL(c.service_name, '') AS service,
+             \(accountIDColumn) AS account_id,
+             \(accountLoginColumn) AS account_login,
+             \(lastAddressedHandleColumn) AS last_addressed_handle
+      FROM chat c
+      WHERE c.chat_identifier = ? OR c.guid = ?
+      LIMIT 1
+      """
+    return try withConnection { db in
+      let rows = try db.prepareRowIterator(sql, bindings: [trimmed, trimmed])
+      guard let row = try rows.failableNext() else { return nil }
+      return ChatInfo(
+        id: try int64Value(row, "chat_rowid") ?? 0,
+        identifier: try stringValue(row, "identifier"),
+        guid: try stringValue(row, "guid"),
+        name: try stringValue(row, "name"),
+        service: try stringValue(row, "service"),
+        accountID: try stringValue(row, "account_id").nilIfEmpty,
+        accountLogin: try stringValue(row, "account_login").nilIfEmpty,
+        lastAddressedHandle: try stringValue(row, "last_addressed_handle").nilIfEmpty
+      )
+    }
+  }
+
   public func chatInfo(matchingTarget target: String) throws -> ChatInfo? {
     let candidates = Self.chatTargetCandidates(target)
     guard !candidates.isEmpty else { return nil }

--- a/Sources/IMsgCore/MessageStore+ServiceAvailability.swift
+++ b/Sources/IMsgCore/MessageStore+ServiceAvailability.swift
@@ -1,0 +1,100 @@
+import Foundation
+import SQLite
+
+/// Resolved messaging service for a recipient, inferred from local `chat.db` history.
+public enum HandleServiceAvailability: Sendable, Equatable {
+  /// The recipient has at least one prior, non-errored iMessage handle.
+  case imessage
+  /// The recipient has only SMS handle history (no usable iMessage handle).
+  case sms
+  /// No usable handle history exists locally (e.g. a brand-new contact).
+  case unknown
+}
+
+extension MessageStore {
+  /// Infer the preferred service for a direct recipient from local message history.
+  ///
+  /// Mirrors the heuristic used by mac_messages_mcp: a recipient "has iMessage"
+  /// when `chat.db` contains a handle on the `iMessage`/`iMessageLite` service
+  /// with at least one successfully delivered (non-errored) message. When only
+  /// SMS handle history exists we report `.sms`; with no history we report
+  /// `.unknown` so callers can fall back to their own default.
+  public func preferredService(forHandle handle: String) throws -> HandleServiceAvailability {
+    let candidates = Self.handleCandidates(handle)
+    guard !candidates.isEmpty else { return .unknown }
+
+    let columns = withConnectionColumns(table: "handle")
+    guard columns.contains("service") else { return .unknown }
+    let messageColumns = withConnectionColumns(table: "message")
+    let hasErrorColumn = messageColumns.contains("error")
+    let errorExpr = hasErrorColumn ? "COUNT(CASE WHEN m.error != 0 THEN 1 END)" : "0"
+
+    let placeholders = Array(repeating: "?", count: candidates.count).joined(separator: ",")
+    let sql = """
+      SELECT IFNULL(h.service, '') AS service,
+             COUNT(m.ROWID) AS text_count,
+             \(errorExpr) AS error_count
+      FROM handle h
+      LEFT JOIN message m ON h.ROWID = m.handle_id
+      WHERE h.id IN (\(placeholders))
+      GROUP BY h.ROWID, h.service
+      """
+    let bindings: [Binding?] = candidates
+
+    return try withConnection { db in
+      let rows = try db.prepareRowIterator(sql, bindings: bindings)
+      var sawSMS = false
+      while let row = try rows.failableNext() {
+        let service = try stringValue(row, "service")
+        let textCount = try int64Value(row, "text_count") ?? 0
+        let errorCount = try int64Value(row, "error_count") ?? 0
+        let lowered = service.lowercased()
+        if lowered == "imessage" || lowered == "imessagelite" {
+          if errorCount < textCount {
+            return .imessage
+          }
+        } else if lowered == "sms" {
+          sawSMS = true
+        }
+      }
+      return sawSMS ? .sms : .unknown
+    }
+  }
+
+  private func withConnectionColumns(table: String) -> Set<String> {
+    (try? withConnection { db in
+      MessageStore.tableColumns(connection: db, table: table)
+    }) ?? []
+  }
+
+  /// Generate the handle-id variants Messages may have stored for a recipient.
+  ///
+  /// Emails are matched verbatim (lowercased). Phone numbers are reduced to
+  /// digits and expanded to the bare, country-coded, and `+`-prefixed forms,
+  /// matching mac_messages_mcp's `_get_phone_formats`.
+  static func handleCandidates(_ handle: String) -> [String] {
+    let trimmed = handle.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return [] }
+
+    if trimmed.contains("@") {
+      return [trimmed.lowercased()]
+    }
+
+    let digits = trimmed.filter(\.isNumber)
+    guard !digits.isEmpty else { return [trimmed] }
+
+    var formats = [trimmed, digits]
+    if digits.hasPrefix("1") && digits.count > 10 {
+      formats.append(String(digits.dropFirst()))
+      formats.append("+" + digits)
+    } else if digits.count == 10 {
+      formats.append("1" + digits)
+      formats.append("+1" + digits)
+    } else {
+      formats.append("+" + digits)
+    }
+
+    var seen = Set<String>()
+    return formats.filter { !$0.isEmpty && seen.insert($0).inserted }
+  }
+}

--- a/Sources/IMsgCore/MessageStore+ServiceAvailability.swift
+++ b/Sources/IMsgCore/MessageStore+ServiceAvailability.swift
@@ -12,6 +12,23 @@ public enum HandleServiceAvailability: Sendable, Equatable {
 }
 
 extension MessageStore {
+  /// Infer the preferred service after applying the same region-aware phone
+  /// normalization used by `MessageSender`.
+  public func preferredService(
+    forHandle handle: String,
+    region: String
+  ) throws -> HandleServiceAvailability {
+    let normalized = PhoneNumberNormalizer().normalize(
+      handle,
+      region: region.isEmpty ? "US" : region
+    )
+    let normalizedAvailability = try preferredService(forHandle: normalized)
+    if normalizedAvailability != .unknown || normalized == handle {
+      return normalizedAvailability
+    }
+    return try preferredService(forHandle: handle)
+  }
+
   /// Infer the preferred service for a direct recipient from local message history.
   ///
   /// Mirrors the heuristic used by mac_messages_mcp: a recipient "has iMessage"

--- a/Sources/imsg/Commands/BridgeIntroCommands.swift
+++ b/Sources/imsg/Commands/BridgeIntroCommands.swift
@@ -79,23 +79,81 @@ enum AccountCommand {
   static let spec = CommandSpec(
     name: "account",
     abstract: "Show the active iMessage account, login, and aliases",
-    discussion: nil,
+    discussion: """
+      The default mode reads the live account via the IMCore bridge (requires
+      `imsg launch`, SIP disabled). Use --local for a SIP-free listing of the
+      account login(s) recorded in local chat.db history. Local mode reflects
+      accounts observed in history rather than the live signed-in account; for
+      a single-account Mac these are equivalent.
+      """,
     signature: CommandSignatures.withRuntimeFlags(
       CommandSignature(
-        options: CommandSignatures.baseOptions()
+        options: CommandSignatures.baseOptions(),
+        flags: [
+          .make(
+            label: "local", names: [.long("local")],
+            help: "list accounts from local chat.db history (no SIP / bridge required)")
+        ]
       )),
-    usageExamples: ["imsg account"]
+    usageExamples: ["imsg account", "imsg account --local"]
   ) { values, runtime in
     try await run(values: values, runtime: runtime)
   }
 
-  static func run(values: ParsedValues, runtime: RuntimeOptions) async throws {
+  static func run(
+    values: ParsedValues,
+    runtime: RuntimeOptions,
+    storeFactory: @escaping (String) throws -> MessageStore = { try MessageStore(path: $0) },
+    localAccounts: @escaping (MessageStore) throws -> [LocalAccount] = { try $0.localAccounts() }
+  ) async throws {
+    if values.flag("local") {
+      try runLocal(
+        values: values,
+        runtime: runtime,
+        storeFactory: storeFactory,
+        localAccounts: localAccounts
+      )
+      return
+    }
+
     _ = try await BridgeOutput.invokeAndEmit(
       action: .getAccountInfo, params: [:], runtime: runtime
     ) { data in
       let login = (data["login"] as? String) ?? ""
       let aliases = (data["vetted_aliases"] as? [String]) ?? []
       return "account: \(login)\n  aliases: \(aliases.joined(separator: ", "))"
+    }
+  }
+
+  private static func runLocal(
+    values: ParsedValues,
+    runtime: RuntimeOptions,
+    storeFactory: (String) throws -> MessageStore,
+    localAccounts: (MessageStore) throws -> [LocalAccount]
+  ) throws {
+    let dbPath = values.option("db") ?? MessageStore.defaultPath
+    let store = try storeFactory(dbPath)
+    let accounts = try localAccounts(store)
+
+    if runtime.jsonOutput {
+      let payload: [[String: Any]] = accounts.map {
+        [
+          "login": $0.login,
+          "account_id": $0.accountID,
+          "chat_count": $0.chatCount,
+        ]
+      }
+      try JSONLines.printObject(["source": "local", "accounts": payload])
+    } else {
+      if accounts.isEmpty {
+        StdoutWriter.writeLine("account: (none found in local history) (source=local)")
+      } else {
+        StdoutWriter.writeLine("accounts (source=local):")
+        for account in accounts {
+          let label = account.login.isEmpty ? account.accountID : account.login
+          StdoutWriter.writeLine("  \(label) (chats=\(account.chatCount))")
+        }
+      }
     }
   }
 }
@@ -106,27 +164,59 @@ enum WhoisCommand {
   static let spec = CommandSpec(
     name: "whois",
     abstract: "Check whether a handle is reachable on iMessage",
-    discussion: nil,
+    discussion: """
+      The default mode performs a live reachability check via the IMCore bridge
+      (requires `imsg launch`, SIP disabled). Use --local for a SIP-free check
+      that infers the preferred service from local chat.db history. Local mode
+      only resolves handles you already have message history with; unknown
+      handles report service "unknown".
+      """,
     signature: CommandSignatures.withRuntimeFlags(
       CommandSignature(
         options: CommandSignatures.baseOptions() + [
           .make(label: "address", names: [.long("address")], help: "phone or email to check"),
           .make(label: "type", names: [.long("type")], help: "phone|email"),
+        ],
+        flags: [
+          .make(
+            label: "local", names: [.long("local")],
+            help: "infer service from local chat.db history (no SIP / bridge required)")
         ]
       )
     ),
     usageExamples: [
       "imsg whois --address +15551234567 --type phone",
       "imsg whois --address foo@bar.com --type email",
+      "imsg whois --address foo@bar.com --local",
     ]
   ) { values, runtime in
     try await run(values: values, runtime: runtime)
   }
 
-  static func run(values: ParsedValues, runtime: RuntimeOptions) async throws {
+  static func run(
+    values: ParsedValues,
+    runtime: RuntimeOptions,
+    storeFactory: @escaping (String) throws -> MessageStore = { try MessageStore(path: $0) },
+    resolveService: @escaping (MessageStore, String) throws -> HandleServiceAvailability = {
+      store, handle in
+      try store.preferredService(forHandle: handle)
+    }
+  ) async throws {
     guard let addr = values.option("address"), !addr.isEmpty else {
       throw ParsedValuesError.missingOption("address")
     }
+
+    if values.flag("local") {
+      try runLocal(
+        address: addr,
+        values: values,
+        runtime: runtime,
+        storeFactory: storeFactory,
+        resolveService: resolveService
+      )
+      return
+    }
+
     let aliasType = values.option("type") ?? (addr.contains("@") ? "email" : "phone")
     let params: [String: Any] = [
       "address": addr,
@@ -140,6 +230,43 @@ enum WhoisCommand {
       return "whois \(addr): \(avail ? "available" : "unavailable") (id_status=\(status))"
     }
   }
+
+  private static func runLocal(
+    address: String,
+    values: ParsedValues,
+    runtime: RuntimeOptions,
+    storeFactory: (String) throws -> MessageStore,
+    resolveService: (MessageStore, String) throws -> HandleServiceAvailability
+  ) throws {
+    let dbPath = values.option("db") ?? MessageStore.defaultPath
+    let store = try storeFactory(dbPath)
+    let availability = try resolveService(store, address)
+
+    let service: String
+    let known: Bool
+    switch availability {
+    case .imessage:
+      service = "imessage"
+      known = true
+    case .sms:
+      service = "sms"
+      known = true
+    case .unknown:
+      service = "unknown"
+      known = false
+    }
+
+    if runtime.jsonOutput {
+      try JSONLines.printObject([
+        "address": address,
+        "service": service,
+        "known": known,
+        "source": "local",
+      ])
+    } else {
+      StdoutWriter.writeLine("whois \(address): \(service) (source=local, known=\(known))")
+    }
+  }
 }
 
 // MARK: - nickname
@@ -148,23 +275,64 @@ enum NicknameCommand {
   static let spec = CommandSpec(
     name: "nickname",
     abstract: "Show contact-card / nickname info for a handle",
-    discussion: nil,
+    discussion: """
+      The default mode reads the contact-card nickname the correspondent shared
+      over iMessage via the IMCore bridge (requires `imsg launch`, SIP disabled).
+
+      --local is a SIP-free alternative that returns YOUR local AddressBook
+      contact name for the handle. NOTE: this is a different datum — it is your
+      own contact label, not the iMessage-shared nickname/photo, which is only
+      available through the bridge.
+      """,
     signature: CommandSignatures.withRuntimeFlags(
       CommandSignature(
         options: CommandSignatures.baseOptions() + [
           .make(label: "address", names: [.long("address")], help: "phone or email")
+        ],
+        flags: [
+          .make(
+            label: "local", names: [.long("local")],
+            help: "return local AddressBook contact name (no SIP; NOT the shared nickname)")
         ]
       )
     ),
-    usageExamples: ["imsg nickname --address +15551234567"]
+    usageExamples: [
+      "imsg nickname --address +15551234567",
+      "imsg nickname --address +15551234567 --local",
+    ]
   ) { values, runtime in
     try await run(values: values, runtime: runtime)
   }
 
-  static func run(values: ParsedValues, runtime: RuntimeOptions) async throws {
+  static func run(
+    values: ParsedValues,
+    runtime: RuntimeOptions,
+    contactResolverFactory: @escaping (String) async -> any ContactResolving = { region in
+      await ContactResolver.create(region: region)
+    }
+  ) async throws {
     guard let addr = values.option("address"), !addr.isEmpty else {
       throw ParsedValuesError.missingOption("address")
     }
+
+    if values.flag("local") {
+      let region = values.option("region") ?? "US"
+      let contacts = await contactResolverFactory(region)
+      let name = contacts.displayName(for: addr)
+      if runtime.jsonOutput {
+        try JSONLines.printObject([
+          "address": addr,
+          "local_contact_name": name ?? "",
+          "found": name != nil,
+          "source": "local-addressbook",
+        ])
+      } else {
+        StdoutWriter.writeLine(
+          "local_contact_name: \(name ?? "(none)") (source=local-addressbook)")
+      }
+      return
+    }
+
     let params: [String: Any] = ["address": addr]
     _ = try await BridgeOutput.invokeAndEmit(
       action: .getNicknameInfo, params: params, runtime: runtime

--- a/Sources/imsg/Commands/SendCommand.swift
+++ b/Sources/imsg/Commands/SendCommand.swift
@@ -27,7 +27,7 @@ enum SendCommand {
         flags: [
           .make(
             label: "noSMSFallback", names: [.long("no-sms-fallback")],
-            help: "disable automatic iMessage->SMS fallback for phone recipients")
+            help: "disable automatic iMessage->SMS fallback for text-only auto phone sends")
         ]
       )
     ),
@@ -60,8 +60,6 @@ enum SendCommand {
       (try? store.preferredService(forHandle: handle)) ?? .unknown
     }
   ) async throws {
-    let dbPath = values.option("db") ?? MessageStore.defaultPath
-    let store = try storeFactory(dbPath)
     let region = values.option("region") ?? "US"
     let rawRecipient = values.option("to") ?? ""
     let rawInput = ChatTargetInput(
@@ -82,6 +80,7 @@ enum SendCommand {
     } else {
       recipient = rawRecipient
     }
+
     let input = ChatTargetInput(
       recipient: recipient,
       chatID: rawInput.chatID,
@@ -98,6 +97,9 @@ enum SendCommand {
     guard let service = MessageService(rawValue: serviceRaw) else {
       throw IMsgError.invalidService(serviceRaw)
     }
+
+    let dbPath = values.option("db") ?? MessageStore.defaultPath
+    let store = try storeFactory(dbPath)
 
     let resolvedTarget = try await ChatTargetResolver.resolveChatTarget(
       input: input,
@@ -116,13 +118,19 @@ enum SendCommand {
     if service == .auto && !input.hasChatTarget && !input.recipient.isEmpty {
       switch resolveService(store, input.recipient) {
       case .imessage, .unknown:
-        effectiveService = .imessage
+        effectiveService = .auto
       case .sms:
         effectiveService = .sms
       }
     }
 
-    let allowSMSFallback = !values.flag("noSMSFallback")
+    let allowSMSFallback =
+      service == .auto
+      && !input.hasChatTarget
+      && !input.recipient.isEmpty
+      && !text.isEmpty
+      && file.isEmpty
+      && !values.flag("noSMSFallback")
 
     let options = MessageSendOptions(
       recipient: input.recipient,

--- a/Sources/imsg/Commands/SendCommand.swift
+++ b/Sources/imsg/Commands/SendCommand.swift
@@ -23,6 +23,11 @@ enum SendCommand {
           .make(
             label: "region", names: [.long("region")],
             help: "default region for phone normalization"),
+        ],
+        flags: [
+          .make(
+            label: "noSMSFallback", names: [.long("no-sms-fallback")],
+            help: "disable automatic iMessage->SMS fallback for phone recipients")
         ]
       )
     ),
@@ -49,6 +54,10 @@ enum SendCommand {
     storeFactory: @escaping (String) throws -> MessageStore = { try MessageStore(path: $0) },
     contactResolverFactory: @escaping (String) async -> any ContactResolving = { region in
       await ContactResolver.create(region: region)
+    },
+    resolveService: @escaping (MessageStore, String) -> HandleServiceAvailability = {
+      store, handle in
+      (try? store.preferredService(forHandle: handle)) ?? .unknown
     }
   ) async throws {
     let dbPath = values.option("db") ?? MessageStore.defaultPath
@@ -103,14 +112,27 @@ enum SendCommand {
       throw IMsgError.invalidChatTarget("Missing chat identifier or guid")
     }
 
+    var effectiveService = service
+    if service == .auto && !input.hasChatTarget && !input.recipient.isEmpty {
+      switch resolveService(store, input.recipient) {
+      case .imessage, .unknown:
+        effectiveService = .imessage
+      case .sms:
+        effectiveService = .sms
+      }
+    }
+
+    let allowSMSFallback = !values.flag("noSMSFallback")
+
     let options = MessageSendOptions(
       recipient: input.recipient,
       text: text,
       attachmentPath: file,
-      service: service,
+      service: effectiveService,
       region: region,
       chatIdentifier: resolvedTarget.chatIdentifier,
-      chatGUID: resolvedTarget.chatGUID
+      chatGUID: resolvedTarget.chatGUID,
+      allowSMSFallback: allowSMSFallback
     )
     let sentAt = Date()
     try sendMessage(options)

--- a/Sources/imsg/Commands/SendCommand.swift
+++ b/Sources/imsg/Commands/SendCommand.swift
@@ -55,9 +55,9 @@ enum SendCommand {
     contactResolverFactory: @escaping (String) async -> any ContactResolving = { region in
       await ContactResolver.create(region: region)
     },
-    resolveService: @escaping (MessageStore, String) -> HandleServiceAvailability = {
-      store, handle in
-      (try? store.preferredService(forHandle: handle)) ?? .unknown
+    resolveService: @escaping (MessageStore, String, String) -> HandleServiceAvailability = {
+      store, handle, region in
+      (try? store.preferredService(forHandle: handle, region: region)) ?? .unknown
     }
   ) async throws {
     let region = values.option("region") ?? "US"
@@ -116,7 +116,7 @@ enum SendCommand {
 
     var effectiveService = service
     if service == .auto && !input.hasChatTarget && !input.recipient.isEmpty {
-      switch resolveService(store, input.recipient) {
+      switch resolveService(store, input.recipient, region) {
       case .imessage, .unknown:
         effectiveService = .auto
       case .sms:

--- a/Sources/imsg/RPCServer+Handlers.swift
+++ b/Sources/imsg/RPCServer+Handlers.swift
@@ -215,18 +215,36 @@ extension RPCServer {
     if input.hasChatTarget && resolvedTarget.preferredIdentifier == nil {
       throw RPCError.invalidParams("missing chat identifier or guid")
     }
+    var effectiveService = service
+    if service == .auto && !input.hasChatTarget && !input.recipient.isEmpty {
+      switch (try? store.preferredService(forHandle: input.recipient)) ?? .unknown {
+      case .imessage, .unknown:
+        effectiveService = .auto
+      case .sms:
+        effectiveService = .sms
+      }
+    }
+
     let directChatInfo =
       input.hasChatTarget
-      ? nil : try resolveDirectChatInfo(recipient: input.recipient, service: service)
+      ? nil : try resolveDirectChatInfo(recipient: input.recipient, service: effectiveService)
+
+    let allowSMSFallback =
+      service == .auto
+      && !input.hasChatTarget
+      && !input.recipient.isEmpty
+      && !text.isEmpty
+      && file.isEmpty
 
     let options = MessageSendOptions(
       recipient: input.recipient,
       text: text,
       attachmentPath: file,
-      service: service,
+      service: effectiveService,
       region: region,
       chatIdentifier: resolvedTarget.chatIdentifier,
-      chatGUID: resolvedTarget.chatGUID
+      chatGUID: resolvedTarget.chatGUID,
+      allowSMSFallback: allowSMSFallback
     )
     let sentAt = Date()
 

--- a/Sources/imsg/RPCServer+Handlers.swift
+++ b/Sources/imsg/RPCServer+Handlers.swift
@@ -217,7 +217,7 @@ extension RPCServer {
     }
     var effectiveService = service
     if service == .auto && !input.hasChatTarget && !input.recipient.isEmpty {
-      switch (try? store.preferredService(forHandle: input.recipient)) ?? .unknown {
+      switch (try? store.preferredService(forHandle: input.recipient, region: region)) ?? .unknown {
       case .imessage, .unknown:
         effectiveService = .auto
       case .sms:

--- a/Sources/imsg/RPCServer+Handlers.swift
+++ b/Sources/imsg/RPCServer+Handlers.swift
@@ -227,7 +227,12 @@ extension RPCServer {
 
     let directChatInfo =
       input.hasChatTarget
-      ? nil : try resolveDirectChatInfo(recipient: input.recipient, service: effectiveService)
+      ? nil
+      : try resolveDirectChatInfo(
+        recipient: input.recipient,
+        service: effectiveService,
+        includeAnyForSMS: service == .auto && effectiveService == .sms
+      )
 
     let allowSMSFallback =
       service == .auto
@@ -477,11 +482,25 @@ extension RPCServer {
     respond(id: id, result: ["ok": true])
   }
 
-  private func resolveDirectChatInfo(recipient: String, service: MessageService) throws -> ChatInfo?
-  {
-    for candidate in ChatTargetResolver.directChatCandidates(recipient: recipient, service: service)
-    {
-      if let info = try store.chatInfo(matchingTarget: candidate) {
+  private func resolveDirectChatInfo(
+    recipient: String,
+    service: MessageService,
+    includeAnyForSMS: Bool = false
+  ) throws -> ChatInfo? {
+    let trimmed = recipient.trimmingCharacters(in: .whitespacesAndNewlines)
+    var candidates = ChatTargetResolver.directChatCandidates(recipient: recipient, service: service)
+    let requireExactMatch = includeAnyForSMS
+    if includeAnyForSMS, !trimmed.isEmpty {
+      candidates = ["SMS;-;\(trimmed)", "any;-;\(trimmed)", "any;+;\(trimmed)"]
+    }
+    for candidate in candidates {
+      let info: ChatInfo?
+      if requireExactMatch {
+        info = try store.chatInfo(matchingExactTarget: candidate)
+      } else {
+        info = try store.chatInfo(matchingTarget: candidate)
+      }
+      if let info {
         return info
       }
     }

--- a/Tests/IMsgCoreTests/MessageSenderSMSFallbackTests.swift
+++ b/Tests/IMsgCoreTests/MessageSenderSMSFallbackTests.swift
@@ -26,13 +26,30 @@ import Testing
     let options = MessageSendOptions(
       recipient: "+15551234567",
       text: "hi",
-      service: .imessage,
-      allowSMSFallback: true
+      service: .auto
     )
 
     try sender.send(options)
 
     #expect(spy.services == ["imessage", "sms"])
+  }
+
+  @Test
+  func smsFallbackDoesNotOverrideExplicitIMessage() throws {
+    let spy = RunnerSpy()
+    spy.failOnFirst = true
+    let sender = MessageSender(runner: spy.run)
+    let options = MessageSendOptions(
+      recipient: "+15551234567",
+      text: "hi",
+      service: .imessage,
+      allowSMSFallback: true
+    )
+
+    #expect(throws: IMsgError.self) {
+      try sender.send(options)
+    }
+    #expect(spy.services == ["imessage"])
   }
 
   @Test
@@ -43,7 +60,7 @@ import Testing
     let options = MessageSendOptions(
       recipient: "+15551234567",
       text: "hi",
-      service: .imessage,
+      service: .auto,
       allowSMSFallback: false
     )
 
@@ -81,6 +98,34 @@ import Testing
       text: "hi",
       service: .imessage,
       chatGUID: "iMessage;+;chat123",
+      allowSMSFallback: true
+    )
+
+    #expect(throws: IMsgError.self) {
+      try sender.send(options)
+    }
+    #expect(spy.services == ["imessage"])
+  }
+
+  @Test
+  func smsFallbackDoesNotEngageForAttachmentSend() throws {
+    let spy = RunnerSpy()
+    spy.failOnFirst = true
+    let sender = MessageSender(
+      runner: spy.run,
+      attachmentsSubdirectoryProvider: {
+        FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+      }
+    )
+    let attachment = FileManager.default.temporaryDirectory
+      .appendingPathComponent(UUID().uuidString)
+    try Data("photo".utf8).write(to: attachment)
+    defer { try? FileManager.default.removeItem(at: attachment) }
+    let options = MessageSendOptions(
+      recipient: "+15551234567",
+      text: "hi",
+      attachmentPath: attachment.path,
+      service: .auto,
       allowSMSFallback: true
     )
 

--- a/Tests/IMsgCoreTests/MessageSenderSMSFallbackTests.swift
+++ b/Tests/IMsgCoreTests/MessageSenderSMSFallbackTests.swift
@@ -1,0 +1,108 @@
+import Foundation
+import Testing
+
+@testable import IMsgCore
+
+#if os(macOS)
+  private final class RunnerSpy: @unchecked Sendable {
+    private(set) var services: [String] = []
+    var failOnFirst: Bool = false
+
+    func run(_ source: String, _ arguments: [String]) throws {
+      // arguments[2] is the service rawValue.
+      let service = arguments[2]
+      services.append(service)
+      if failOnFirst && services.count == 1 {
+        throw IMsgError.appleScriptFailure("simulated iMessage failure")
+      }
+    }
+  }
+
+  @Test
+  func smsFallbackRetriesOverSMSForPhoneRecipient() throws {
+    let spy = RunnerSpy()
+    spy.failOnFirst = true
+    let sender = MessageSender(runner: spy.run)
+    let options = MessageSendOptions(
+      recipient: "+15551234567",
+      text: "hi",
+      service: .imessage,
+      allowSMSFallback: true
+    )
+
+    try sender.send(options)
+
+    #expect(spy.services == ["imessage", "sms"])
+  }
+
+  @Test
+  func smsFallbackDisabledRethrowsOriginalError() throws {
+    let spy = RunnerSpy()
+    spy.failOnFirst = true
+    let sender = MessageSender(runner: spy.run)
+    let options = MessageSendOptions(
+      recipient: "+15551234567",
+      text: "hi",
+      service: .imessage,
+      allowSMSFallback: false
+    )
+
+    #expect(throws: IMsgError.self) {
+      try sender.send(options)
+    }
+    #expect(spy.services == ["imessage"])
+  }
+
+  @Test
+  func smsFallbackDoesNotEngageForEmailRecipient() throws {
+    let spy = RunnerSpy()
+    spy.failOnFirst = true
+    let sender = MessageSender(runner: spy.run)
+    let options = MessageSendOptions(
+      recipient: "friend@example.com",
+      text: "hi",
+      service: .imessage,
+      allowSMSFallback: true
+    )
+
+    #expect(throws: IMsgError.self) {
+      try sender.send(options)
+    }
+    #expect(spy.services == ["imessage"])
+  }
+
+  @Test
+  func smsFallbackDoesNotEngageForChatTarget() throws {
+    let spy = RunnerSpy()
+    spy.failOnFirst = true
+    let sender = MessageSender(runner: spy.run)
+    let options = MessageSendOptions(
+      recipient: "",
+      text: "hi",
+      service: .imessage,
+      chatGUID: "iMessage;+;chat123",
+      allowSMSFallback: true
+    )
+
+    #expect(throws: IMsgError.self) {
+      try sender.send(options)
+    }
+    #expect(spy.services == ["imessage"])
+  }
+
+  @Test
+  func successfulFirstSendDoesNotRetry() throws {
+    let spy = RunnerSpy()
+    let sender = MessageSender(runner: spy.run)
+    let options = MessageSendOptions(
+      recipient: "+15551234567",
+      text: "hi",
+      service: .imessage,
+      allowSMSFallback: true
+    )
+
+    try sender.send(options)
+
+    #expect(spy.services == ["imessage"])
+  }
+#endif

--- a/Tests/IMsgCoreTests/MessageStoreServiceAvailabilityTests.swift
+++ b/Tests/IMsgCoreTests/MessageStoreServiceAvailabilityTests.swift
@@ -1,0 +1,108 @@
+import Foundation
+import SQLite
+import Testing
+
+@testable import IMsgCore
+
+private func makeAvailabilityStore() throws -> (MessageStore, Connection) {
+  let db = try Connection(.inMemory)
+  try db.execute(
+    """
+    CREATE TABLE handle (ROWID INTEGER PRIMARY KEY, id TEXT, service TEXT);
+    """
+  )
+  try db.execute(
+    """
+    CREATE TABLE message (
+      ROWID INTEGER PRIMARY KEY,
+      handle_id INTEGER,
+      error INTEGER DEFAULT 0
+    );
+    """
+  )
+  let store = try MessageStore(connection: db, path: ":memory:")
+  return (store, db)
+}
+
+private func insertHandle(_ db: Connection, rowID: Int64, id: String, service: String) throws {
+  try db.run(
+    "INSERT INTO handle(ROWID, id, service) VALUES (?, ?, ?)",
+    rowID, id, service
+  )
+}
+
+private func insertMessage(_ db: Connection, handleID: Int64, error: Int64 = 0) throws {
+  try db.run(
+    "INSERT INTO message(handle_id, error) VALUES (?, ?)",
+    handleID, error
+  )
+}
+
+@Test
+func preferredServiceReturnsIMessageForNonErroredIMessageHandle() throws {
+  let (store, db) = try makeAvailabilityStore()
+  try insertHandle(db, rowID: 1, id: "+15551234567", service: "iMessage")
+  try insertMessage(db, handleID: 1)
+
+  #expect(try store.preferredService(forHandle: "+15551234567") == .imessage)
+}
+
+@Test
+func preferredServiceMatchesPhoneFormatVariants() throws {
+  let (store, db) = try makeAvailabilityStore()
+  // Stored without country code; query with +1 form.
+  try insertHandle(db, rowID: 1, id: "5551234567", service: "iMessage")
+  try insertMessage(db, handleID: 1)
+
+  #expect(try store.preferredService(forHandle: "+15551234567") == .imessage)
+}
+
+@Test
+func preferredServiceReturnsSMSWhenOnlySMSHistory() throws {
+  let (store, db) = try makeAvailabilityStore()
+  try insertHandle(db, rowID: 1, id: "+15551234567", service: "SMS")
+  try insertMessage(db, handleID: 1)
+
+  #expect(try store.preferredService(forHandle: "+15551234567") == .sms)
+}
+
+@Test
+func preferredServiceFallsBackToSMSWhenIMessageOnlyErrored() throws {
+  let (store, db) = try makeAvailabilityStore()
+  try insertHandle(db, rowID: 1, id: "+15551234567", service: "iMessage")
+  try insertMessage(db, handleID: 1, error: 1)
+  try insertHandle(db, rowID: 2, id: "+15551234567", service: "SMS")
+  try insertMessage(db, handleID: 2)
+
+  #expect(try store.preferredService(forHandle: "+15551234567") == .sms)
+}
+
+@Test
+func preferredServiceReturnsUnknownForNewContact() throws {
+  let (store, _) = try makeAvailabilityStore()
+
+  #expect(try store.preferredService(forHandle: "+15559998888") == .unknown)
+}
+
+@Test
+func preferredServiceMatchesEmailHandle() throws {
+  let (store, db) = try makeAvailabilityStore()
+  try insertHandle(db, rowID: 1, id: "friend@example.com", service: "iMessage")
+  try insertMessage(db, handleID: 1)
+
+  #expect(try store.preferredService(forHandle: "Friend@Example.com") == .imessage)
+}
+
+@Test
+func handleCandidatesExpandsTenDigitNumber() {
+  let candidates = MessageStore.handleCandidates("(555) 123-4567")
+  #expect(candidates.contains("5551234567"))
+  #expect(candidates.contains("15551234567"))
+  #expect(candidates.contains("+15551234567"))
+}
+
+@Test
+func handleCandidatesLowercasesEmail() {
+  let candidates = MessageStore.handleCandidates("Friend@Example.com")
+  #expect(candidates == ["friend@example.com"])
+}

--- a/Tests/IMsgCoreTests/MessageStoreServiceAvailabilityTests.swift
+++ b/Tests/IMsgCoreTests/MessageStoreServiceAvailabilityTests.swift
@@ -67,6 +67,15 @@ func preferredServiceReturnsSMSWhenOnlySMSHistory() throws {
 }
 
 @Test
+func preferredServiceNormalizesHandleWithRegion() throws {
+  let (store, db) = try makeAvailabilityStore()
+  try insertHandle(db, rowID: 1, id: "+447700900000", service: "SMS")
+  try insertMessage(db, handleID: 1)
+
+  #expect(try store.preferredService(forHandle: "07700 900000", region: "GB") == .sms)
+}
+
+@Test
 func preferredServiceFallsBackToSMSWhenIMessageOnlyErrored() throws {
   let (store, db) = try makeAvailabilityStore()
   try insertHandle(db, rowID: 1, id: "+15551234567", service: "iMessage")

--- a/Tests/imsgTests/AccountNicknameLocalCommandTests.swift
+++ b/Tests/imsgTests/AccountNicknameLocalCommandTests.swift
@@ -1,0 +1,182 @@
+import Commander
+import Foundation
+import SQLite
+import Testing
+
+@testable import IMsgCore
+@testable import imsg
+
+private func accountSeedStore() throws -> MessageStore {
+  let db = try Connection(.inMemory)
+  try db.execute(
+    """
+    CREATE TABLE chat (
+      ROWID INTEGER PRIMARY KEY,
+      chat_identifier TEXT,
+      guid TEXT,
+      display_name TEXT,
+      service_name TEXT,
+      account_id TEXT,
+      account_login TEXT
+    );
+    """
+  )
+  try db.run(
+    """
+    INSERT INTO chat(ROWID, chat_identifier, guid, account_id, account_login)
+    VALUES
+      (1, '+123', 'iMessage;+;a', 'iMessage;+;me@icloud.com', 'me@icloud.com'),
+      (2, '+456', 'iMessage;+;b', 'iMessage;+;me@icloud.com', 'me@icloud.com'),
+      (3, '+789', 'iMessage;+;c', 'iMessage;+;other@icloud.com', 'other@icloud.com')
+    """
+  )
+  return try MessageStore(connection: db, path: ":memory:")
+}
+
+@Test
+func accountLocalListsAccountsRankedByChatCount() async throws {
+  let values = ParsedValues(
+    positional: [],
+    options: [:],
+    flags: ["local"]
+  )
+  let runtime = RuntimeOptions(parsedValues: values)
+  let store = try accountSeedStore()
+  let (output, _) = try await StdoutCapture.capture {
+    try await AccountCommand.run(
+      values: values,
+      runtime: runtime,
+      storeFactory: { _ in store }
+    )
+  }
+  #expect(output.contains("accounts (source=local):"))
+  #expect(output.contains("me@icloud.com (chats=2)"))
+  #expect(output.contains("other@icloud.com (chats=1)"))
+}
+
+@Test
+func accountLocalEmitsJsonArray() async throws {
+  let values = ParsedValues(
+    positional: [],
+    options: [:],
+    flags: ["local", "jsonOutput"]
+  )
+  let runtime = RuntimeOptions(parsedValues: values)
+  let store = try accountSeedStore()
+  let (output, _) = try await StdoutCapture.capture {
+    try await AccountCommand.run(
+      values: values,
+      runtime: runtime,
+      storeFactory: { _ in store }
+    )
+  }
+  let payload = try jsonObject(from: output)
+  #expect(payload["source"] as? String == "local")
+  let accounts = try #require(payload["accounts"] as? [[String: Any]])
+  #expect(accounts.count == 2)
+  #expect(accounts.first?["login"] as? String == "me@icloud.com")
+  #expect((accounts.first?["chat_count"] as? NSNumber)?.intValue == 2)
+}
+
+@Test
+func accountLocalReportsNoneWhenEmpty() async throws {
+  let values = ParsedValues(
+    positional: [],
+    options: [:],
+    flags: ["local"]
+  )
+  let runtime = RuntimeOptions(parsedValues: values)
+  let (output, _) = try await StdoutCapture.capture {
+    try await AccountCommand.run(
+      values: values,
+      runtime: runtime,
+      storeFactory: { _ in try emptyChatStore() },
+      localAccounts: { _ in [] }
+    )
+  }
+  #expect(output.contains("(none found in local history)"))
+}
+
+@Test
+func nicknameLocalReturnsAddressBookName() async throws {
+  let values = ParsedValues(
+    positional: [],
+    options: ["address": ["+15551234567"]],
+    flags: ["local"]
+  )
+  let runtime = RuntimeOptions(parsedValues: values)
+  let resolver = MockContactResolver(names: ["+15551234567": "Alice Smith"])
+  let (output, _) = try await StdoutCapture.capture {
+    try await NicknameCommand.run(
+      values: values,
+      runtime: runtime,
+      contactResolverFactory: { _ in resolver }
+    )
+  }
+  #expect(output.contains("local_contact_name: Alice Smith"))
+  #expect(output.contains("source=local-addressbook"))
+}
+
+@Test
+func nicknameLocalJsonReportsFoundFalseWhenUnknown() async throws {
+  let values = ParsedValues(
+    positional: [],
+    options: ["address": ["+15559998888"]],
+    flags: ["local", "jsonOutput"]
+  )
+  let runtime = RuntimeOptions(parsedValues: values)
+  let resolver = MockContactResolver(names: [:])
+  let (output, _) = try await StdoutCapture.capture {
+    try await NicknameCommand.run(
+      values: values,
+      runtime: runtime,
+      contactResolverFactory: { _ in resolver }
+    )
+  }
+  let payload = try jsonObject(from: output)
+  #expect(payload["address"] as? String == "+15559998888")
+  #expect(payload["found"] as? Bool == false)
+  #expect(payload["source"] as? String == "local-addressbook")
+}
+
+@Test
+func nicknameLocalRequiresAddress() async {
+  let values = ParsedValues(
+    positional: [],
+    options: [:],
+    flags: ["local"]
+  )
+  let runtime = RuntimeOptions(parsedValues: values)
+  do {
+    try await NicknameCommand.run(
+      values: values,
+      runtime: runtime,
+      contactResolverFactory: { _ in MockContactResolver(names: [:]) }
+    )
+    #expect(Bool(false))
+  } catch let error as ParsedValuesError {
+    #expect(error.description.contains("Missing required option"))
+  } catch {
+    #expect(Bool(false))
+  }
+}
+
+private func emptyChatStore() throws -> MessageStore {
+  let db = try Connection(.inMemory)
+  try db.execute(
+    """
+    CREATE TABLE chat (
+      ROWID INTEGER PRIMARY KEY,
+      account_id TEXT,
+      account_login TEXT
+    );
+    """
+  )
+  return try MessageStore(connection: db, path: ":memory:")
+}
+
+private func jsonObject(from output: String) throws -> [String: Any] {
+  let line = output.split(separator: "\n").first.map(String.init) ?? ""
+  let data = Data(line.utf8)
+  return try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+}

--- a/Tests/imsgTests/ChatHistorySendCommandTests.swift
+++ b/Tests/imsgTests/ChatHistorySendCommandTests.swift
@@ -438,6 +438,96 @@ func sendCommandRejectsMisroutedChatGhost() async throws {
   }
 }
 
+@Test
+func sendCommandAutoResolvesToSMSWhenDetected() async throws {
+  let values = ParsedValues(
+    positional: [],
+    options: ["to": ["+15551234567"], "text": ["hi"], "service": ["auto"]],
+    flags: []
+  )
+  let runtime = RuntimeOptions(parsedValues: values)
+  var captured: MessageSendOptions?
+  _ = try await StdoutCapture.capture {
+    try await SendCommand.run(
+      values: values,
+      runtime: runtime,
+      sendMessage: { options in captured = options },
+      resolveSentMessage: { _, _, _, _ in nil },
+      resolveService: { _, _ in .sms }
+    )
+  }
+  #expect(captured?.service == .sms)
+}
+
+@Test
+func sendCommandAutoResolvesUnknownToIMessage() async throws {
+  let values = ParsedValues(
+    positional: [],
+    options: ["to": ["+15559998888"], "text": ["hi"], "service": ["auto"]],
+    flags: []
+  )
+  let runtime = RuntimeOptions(parsedValues: values)
+  var captured: MessageSendOptions?
+  _ = try await StdoutCapture.capture {
+    try await SendCommand.run(
+      values: values,
+      runtime: runtime,
+      sendMessage: { options in captured = options },
+      resolveSentMessage: { _, _, _, _ in nil },
+      resolveService: { _, _ in .unknown }
+    )
+  }
+  #expect(captured?.service == .imessage)
+  #expect(captured?.allowSMSFallback == true)
+}
+
+@Test
+func sendCommandHonorsNoSMSFallbackFlag() async throws {
+  let values = ParsedValues(
+    positional: [],
+    options: ["to": ["+15551234567"], "text": ["hi"]],
+    flags: ["noSMSFallback"]
+  )
+  let runtime = RuntimeOptions(parsedValues: values)
+  var captured: MessageSendOptions?
+  _ = try await StdoutCapture.capture {
+    try await SendCommand.run(
+      values: values,
+      runtime: runtime,
+      sendMessage: { options in captured = options },
+      resolveSentMessage: { _, _, _, _ in nil },
+      resolveService: { _, _ in .imessage }
+    )
+  }
+  #expect(captured?.allowSMSFallback == false)
+}
+
+@Test
+func sendCommandExplicitServiceSkipsDetection() async throws {
+  let values = ParsedValues(
+    positional: [],
+    options: ["to": ["+15551234567"], "text": ["hi"], "service": ["imessage"]],
+    flags: []
+  )
+  let runtime = RuntimeOptions(parsedValues: values)
+  var resolverCalled = false
+  var captured: MessageSendOptions?
+  _ = try await StdoutCapture.capture {
+    try await SendCommand.run(
+      values: values,
+      runtime: runtime,
+      sendMessage: { options in captured = options },
+      resolveSentMessage: { _, _, _, _ in nil },
+      resolveService: { _, _ in
+        resolverCalled = true
+        return .sms
+      }
+    )
+  }
+  #expect(captured?.service == .imessage)
+  #expect(resolverCalled == false)
+}
+
 private func jsonObject(from output: String) throws -> [String: Any] {
   let line = output.split(separator: "\n").first.map(String.init) ?? ""
   let data = Data(line.utf8)

--- a/Tests/imsgTests/ChatHistorySendCommandTests.swift
+++ b/Tests/imsgTests/ChatHistorySendCommandTests.swift
@@ -282,6 +282,7 @@ func sendCommandResolvesUniqueContactName() async throws {
       runtime: runtime,
       sendMessage: { options in captured = options },
       resolveSentMessage: { _, _, _, _ in nil },
+      storeFactory: { _ in try CommandTestDatabase.makeStoreForRPC() },
       contactResolverFactory: { _ in resolver }
     )
   }
@@ -334,7 +335,8 @@ func sendCommandRunsWithStubSender() async throws {
       sendMessage: { options in
         captured = options
       },
-      resolveSentMessage: { _, _, _, _ in nil }
+      resolveSentMessage: { _, _, _, _ in nil },
+      storeFactory: { _ in try CommandTestDatabase.makeStoreForRPC() }
     )
   }
   #expect(captured?.recipient == "+15551234567")
@@ -453,6 +455,7 @@ func sendCommandAutoResolvesToSMSWhenDetected() async throws {
       runtime: runtime,
       sendMessage: { options in captured = options },
       resolveSentMessage: { _, _, _, _ in nil },
+      storeFactory: { _ in try CommandTestDatabase.makeStoreForRPC() },
       resolveService: { _, _ in .sms }
     )
   }
@@ -474,10 +477,11 @@ func sendCommandAutoResolvesUnknownToIMessage() async throws {
       runtime: runtime,
       sendMessage: { options in captured = options },
       resolveSentMessage: { _, _, _, _ in nil },
+      storeFactory: { _ in try CommandTestDatabase.makeStoreForRPC() },
       resolveService: { _, _ in .unknown }
     )
   }
-  #expect(captured?.service == .imessage)
+  #expect(captured?.service == .auto)
   #expect(captured?.allowSMSFallback == true)
 }
 
@@ -496,9 +500,33 @@ func sendCommandHonorsNoSMSFallbackFlag() async throws {
       runtime: runtime,
       sendMessage: { options in captured = options },
       resolveSentMessage: { _, _, _, _ in nil },
+      storeFactory: { _ in try CommandTestDatabase.makeStoreForRPC() },
       resolveService: { _, _ in .imessage }
     )
   }
+  #expect(captured?.allowSMSFallback == false)
+}
+
+@Test
+func sendCommandDisablesSMSFallbackForAttachments() async throws {
+  let values = ParsedValues(
+    positional: [],
+    options: ["to": ["+15551234567"], "text": ["hi"], "file": ["/tmp/photo.jpg"]],
+    flags: []
+  )
+  let runtime = RuntimeOptions(parsedValues: values)
+  var captured: MessageSendOptions?
+  _ = try await StdoutCapture.capture {
+    try await SendCommand.run(
+      values: values,
+      runtime: runtime,
+      sendMessage: { options in captured = options },
+      resolveSentMessage: { _, _, _, _ in nil },
+      storeFactory: { _ in try CommandTestDatabase.makeStoreForRPC() },
+      resolveService: { _, _ in .imessage }
+    )
+  }
+  #expect(captured?.service == .auto)
   #expect(captured?.allowSMSFallback == false)
 }
 
@@ -518,6 +546,7 @@ func sendCommandExplicitServiceSkipsDetection() async throws {
       runtime: runtime,
       sendMessage: { options in captured = options },
       resolveSentMessage: { _, _, _, _ in nil },
+      storeFactory: { _ in try CommandTestDatabase.makeStoreForRPC() },
       resolveService: { _, _ in
         resolverCalled = true
         return .sms
@@ -525,6 +554,7 @@ func sendCommandExplicitServiceSkipsDetection() async throws {
     )
   }
   #expect(captured?.service == .imessage)
+  #expect(captured?.allowSMSFallback == false)
   #expect(resolverCalled == false)
 }
 

--- a/Tests/imsgTests/ChatHistorySendCommandTests.swift
+++ b/Tests/imsgTests/ChatHistorySendCommandTests.swift
@@ -456,7 +456,7 @@ func sendCommandAutoResolvesToSMSWhenDetected() async throws {
       sendMessage: { options in captured = options },
       resolveSentMessage: { _, _, _, _ in nil },
       storeFactory: { _ in try CommandTestDatabase.makeStoreForRPC() },
-      resolveService: { _, _ in .sms }
+      resolveService: { _, _, _ in .sms }
     )
   }
   #expect(captured?.service == .sms)
@@ -478,7 +478,7 @@ func sendCommandAutoResolvesUnknownToIMessage() async throws {
       sendMessage: { options in captured = options },
       resolveSentMessage: { _, _, _, _ in nil },
       storeFactory: { _ in try CommandTestDatabase.makeStoreForRPC() },
-      resolveService: { _, _ in .unknown }
+      resolveService: { _, _, _ in .unknown }
     )
   }
   #expect(captured?.service == .auto)
@@ -501,7 +501,7 @@ func sendCommandHonorsNoSMSFallbackFlag() async throws {
       sendMessage: { options in captured = options },
       resolveSentMessage: { _, _, _, _ in nil },
       storeFactory: { _ in try CommandTestDatabase.makeStoreForRPC() },
-      resolveService: { _, _ in .imessage }
+      resolveService: { _, _, _ in .imessage }
     )
   }
   #expect(captured?.allowSMSFallback == false)
@@ -523,7 +523,7 @@ func sendCommandDisablesSMSFallbackForAttachments() async throws {
       sendMessage: { options in captured = options },
       resolveSentMessage: { _, _, _, _ in nil },
       storeFactory: { _ in try CommandTestDatabase.makeStoreForRPC() },
-      resolveService: { _, _ in .imessage }
+      resolveService: { _, _, _ in .imessage }
     )
   }
   #expect(captured?.service == .auto)
@@ -547,7 +547,7 @@ func sendCommandExplicitServiceSkipsDetection() async throws {
       sendMessage: { options in captured = options },
       resolveSentMessage: { _, _, _, _ in nil },
       storeFactory: { _ in try CommandTestDatabase.makeStoreForRPC() },
-      resolveService: { _, _ in
+      resolveService: { _, _, _ in
         resolverCalled = true
         return .sms
       }

--- a/Tests/imsgTests/RPCServerBridgeTests.swift
+++ b/Tests/imsgTests/RPCServerBridgeTests.swift
@@ -41,6 +41,92 @@ func rpcSendUsesBridgeWhenReadyAndExistingDirectChatResolves() async throws {
 }
 
 @Test
+func rpcSendAutoSMSDetectionKeepsAnyPrefixBridgeLookup() async throws {
+  let store = try CommandTestDatabase.makeStoreForRPCDirectChat()
+  try store.withConnection { db in
+    try db.run(
+      """
+      UPDATE chat
+      SET chat_identifier = 'any;-;+123', guid = 'any;-;+123'
+      WHERE ROWID = 1
+      """
+    )
+    try db.run(
+      """
+      INSERT INTO chat(
+        ROWID, chat_identifier, guid, display_name, service_name,
+        account_id, account_login, last_addressed_handle
+      )
+      VALUES (
+        0, '+123', 'iMessage;-;+123', 'Old iMessage Chat', 'iMessage',
+        'iMessage;+;me@icloud.com', 'me@icloud.com', '+123'
+      )
+      """
+    )
+    try db.run("ALTER TABLE handle ADD COLUMN service TEXT")
+    try db.run("UPDATE handle SET service = 'SMS' WHERE id = '+123'")
+  }
+  let output = TestRPCOutput()
+  var appleScriptCalled = false
+  var capturedAction: BridgeAction?
+  var capturedParams: [String: Any] = [:]
+  let server = RPCServer(
+    store: store,
+    verbose: false,
+    output: output,
+    sendMessage: { _ in appleScriptCalled = true },
+    resolveSentMessage: { _, _, _, _ in nil },
+    invokeBridge: { action, params in
+      capturedAction = action
+      capturedParams = params
+      return ["messageGuid": "bridge-guid", "chatGuid": "any;-;+123", "service": "SMS"]
+    },
+    isBridgeReady: { true }
+  )
+
+  let line =
+    #"{"jsonrpc":"2.0","id":"3anysms","method":"send","params":{"to":"+123","text":"yo","transport":"bridge"}}"#
+  await server.handleLineForTesting(line)
+
+  #expect(appleScriptCalled == false)
+  #expect(capturedAction == .sendMessage)
+  #expect(capturedParams["chatGuid"] as? String == "any;-;+123")
+  let result = output.responses.first?["result"] as? [String: Any]
+  #expect(result?["transport"] as? String == "bridge")
+}
+
+@Test
+func rpcSendAutoSMSDetectionDoesNotUseIMessageBridgeChat() async throws {
+  let store = try CommandTestDatabase.makeStoreForRPCDirectChat()
+  try store.withConnection { db in
+    try db.run("ALTER TABLE handle ADD COLUMN service TEXT")
+    try db.run("UPDATE handle SET service = 'SMS' WHERE id = '+123'")
+  }
+  let output = TestRPCOutput()
+  var bridgeCalled = false
+  let server = RPCServer(
+    store: store,
+    verbose: false,
+    output: output,
+    sendMessage: { _ in },
+    resolveSentMessage: { _, _, _, _ in nil },
+    invokeBridge: { _, _ in
+      bridgeCalled = true
+      return [:]
+    },
+    isBridgeReady: { true }
+  )
+
+  let line =
+    #"{"jsonrpc":"2.0","id":"3imsms","method":"send","params":{"to":"+123","text":"yo","transport":"bridge"}}"#
+  await server.handleLineForTesting(line)
+
+  #expect(bridgeCalled == false)
+  let error = output.errors.first?["error"] as? [String: Any]
+  #expect(error?["data"] as? String == "bridge transport requires an existing chat target")
+}
+
+@Test
 func rpcSendFallsBackToAppleScriptWhenAutoBridgeFails() async throws {
   let store = try CommandTestDatabase.makeStoreForRPCDirectChat()
   let output = TestRPCOutput()

--- a/Tests/imsgTests/RPCServerSendFallbackTests.swift
+++ b/Tests/imsgTests/RPCServerSendFallbackTests.swift
@@ -1,0 +1,80 @@
+import Foundation
+import SQLite
+import Testing
+
+@testable import IMsgCore
+@testable import imsg
+
+@Test
+func rpcSendEnablesSMSFallbackForAutoTextDirectSend() async throws {
+  let store = try CommandTestDatabase.makeStoreForRPC()
+  let output = TestRPCOutput()
+  var captured: MessageSendOptions?
+  let server = RPCServer(
+    store: store,
+    verbose: false,
+    output: output,
+    sendMessage: { options in captured = options },
+    resolveSentMessage: { _, _, _, _ in nil }
+  )
+
+  let line =
+    #"{"jsonrpc":"2.0","id":"3sms","method":"send","params":{"to":"+15551234567","text":"yo"}}"#
+  await server.handleLineForTesting(line)
+
+  #expect(captured?.service == .auto)
+  #expect(captured?.allowSMSFallback == true)
+}
+
+@Test
+func rpcSendAutoUsesLocalSMSHistoryForAttachmentSend() async throws {
+  let store = try CommandTestDatabase.makeStoreForRPC()
+  try store.withConnection { db in
+    try db.run("ALTER TABLE handle ADD COLUMN service TEXT")
+    try db.run("INSERT INTO handle(ROWID, id, service) VALUES (10, '+15551234567', 'SMS')")
+    try db.run(
+      """
+      INSERT INTO message(ROWID, handle_id, text, date, is_from_me, service)
+      VALUES (10, 10, 'sms history', ?, 0, 'SMS')
+      """,
+      CommandTestDatabase.appleEpoch(Date())
+    )
+  }
+  let output = TestRPCOutput()
+  var captured: MessageSendOptions?
+  let server = RPCServer(
+    store: store,
+    verbose: false,
+    output: output,
+    sendMessage: { options in captured = options },
+    resolveSentMessage: { _, _, _, _ in nil }
+  )
+
+  let line =
+    #"{"jsonrpc":"2.0","id":"3smsfile","method":"send","params":{"to":"+15551234567","file":"/tmp/photo.jpg"}}"#
+  await server.handleLineForTesting(line)
+
+  #expect(captured?.service == .sms)
+  #expect(captured?.allowSMSFallback == false)
+}
+
+@Test
+func rpcSendDisablesSMSFallbackForExplicitService() async throws {
+  let store = try CommandTestDatabase.makeStoreForRPC()
+  let output = TestRPCOutput()
+  var captured: MessageSendOptions?
+  let server = RPCServer(
+    store: store,
+    verbose: false,
+    output: output,
+    sendMessage: { options in captured = options },
+    resolveSentMessage: { _, _, _, _ in nil }
+  )
+
+  let line =
+    #"{"jsonrpc":"2.0","id":"3nosms","method":"send","params":{"to":"+15551234567","text":"yo","service":"imessage"}}"#
+  await server.handleLineForTesting(line)
+
+  #expect(captured?.service == .imessage)
+  #expect(captured?.allowSMSFallback == false)
+}

--- a/Tests/imsgTests/RPCServerSendFallbackTests.swift
+++ b/Tests/imsgTests/RPCServerSendFallbackTests.swift
@@ -59,6 +59,38 @@ func rpcSendAutoUsesLocalSMSHistoryForAttachmentSend() async throws {
 }
 
 @Test
+func rpcSendAutoDetectionUsesRegionNormalizedRecipient() async throws {
+  let store = try CommandTestDatabase.makeStoreForRPC()
+  try store.withConnection { db in
+    try db.run("ALTER TABLE handle ADD COLUMN service TEXT")
+    try db.run("INSERT INTO handle(ROWID, id, service) VALUES (44, '+447700900000', 'SMS')")
+    try db.run(
+      """
+      INSERT INTO message(ROWID, handle_id, text, date, is_from_me, service)
+      VALUES (44, 44, 'sms history', ?, 0, 'SMS')
+      """,
+      CommandTestDatabase.appleEpoch(Date())
+    )
+  }
+  let output = TestRPCOutput()
+  var captured: MessageSendOptions?
+  let server = RPCServer(
+    store: store,
+    verbose: false,
+    output: output,
+    sendMessage: { options in captured = options },
+    resolveSentMessage: { _, _, _, _ in nil }
+  )
+
+  let line =
+    #"{"jsonrpc":"2.0","id":"3region","method":"send","params":{"to":"07700 900000","file":"/tmp/photo.jpg","region":"GB"}}"#
+  await server.handleLineForTesting(line)
+
+  #expect(captured?.service == .sms)
+  #expect(captured?.allowSMSFallback == false)
+}
+
+@Test
 func rpcSendDisablesSMSFallbackForExplicitService() async throws {
   let store = try CommandTestDatabase.makeStoreForRPC()
   let output = TestRPCOutput()

--- a/Tests/imsgTests/SendCommandServiceDetectionTests.swift
+++ b/Tests/imsgTests/SendCommandServiceDetectionTests.swift
@@ -1,0 +1,44 @@
+import Commander
+import Foundation
+import SQLite
+import Testing
+
+@testable import IMsgCore
+@testable import imsg
+
+@Test
+func sendCommandAutoDetectionUsesRegionNormalizedRecipient() async throws {
+  let path = try CommandTestDatabase.makePath()
+  let db = try Connection(path)
+  try db.run("ALTER TABLE handle ADD COLUMN service TEXT")
+  try db.run("INSERT INTO handle(ROWID, id, service) VALUES (44, '+447700900000', 'SMS')")
+  try db.run(
+    """
+    INSERT INTO message(ROWID, handle_id, text, date, is_from_me, service)
+    VALUES (44, 44, 'sms history', ?, 0, 'SMS')
+    """,
+    CommandTestDatabase.appleEpoch(Date())
+  )
+  let values = ParsedValues(
+    positional: [],
+    options: [
+      "db": [path],
+      "to": ["07700 900000"],
+      "file": ["/tmp/photo.jpg"],
+      "region": ["GB"],
+    ],
+    flags: []
+  )
+  let runtime = RuntimeOptions(parsedValues: values)
+  var captured: MessageSendOptions?
+  _ = try await StdoutCapture.capture {
+    try await SendCommand.run(
+      values: values,
+      runtime: runtime,
+      sendMessage: { options in captured = options },
+      resolveSentMessage: { _, _, _, _ in nil }
+    )
+  }
+  #expect(captured?.service == .sms)
+  #expect(captured?.allowSMSFallback == false)
+}

--- a/Tests/imsgTests/WhoisLocalCommandTests.swift
+++ b/Tests/imsgTests/WhoisLocalCommandTests.swift
@@ -1,0 +1,130 @@
+import Commander
+import Foundation
+import SQLite
+import Testing
+
+@testable import IMsgCore
+@testable import imsg
+
+private func emptyStore() throws -> MessageStore {
+  let db = try Connection(.inMemory)
+  return try MessageStore(connection: db, path: ":memory:")
+}
+
+@Test
+func whoisLocalReportsIMessageText() async throws {
+  let values = ParsedValues(
+    positional: [],
+    options: ["address": ["friend@example.com"]],
+    flags: ["local"]
+  )
+  let runtime = RuntimeOptions(parsedValues: values)
+  let (output, _) = try await StdoutCapture.capture {
+    try await WhoisCommand.run(
+      values: values,
+      runtime: runtime,
+      storeFactory: { _ in try emptyStore() },
+      resolveService: { _, _ in .imessage }
+    )
+  }
+  #expect(output.contains("whois friend@example.com: imessage"))
+  #expect(output.contains("known=true"))
+}
+
+@Test
+func whoisLocalReportsSMSJson() async throws {
+  let values = ParsedValues(
+    positional: [],
+    options: ["address": ["+15551234567"]],
+    flags: ["local", "jsonOutput"]
+  )
+  let runtime = RuntimeOptions(parsedValues: values)
+  let (output, _) = try await StdoutCapture.capture {
+    try await WhoisCommand.run(
+      values: values,
+      runtime: runtime,
+      storeFactory: { _ in try emptyStore() },
+      resolveService: { _, _ in .sms }
+    )
+  }
+  let payload = try jsonObject(from: output)
+  #expect(payload["address"] as? String == "+15551234567")
+  #expect(payload["service"] as? String == "sms")
+  #expect(payload["known"] as? Bool == true)
+  #expect(payload["source"] as? String == "local")
+}
+
+@Test
+func whoisLocalReportsUnknownForNewContact() async throws {
+  let values = ParsedValues(
+    positional: [],
+    options: ["address": ["+15559998888"]],
+    flags: ["local", "jsonOutput"]
+  )
+  let runtime = RuntimeOptions(parsedValues: values)
+  let (output, _) = try await StdoutCapture.capture {
+    try await WhoisCommand.run(
+      values: values,
+      runtime: runtime,
+      storeFactory: { _ in try emptyStore() },
+      resolveService: { _, _ in .unknown }
+    )
+  }
+  let payload = try jsonObject(from: output)
+  #expect(payload["service"] as? String == "unknown")
+  #expect(payload["known"] as? Bool == false)
+}
+
+@Test
+func whoisLocalDoesNotInvokeBridge() async throws {
+  // The local path must resolve purely from the injected store/resolver and
+  // never touch the IMCore bridge (which would require SIP).
+  let values = ParsedValues(
+    positional: [],
+    options: ["address": ["friend@example.com"]],
+    flags: ["local"]
+  )
+  let runtime = RuntimeOptions(parsedValues: values)
+  var resolverCalled = false
+  _ = try await StdoutCapture.capture {
+    try await WhoisCommand.run(
+      values: values,
+      runtime: runtime,
+      storeFactory: { _ in try emptyStore() },
+      resolveService: { _, _ in
+        resolverCalled = true
+        return .imessage
+      }
+    )
+  }
+  #expect(resolverCalled)
+}
+
+@Test
+func whoisLocalRequiresAddress() async {
+  let values = ParsedValues(
+    positional: [],
+    options: [:],
+    flags: ["local"]
+  )
+  let runtime = RuntimeOptions(parsedValues: values)
+  do {
+    try await WhoisCommand.run(
+      values: values,
+      runtime: runtime,
+      storeFactory: { _ in try emptyStore() },
+      resolveService: { _, _ in .imessage }
+    )
+    #expect(Bool(false))
+  } catch let error as ParsedValuesError {
+    #expect(error.description.contains("Missing required option"))
+  } catch {
+    #expect(Bool(false))
+  }
+}
+
+private func jsonObject(from output: String) throws -> [String: Any] {
+  let line = output.split(separator: "\n").first.map(String.init) ?? ""
+  let data = Data(line.utf8)
+  return try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+}

--- a/docs/send.md
+++ b/docs/send.md
@@ -59,13 +59,14 @@ Audio files (`.m4a`, `.caf`, `.aiff`, etc.) send the same way as any other file.
 imsg send --to "+14155551212" --text "hi" --service auto       # default
 imsg send --to "+14155551212" --text "hi" --service imessage
 imsg send --to "+14155551212" --text "hi" --service sms
+imsg send --to "+14155551212" --text "hi" --no-sms-fallback
 ```
 
-- `auto` — Messages picks. iMessage when the recipient is an Apple device; SMS when not, given Text Message Forwarding is enabled.
+- `auto` — `imsg` first checks local Messages history for the handle's observed service. Existing SMS-only phone threads use SMS; known iMessage handles use iMessage; unknown handles try iMessage. For text-only direct phone sends, a failed iMessage attempt retries once over SMS unless `--no-sms-fallback` is set.
 - `imessage` — force iMessage. Fails fast if the recipient isn't on iMessage.
 - `sms` — force SMS relay. Requires Text Message Forwarding enabled on your iPhone for this Mac.
 
-For groups, omit `--service`. Group sends always use the chat's existing service.
+Fallback is intentionally narrow: it does not run for explicit `--service imessage`, `--service sms`, chat-target sends, email recipients, or attachment sends. For groups, omit `--service`. Group sends always use the chat's existing service.
 
 ## Region for phone normalization
 

--- a/docs/send.md
+++ b/docs/send.md
@@ -74,7 +74,7 @@ Fallback is intentionally narrow: it does not run for explicit `--service imessa
 imsg send --to "415-555-1212" --text "hi" --region US
 ```
 
-Defaults to `US`. Pass an ISO 3166-1 alpha-2 country code to normalize locally-formatted numbers.
+Defaults to `US`. Pass an ISO 3166-1 alpha-2 country code to normalize locally-formatted numbers. `--service auto` uses the same normalized phone number when checking local Messages history, so SMS-only history is detected for local-format numbers outside the US too.
 
 ## Confirming what was sent
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -51,7 +51,7 @@ Two possible causes:
 
 **Tahoe ghost-row failure (group sends).** On macOS 26, Messages.app sometimes reports AppleScript success while writing an empty unjoined SMS row instead of delivering. `imsg send` for chat-target sends already detects this and reports an error instead of `sent`. If you're still seeing silent failures with `--chat-id`/`--chat-identifier`/`--chat-guid`, make sure you're on `imsg` 0.6.0 or newer (`imsg --version`).
 
-**Service mismatch.** A send to a phone number with `--service imessage` fails fast if the recipient isn't on iMessage. With `--service sms`, Text Message Forwarding must be enabled on your iPhone for this Mac. With `--service auto`, Messages picks; this is the recommended default.
+**Service mismatch.** A send to a phone number with `--service imessage` fails fast if the recipient isn't on iMessage. With `--service sms`, Text Message Forwarding must be enabled on your iPhone for this Mac. With `--service auto`, `imsg` checks local history first; text-only direct phone sends may retry once over SMS unless `--no-sms-fallback` is set.
 
 ## `imsg watch` goes silent after a while
 


### PR DESCRIPTION
## Summary
- restore PR #132 via maintainer branch with hardened send service routing
- keep SMS fallback limited to auto, direct, text-only phone sends
- mirror CLI/RPC local service detection, including region-normalized numbers and exact SMS bridge lookup
- update README, send/troubleshooting docs, and changelog with @ranaroussi credit

## Proof
- autoreview clean on full branch against origin/main
- make lint
- make test
