### PR TITLE
fix: fail open on undetermined contacts auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.11.1 - Unreleased
 
+### Read Commands
+- fix: let `chats` and `history` run without prompting for Contacts when permission is still undecided, while preserving Contacts prompts for explicit name-resolution flows (#135, thanks @cemendes).
+
 ## 0.11.0 - 2026-05-31
 
 ### Send

--- a/Sources/IMsgCore/ContactResolver.swift
+++ b/Sources/IMsgCore/ContactResolver.swift
@@ -34,6 +34,11 @@ public final class NoOpContactResolver: ContactResolving, Sendable {
   public func searchByName(_ query: String) -> [ContactMatch] { [] }
 }
 
+public enum ContactsAccessPolicy: Sendable {
+  case requestIfNeeded
+  case skipIfNotDetermined
+}
+
 public final class ContactResolver: ContactResolving, @unchecked Sendable {
   #if os(macOS)
     private let phoneToName: [String: String]
@@ -60,28 +65,51 @@ public final class ContactResolver: ContactResolving, @unchecked Sendable {
     public let contactsUnavailable = true
   #endif
 
-  public static func create(region: String = "US") async -> any ContactResolving {
+  public static func create(
+    region: String = "US",
+    accessPolicy: ContactsAccessPolicy = .requestIfNeeded
+  ) async -> any ContactResolving {
     #if os(macOS)
       let store = CNContactStore()
-      switch CNContactStore.authorizationStatus(for: .contacts) {
+      return await create(
+        region: region,
+        accessPolicy: accessPolicy,
+        store: store,
+        authorizationStatus: CNContactStore.authorizationStatus(for: .contacts),
+        requestAccess: requestAccess(store:)
+      )
+    #else
+      _ = region
+      _ = accessPolicy
+      return NoOpContactResolver(contactsUnavailable: true)
+    #endif
+  }
+
+  #if os(macOS)
+    static func create(
+      region: String = "US",
+      accessPolicy: ContactsAccessPolicy = .requestIfNeeded,
+      store: CNContactStore,
+      authorizationStatus: CNAuthorizationStatus,
+      requestAccess: @escaping (CNContactStore) async -> Bool
+    ) async -> any ContactResolving {
+      switch authorizationStatus {
       case .authorized:
         return load(store: store, region: region)
       case .notDetermined:
-        // Do not block core CLI read paths on a permission request that may never
-        // resolve promptly in headless or non-app contexts. Commands like
-        // `imsg chats` and `imsg history` should still work without contact-name
-        // enrichment.
-        return NoOpContactResolver(contactsUnavailable: true)
+        guard accessPolicy == .requestIfNeeded else {
+          return NoOpContactResolver(contactsUnavailable: true)
+        }
+        let granted = await requestAccess(store)
+        return granted
+          ? load(store: store, region: region) : NoOpContactResolver(contactsUnavailable: true)
       case .denied, .restricted:
         return NoOpContactResolver(contactsUnavailable: true)
       @unknown default:
         return NoOpContactResolver(contactsUnavailable: true)
       }
-    #else
-      _ = region
-      return NoOpContactResolver(contactsUnavailable: true)
-    #endif
-  }
+    }
+  #endif
 
   public func displayName(for handle: String) -> String? {
     #if os(macOS)

--- a/Sources/IMsgCore/ContactResolver.swift
+++ b/Sources/IMsgCore/ContactResolver.swift
@@ -67,9 +67,11 @@ public final class ContactResolver: ContactResolving, @unchecked Sendable {
       case .authorized:
         return load(store: store, region: region)
       case .notDetermined:
-        let granted = await requestAccess(store: store)
-        return granted
-          ? load(store: store, region: region) : NoOpContactResolver(contactsUnavailable: true)
+        // Do not block core CLI read paths on a permission request that may never
+        // resolve promptly in headless or non-app contexts. Commands like
+        // `imsg chats` and `imsg history` should still work without contact-name
+        // enrichment.
+        return NoOpContactResolver(contactsUnavailable: true)
       case .denied, .restricted:
         return NoOpContactResolver(contactsUnavailable: true)
       @unknown default:

--- a/Sources/imsg/Commands/ChatsCommand.swift
+++ b/Sources/imsg/Commands/ChatsCommand.swift
@@ -26,7 +26,7 @@ enum ChatsCommand {
     values: ParsedValues,
     runtime: RuntimeOptions,
     contactResolverFactory: @escaping () async -> any ContactResolving = {
-      await ContactResolver.create()
+      await ContactResolver.create(accessPolicy: .skipIfNotDetermined)
     }
   ) async throws {
     let dbPath = values.option("db") ?? MessageStore.defaultPath

--- a/Sources/imsg/Commands/HistoryCommand.swift
+++ b/Sources/imsg/Commands/HistoryCommand.swift
@@ -41,7 +41,7 @@ enum HistoryCommand {
     values: ParsedValues,
     runtime: RuntimeOptions,
     contactResolverFactory: @escaping () async -> any ContactResolving = {
-      await ContactResolver.create()
+      await ContactResolver.create(accessPolicy: .skipIfNotDetermined)
     }
   ) async throws {
     guard let chatID = values.optionInt64("chatID") else {

--- a/Tests/IMsgCoreTests/ContactResolverTests.swift
+++ b/Tests/IMsgCoreTests/ContactResolverTests.swift
@@ -2,6 +2,10 @@ import Testing
 
 @testable import IMsgCore
 
+#if os(macOS)
+  @preconcurrency import Contacts
+#endif
+
 @Test
 func noOpContactResolverReturnsNoMatches() {
   let resolver = NoOpContactResolver()
@@ -16,3 +20,46 @@ func noOpContactResolverCanRepresentUnavailableContacts() {
   let resolver = NoOpContactResolver(contactsUnavailable: true)
   #expect(resolver.contactsUnavailable == true)
 }
+
+#if os(macOS)
+  private actor ContactAccessSpy {
+    private var requestCount = 0
+
+    func request(_ store: CNContactStore) async -> Bool {
+      _ = store
+      requestCount += 1
+      return false
+    }
+
+    func count() -> Int {
+      requestCount
+    }
+  }
+
+  @Test
+  func contactResolverSkipsPromptWhenContactsAreUndeterminedAndPolicyAllowsFailOpen() async {
+    let spy = ContactAccessSpy()
+    let resolver = await ContactResolver.create(
+      accessPolicy: .skipIfNotDetermined,
+      store: CNContactStore(),
+      authorizationStatus: .notDetermined,
+      requestAccess: { store in await spy.request(store) }
+    )
+
+    #expect(resolver.contactsUnavailable == true)
+    #expect(await spy.count() == 0)
+  }
+
+  @Test
+  func contactResolverStillRequestsAccessByDefaultWhenContactsAreUndetermined() async {
+    let spy = ContactAccessSpy()
+    let resolver = await ContactResolver.create(
+      store: CNContactStore(),
+      authorizationStatus: .notDetermined,
+      requestAccess: { store in await spy.request(store) }
+    )
+
+    #expect(resolver.contactsUnavailable == true)
+    #expect(await spy.count() == 1)
+  }
+#endif


### PR DESCRIPTION
## Summary

Avoid hanging `imsg chats` and `imsg history` when Contacts authorization is still `.notDetermined` in CLI usage.

## Root cause

`ContactResolver.create()` awaited `CNContactStore.requestAccess(for: .contacts)` whenever Contacts auth was undecided. In CLI/headless contexts that callback can fail to resolve promptly, so read commands that only need optional contact-name enrichment can appear to hang even after Messages DB work finished.

## Fix

- Add an explicit `ContactsAccessPolicy` with the existing default behavior preserved as `requestIfNeeded`.
- Use `skipIfNotDetermined` only for `chats` and `history`, so those read commands fail open without contact-name enrichment.
- Keep `send`, RPC, bridge intro, and other explicit contact/name-resolution paths on the default requesting resolver.
- Add resolver tests for both branches: skip policy does not request Contacts, default policy still does.
- Add an `0.11.1` changelog entry thanking @cemendes.

Closes #135.

## Verification

- `swift test --filter ContactResolver` passed: 4 tests.
- `swift test --filter 'ChatHistory|ContactResolver|sendCommandResolvesUniqueContactName|sendCommandRejectsAmbiguousContactName|accountNickname'` passed: 26 tests, including send/name-resolution coverage.
- `make build` passed and produced `bin/imsg` plus `bin/imsg-bridge-helper.dylib`; only existing helper deprecation warnings were emitted.
- Contacts status on this Mac was `.notDetermined` (`CNContactStore.authorizationStatus(for: .contacts).rawValue == 0`).
- Live proof under `.notDetermined`: `bin/imsg chats --limit 1 --json` returned within a 10s alarm; sanitized output showed one chat and no `contact_name` field.
- Live proof under `.notDetermined`: `bin/imsg history --chat-id <id> --limit 1 --json` returned within a 10s alarm; sanitized output showed one message and no `sender_name` field.
- `make lint` exited 0; repo has existing warning-level file length/line length violations, no serious findings.
- `make test` passed: 323 tests.

## Maintainer note

Local autoreview was attempted but the review engine returned empty output after a long-running child process was stopped, so it is not counted as proof here. The patch was manually reviewed against all `ContactResolver.create` call sites: only `chats` and `history` opt into no-prompt behavior; send/RPC/name paths still use the default requesting behavior.
