### PR TITLE
fix: allow direct sends without Messages DB access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Send
 - feat: add SIP-free local iMessage/SMS service detection for direct `send --service auto`, with text-only iMessage-to-SMS fallback that never overrides explicit `--service` choices (#132, thanks @ranaroussi).
+- fix: keep direct `send --service auto` usable without Full Disk Access by treating local Messages history lookup as best-effort for direct recipients.
 
 ### Local Lookups
 - feat: add `--local` modes for `account`, `whois`, and `nickname` so common introspection can read local history or Contacts without launching the IMCore bridge (#132, thanks @ranaroussi).

--- a/Sources/imsg/Commands/SendCommand.swift
+++ b/Sources/imsg/Commands/SendCommand.swift
@@ -99,11 +99,19 @@ enum SendCommand {
     }
 
     let dbPath = values.option("db") ?? MessageStore.defaultPath
-    let store = try storeFactory(dbPath)
+    let store: MessageStore?
+    if input.hasChatTarget {
+      store = try storeFactory(dbPath)
+    } else {
+      store = try? storeFactory(dbPath)
+    }
 
     let resolvedTarget = try await ChatTargetResolver.resolveChatTarget(
       input: input,
       lookupChat: { chatID in
+        guard let store else {
+          throw IMsgError.invalidChatTarget("Messages database unavailable")
+        }
         return try store.chatInfo(chatID: chatID)
       },
       unknownChatError: { chatID in
@@ -115,7 +123,7 @@ enum SendCommand {
     }
 
     var effectiveService = service
-    if service == .auto && !input.hasChatTarget && !input.recipient.isEmpty {
+    if let store, service == .auto && !input.hasChatTarget && !input.recipient.isEmpty {
       switch resolveService(store, input.recipient, region) {
       case .imessage, .unknown:
         effectiveService = .auto
@@ -147,6 +155,9 @@ enum SendCommand {
 
     var sentMessage: Message?
     if input.hasChatTarget {
+      guard let store else {
+        throw IMsgError.invalidChatTarget("Messages database unavailable")
+      }
       let verificationChatID =
         input.chatID
         ?? resolvedTarget.preferredIdentifier.flatMap {

--- a/Tests/imsgTests/SendCommandServiceDetectionTests.swift
+++ b/Tests/imsgTests/SendCommandServiceDetectionTests.swift
@@ -6,6 +6,38 @@ import Testing
 @testable import IMsgCore
 @testable import imsg
 
+private enum SendCommandServiceDetectionTestError: Error {
+  case unavailable
+}
+
+@Test
+func sendCommandDirectSendDoesNotRequireMessagesDatabase() async throws {
+  let values = ParsedValues(
+    positional: [],
+    options: [
+      "to": ["+436769770569"],
+      "text": ["hi"],
+      "service": ["auto"],
+    ],
+    flags: []
+  )
+  let runtime = RuntimeOptions(parsedValues: values)
+  var captured: MessageSendOptions?
+  _ = try await StdoutCapture.capture {
+    try await SendCommand.run(
+      values: values,
+      runtime: runtime,
+      sendMessage: { options in captured = options },
+      resolveSentMessage: { _, _, _, _ in nil },
+      storeFactory: { _ in throw SendCommandServiceDetectionTestError.unavailable }
+    )
+  }
+
+  #expect(captured?.recipient == "+436769770569")
+  #expect(captured?.service == .auto)
+  #expect(captured?.allowSMSFallback == true)
+}
+
 @Test
 func sendCommandAutoDetectionUsesRegionNormalizedRecipient() async throws {
   let path = try CommandTestDatabase.makePath()

--- a/docs/send.md
+++ b/docs/send.md
@@ -62,7 +62,7 @@ imsg send --to "+14155551212" --text "hi" --service sms
 imsg send --to "+14155551212" --text "hi" --no-sms-fallback
 ```
 
-- `auto` — `imsg` first checks local Messages history for the handle's observed service. Existing SMS-only phone threads use SMS; known iMessage handles use iMessage; unknown handles try iMessage. For text-only direct phone sends, a failed iMessage attempt retries once over SMS unless `--no-sms-fallback` is set.
+- `auto` — `imsg` first checks local Messages history for the handle's observed service when `chat.db` is readable. Existing SMS-only phone threads use SMS; known iMessage handles use iMessage; unknown handles, or sessions without Full Disk Access, try iMessage. For text-only direct phone sends, a failed iMessage attempt retries once over SMS unless `--no-sms-fallback` is set.
 - `imessage` — force iMessage. Fails fast if the recipient isn't on iMessage.
 - `sms` — force SMS relay. Requires Text Message Forwarding enabled on your iPhone for this Mac.
 


### PR DESCRIPTION
## Summary
- keep direct `imsg send --service auto` working when `chat.db` is not readable
- make local service detection best-effort for direct recipients while preserving required DB access for chat-target sends
- document the Full Disk Access fallback behavior and add a regression test

## Proof
- autoreview clean
- live e2e: `swift run imsg send --to '+436769770569' --text 'imsg e2e test 2026-05-31T18:28:50Z' --service auto --region AT --json` -> `{"status":"sent"}`
- `make lint`
- `make test` (321 tests)
