### PR TITLE
fix: render text formatting on the RPC `send` bridge path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.11.2 - Unreleased
 
+### Send
+- fix: thread attributed-text formatting through the RPC `send` bridge path, not just `send-rich`, so direct/handle sends render **bold**/*italic*/etc. on macOS 15+. `handleSend` now forwards format ranges to the bridge, accepting `formatting` (the key OpenClaw's `message` tool emits) alongside `text_formatting`/`textFormatting`.
+
 ## 0.11.1 - 2026-06-10
 
 ### Read Commands

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 0.11.2 - Unreleased
 
 ### Send
-- fix: thread attributed-text formatting through the RPC `send` bridge path, not just `send-rich`, so direct/handle sends render **bold**/*italic*/etc. on macOS 15+. `handleSend` now forwards format ranges to the bridge, accepting `formatting` (the key OpenClaw's `message` tool emits) alongside `text_formatting`/`textFormatting`.
+- fix: thread attributed-text formatting through the RPC `send` bridge path, not just `send-rich`, so direct/handle sends render **bold**/*italic*/etc. on macOS 15+. `handleSend` now forwards format ranges to the bridge, accepting `formatting` (the key OpenClaw's `message` tool emits) alongside `text_formatting`/`textFormatting` (#143, thanks @omarshahine).
 
 ## 0.11.1 - 2026-06-10
 

--- a/Sources/imsg/RPCServer+Handlers.swift
+++ b/Sources/imsg/RPCServer+Handlers.swift
@@ -167,6 +167,12 @@ extension RPCServer {
   func handleSend(params: [String: Any], id: Any?) async throws {
     let text = stringParam(params["text"]) ?? ""
     let file = stringParam(params["file"]) ?? ""
+    // Optional attributed-text formatting (bold/italic/…, macOS 15+). Only the
+    // IMCore bridge transport can render it; AppleScript sends stay plain.
+    // Accept `text_formatting`/`textFormatting` (matching `send-rich`) plus the
+    // bare `formatting` key that the OpenClaw gateway emits on its `send` calls.
+    let textFormatting =
+      params["text_formatting"] ?? params["textFormatting"] ?? params["formatting"]
     let serviceRaw = stringParam(params["service"]) ?? "auto"
     guard let service = MessageService(rawValue: serviceRaw) else {
       throw RPCError.invalidParams("invalid service")
@@ -262,7 +268,8 @@ extension RPCServer {
         let data = try await sendViaBridge(
           chatGUID: bridgeChatGUID,
           text: text,
-          file: file
+          file: file,
+          textFormatting: textFormatting
         )
         var result: [String: Any] = ["ok": true, "transport": "bridge"]
         if let guid = data["messageGuid"] as? String, !guid.isEmpty {
@@ -521,7 +528,8 @@ extension RPCServer {
   private func sendViaBridge(
     chatGUID: String,
     text: String,
-    file: String
+    file: String,
+    textFormatting: Any? = nil
   ) async throws -> [String: Any] {
     if !file.isEmpty {
       guard text.isEmpty else {
@@ -533,7 +541,11 @@ extension RPCServer {
         ["chatGuid": chatGUID, "filePath": stagedFile, "isAudioMessage": false]
       )
     }
-    return try await bridgeInvoker(.sendMessage, ["chatGuid": chatGUID, "message": text])
+    var messageParams: [String: Any] = ["chatGuid": chatGUID, "message": text]
+    if let textFormatting {
+      messageParams["textFormatting"] = textFormatting
+    }
+    return try await bridgeInvoker(.sendMessage, messageParams)
   }
 }
 

--- a/Tests/imsgTests/RPCServerBridgeTests.swift
+++ b/Tests/imsgTests/RPCServerBridgeTests.swift
@@ -41,6 +41,62 @@ func rpcSendUsesBridgeWhenReadyAndExistingDirectChatResolves() async throws {
 }
 
 @Test
+func rpcSendThreadsTextFormattingToBridge() async throws {
+  let store = try CommandTestDatabase.makeStoreForRPCDirectChat()
+  let output = TestRPCOutput()
+  var capturedParams: [String: Any] = [:]
+  let server = RPCServer(
+    store: store,
+    verbose: false,
+    output: output,
+    sendMessage: { _ in },
+    resolveSentMessage: { _, _, _, _ in nil },
+    invokeBridge: { _, params in
+      capturedParams = params
+      return ["messageGuid": "bridge-guid", "chatGuid": "iMessage;-;+123", "service": "iMessage"]
+    },
+    isBridgeReady: { true }
+  )
+
+  // The OpenClaw gateway emits format ranges under the bare `formatting` key.
+  let line = #"""
+    {"jsonrpc":"2.0","id":"3fmt","method":"send","params":{"to":"+123","text":"hello world","formatting":[{"start":0,"length":5,"styles":["bold"]}]}}
+    """#
+  await server.handleLineForTesting(line)
+
+  let ranges = capturedParams["textFormatting"] as? [[String: Any]]
+  #expect(ranges?.count == 1)
+  #expect(ranges?.first?["start"] as? Int == 0)
+  #expect(ranges?.first?["length"] as? Int == 5)
+  #expect(ranges?.first?["styles"] as? [String] == ["bold"])
+  #expect(capturedParams["message"] as? String == "hello world")
+}
+
+@Test
+func rpcSendWithoutFormattingOmitsTextFormatting() async throws {
+  let store = try CommandTestDatabase.makeStoreForRPCDirectChat()
+  let output = TestRPCOutput()
+  var capturedParams: [String: Any] = [:]
+  let server = RPCServer(
+    store: store,
+    verbose: false,
+    output: output,
+    sendMessage: { _ in },
+    resolveSentMessage: { _, _, _, _ in nil },
+    invokeBridge: { _, params in
+      capturedParams = params
+      return ["messageGuid": "bridge-guid", "chatGuid": "iMessage;-;+123", "service": "iMessage"]
+    },
+    isBridgeReady: { true }
+  )
+
+  let line = #"{"jsonrpc":"2.0","id":"3nofmt","method":"send","params":{"to":"+123","text":"yo"}}"#
+  await server.handleLineForTesting(line)
+
+  #expect(capturedParams["textFormatting"] == nil)
+}
+
+@Test
 func rpcSendAutoSMSDetectionKeepsAnyPrefixBridgeLookup() async throws {
   let store = try CommandTestDatabase.makeStoreForRPCDirectChat()
   try store.withConnection { db in


### PR DESCRIPTION
## Problem

`handleSend` (RPC method `send`) forwards `text` and `file` to the IMCore bridge but **never the attributed-text format ranges**. So direct/handle sends come through plain even on macOS 15+ — only `send-rich` (CLI) and the RPC `sendRich` handler honor formatting.

This bites the OpenClaw gateway: its `message` tool routes plain handle targets (`to: +1…`) through the `send` method and puts format ranges in a `formatting` param. imsg's `send` ignores it, so `**bold**`/`*italic*` notifications silently lose styling. Replies render correctly only because the gateway routes those through `sendRich`.

## Fix

Thread the format ranges through `handleSend` → `sendViaBridge` → the bridge `sendMessage` action, mirroring what `sendRich` already does. Accept `formatting` (the key OpenClaw's `message` tool emits) alongside `text_formatting`/`textFormatting` for parity with `handleSendRich`.

- Bridge transport only; AppleScript sends stay plain (attributed text needs the private API).
- No behavior change when no formatting is supplied.

## Tests

- `rpcSendThreadsTextFormattingToBridge` — asserts ranges from the `formatting` key reach `invokeBridge` as `textFormatting`.
- `rpcSendWithoutFormattingOmitsTextFormatting` — asserts no `textFormatting` key when none is supplied.

All `RPCServerBridge` tests pass (7/7, no regressions).

## End-to-end proof (real device, macOS 15+, IMCore bridge v2)

Same RPC `send` call — method `send`, bare `formatting` key, `transport: bridge`, same self-chat (`lobster@shahine.com`) — run through both binaries. Only the binary differs. Verified by reading back the `attributedBody` Messages persisted in `chat.db` and decoding the attribute runs.

**Request (identical except the binary that serves it):**
```json
{"method":"send","params":{"to":"lobster@shahine.com","transport":"bridge",
 "text":"… bold test …","formatting":[{"start":0,"length":N,"styles":["bold"]}]}}
```

**BEFORE — unfixed `/opt/homebrew/bin/imsg` (0.11.1):**
```
RPC response: {"ok":true,"transport":"bridge","guid":"546F64D8-…"}
chat.db attributedBody runs:
  range 0..<30 "BEFORE bold test (brew 0.11.1)"  style=(none)   ← formatting dropped, plain
```

**AFTER — this branch's release build (`bin/imsg`):**
```
RPC response: {"ok":true,"transport":"bridge","guid":"58A3EE57-…"}
chat.db attributedBody runs:
  range 0..<5  "AFTER"                    style=__kIMTextBoldAttributeName  ← bold applied
  range 5..<28 " bold test (branch fix)"  style=(none)
```

The unfixed `send` persists no bold attribute; the fixed `send` persists `__kIMTextBoldAttributeName` over exactly the requested range. `send-rich` already produced this; the fix brings the plain `send` path (the one OpenClaw's `message` tool uses for `to:` handle targets) to parity. (Lobster is a headless Mac, so this is decoded persisted styling rather than a UI screenshot.)
