### PR TITLE
fix: thread rpc send replies

### DIFF
--- a/Sources/IMsgHelper/IMsgInjected.m
+++ b/Sources/IMsgHelper/IMsgInjected.m
@@ -825,6 +825,7 @@ static NSDictionary* handleStatus(NSInteger requestId, NSDictionary *params) {
         @"read_available": @(hasRegistry),
         @"bridge_version": @2,
         @"v2_ready": @(rpcInboxTimer != nil),
+        @"attachment_metadata": @YES,
         @"selectors": selectors
     });
 }

--- a/Sources/imsg/RPCServer+Handlers.swift
+++ b/Sources/imsg/RPCServer+Handlers.swift
@@ -173,6 +173,9 @@ extension RPCServer {
     }
     let transport = try RPCSendTransport.parse(stringParam(params["transport"]))
     let region = stringParam(params["region"]) ?? "US"
+    let selectedMessageGuid = stringParam(
+      params["reply_to"] ?? params["replyTo"] ?? params["reply_to_guid"] ?? params["message_guid"]
+    ).flatMap { $0.isEmpty ? nil : $0 }
     let rawRecipient = stringParam(params["to"]) ?? ""
     let rawInput = ChatTargetInput(
       recipient: rawRecipient,
@@ -262,7 +265,8 @@ extension RPCServer {
         let data = try await sendViaBridge(
           chatGUID: bridgeChatGUID,
           text: text,
-          file: file
+          file: file,
+          selectedMessageGuid: selectedMessageGuid
         )
         var result: [String: Any] = ["ok": true, "transport": "bridge"]
         if let guid = data["messageGuid"] as? String, !guid.isEmpty {
@@ -278,16 +282,20 @@ extension RPCServer {
         respond(id: id, result: result)
         return
       } catch let err as RPCError {
-        if transport == .bridge {
+        if transport == .bridge || selectedMessageGuid != nil {
           throw err
         }
       } catch {
-        if transport == .bridge {
+        if transport == .bridge || selectedMessageGuid != nil {
           throw RPCError.internalError(String(describing: error))
         }
       }
     } else if transport == .bridge {
       throw RPCError.invalidParams("bridge transport requires an existing chat target")
+    } else if selectedMessageGuid != nil {
+      throw RPCError.invalidParams(
+        "reply_to requires bridge transport; AppleScript fallback cannot send threaded replies"
+      )
     }
 
     try sendMessage(options)
@@ -521,19 +529,27 @@ extension RPCServer {
   private func sendViaBridge(
     chatGUID: String,
     text: String,
-    file: String
+    file: String,
+    selectedMessageGuid: String? = nil
   ) async throws -> [String: Any] {
     if !file.isEmpty {
       guard text.isEmpty else {
         throw RPCError.invalidParams("bridge transport does not support text and file together")
       }
       let stagedFile = try stageAttachment(file)
-      return try await bridgeInvoker(
-        .sendAttachment,
-        ["chatGuid": chatGUID, "filePath": stagedFile, "isAudioMessage": false]
-      )
+      var params: [String: Any] = [
+        "chatGuid": chatGUID, "filePath": stagedFile, "isAudioMessage": false,
+      ]
+      if let selectedMessageGuid {
+        params["selectedMessageGuid"] = selectedMessageGuid
+      }
+      return try await bridgeInvoker(.sendAttachment, params)
     }
-    return try await bridgeInvoker(.sendMessage, ["chatGuid": chatGUID, "message": text])
+    var params: [String: Any] = ["chatGuid": chatGUID, "message": text]
+    if let selectedMessageGuid {
+      params["selectedMessageGuid"] = selectedMessageGuid
+    }
+    return try await bridgeInvoker(.sendMessage, params)
   }
 }
 

--- a/Sources/imsg/RPCServer+Handlers.swift
+++ b/Sources/imsg/RPCServer+Handlers.swift
@@ -533,35 +533,6 @@ extension RPCServer {
     return nil
   }
 
-  private func sendViaBridge(
-    chatGUID: String,
-    text: String,
-    file: String,
-    selectedMessageGuid: String? = nil,
-    textFormatting: Any? = nil
-  ) async throws -> [String: Any] {
-    if !file.isEmpty {
-      guard text.isEmpty else {
-        throw RPCError.invalidParams("bridge transport does not support text and file together")
-      }
-      let stagedFile = try stageAttachment(file)
-      var params: [String: Any] = [
-        "chatGuid": chatGUID, "filePath": stagedFile, "isAudioMessage": false,
-      ]
-      if let selectedMessageGuid {
-        params["selectedMessageGuid"] = selectedMessageGuid
-      }
-      return try await bridgeInvoker(.sendAttachment, params)
-    }
-    var params: [String: Any] = ["chatGuid": chatGUID, "message": text]
-    if let selectedMessageGuid {
-      params["selectedMessageGuid"] = selectedMessageGuid
-    }
-    if let textFormatting {
-      params["textFormatting"] = textFormatting
-    }
-    return try await bridgeInvoker(.sendMessage, params)
-  }
 }
 
 func buildMessagePayload(

--- a/Sources/imsg/RPCServer+Support.swift
+++ b/Sources/imsg/RPCServer+Support.swift
@@ -121,3 +121,48 @@ actor ChatCache {
     return participants
   }
 }
+
+extension RPCServer {
+  func sendViaBridge(
+    chatGUID: String,
+    text: String,
+    file: String,
+    selectedMessageGuid: String? = nil,
+    textFormatting: Any? = nil
+  ) async throws -> [String: Any] {
+    if !file.isEmpty {
+      let requiresMetadata = !text.isEmpty || selectedMessageGuid != nil || textFormatting != nil
+      if requiresMetadata {
+        let status = try await bridgeInvoker(.status, [:])
+        guard status["attachment_metadata"] as? Bool == true else {
+          throw RPCError.internalError(
+            "running bridge does not support captioned or threaded attachments; "
+              + "restart Messages with the current imsg bridge"
+          )
+        }
+      }
+      let stagedFile = try stageAttachment(file)
+      var params: [String: Any] = [
+        "chatGuid": chatGUID, "filePath": stagedFile, "isAudioMessage": false,
+      ]
+      if !text.isEmpty {
+        params["message"] = text
+      }
+      if let selectedMessageGuid {
+        params["selectedMessageGuid"] = selectedMessageGuid
+      }
+      if let textFormatting {
+        params["textFormatting"] = textFormatting
+      }
+      return try await bridgeInvoker(.sendAttachment, params)
+    }
+    var params: [String: Any] = ["chatGuid": chatGUID, "message": text]
+    if let selectedMessageGuid {
+      params["selectedMessageGuid"] = selectedMessageGuid
+    }
+    if let textFormatting {
+      params["textFormatting"] = textFormatting
+    }
+    return try await bridgeInvoker(.sendMessage, params)
+  }
+}

--- a/Tests/imsgTests/RPCServerBridgeTests.swift
+++ b/Tests/imsgTests/RPCServerBridgeTests.swift
@@ -78,6 +78,95 @@ func rpcSendForwardsReplyTargetAliasesToBridge() async throws {
 }
 
 @Test
+func rpcSendForwardsCaptionedAttachmentReplyToBridge() async throws {
+  let store = try CommandTestDatabase.makeStoreForRPCDirectChat()
+  let output = TestRPCOutput()
+  var appleScriptCalled = false
+  var capturedActions: [BridgeAction] = []
+  var capturedParams: [String: Any] = [:]
+  let server = RPCServer(
+    store: store,
+    verbose: false,
+    output: output,
+    sendMessage: { _ in appleScriptCalled = true },
+    resolveSentMessage: { _, _, _, _ in nil },
+    invokeBridge: { action, params in
+      capturedActions.append(action)
+      if action == .status {
+        return ["attachment_metadata": true]
+      }
+      capturedParams = params
+      return ["messageGuid": "bridge-guid"]
+    },
+    stageAttachment: { _ in "/tmp/staged-photo.jpg" },
+    isBridgeReady: { true }
+  )
+
+  let line = #"""
+    {
+      "jsonrpc": "2.0",
+      "id": "captioned-reply",
+      "method": "send",
+      "params": {
+        "to": "+123",
+        "text": "caption",
+        "file": "photo.jpg",
+        "reply_to": "parent-guid",
+        "formatting": [{"start": 0, "length": 7, "styles": ["italic"]}]
+      }
+    }
+    """#
+  await server.handleLineForTesting(line)
+
+  #expect(appleScriptCalled == false)
+  #expect(capturedActions == [.status, .sendAttachment])
+  #expect(capturedParams["chatGuid"] as? String == "iMessage;-;+123")
+  #expect(capturedParams["filePath"] as? String == "/tmp/staged-photo.jpg")
+  #expect(capturedParams["message"] as? String == "caption")
+  #expect(capturedParams["selectedMessageGuid"] as? String == "parent-guid")
+  let ranges = capturedParams["textFormatting"] as? [[String: Any]]
+  #expect(ranges?.first?["styles"] as? [String] == ["italic"])
+  let result = output.responses.first?["result"] as? [String: Any]
+  #expect(result?["transport"] as? String == "bridge")
+  #expect(result?["guid"] as? String == "bridge-guid")
+}
+
+@Test
+func rpcSendReplyAttachmentRejectsStaleBridge() async throws {
+  let store = try CommandTestDatabase.makeStoreForRPCDirectChat()
+  let output = TestRPCOutput()
+  var appleScriptCalled = false
+  var capturedActions: [BridgeAction] = []
+  let server = RPCServer(
+    store: store,
+    verbose: false,
+    output: output,
+    sendMessage: { _ in appleScriptCalled = true },
+    resolveSentMessage: { _, _, _, _ in nil },
+    invokeBridge: { action, _ in
+      capturedActions.append(action)
+      return action == .status ? ["bridge_version": 2] : ["messageGuid": "bridge-guid"]
+    },
+    stageAttachment: { _ in "/tmp/staged-photo.jpg" },
+    isBridgeReady: { true }
+  )
+
+  let line = #"""
+    {"jsonrpc":"2.0","id":"stale-reply","method":"send","params":{"to":"+123","file":"photo.jpg","reply_to":"parent-guid"}}
+    """#
+  await server.handleLineForTesting(line)
+
+  #expect(appleScriptCalled == false)
+  #expect(capturedActions == [.status])
+  #expect(output.responses.isEmpty)
+  let error = output.errors.first?["error"] as? [String: Any]
+  #expect(
+    error?["data"] as? String
+      == "running bridge does not support captioned or threaded attachments; restart Messages with the current imsg bridge"
+  )
+}
+
+@Test
 func rpcSendThreadsTextFormattingToBridge() async throws {
   let store = try CommandTestDatabase.makeStoreForRPCDirectChat()
   let output = TestRPCOutput()

--- a/Tests/imsgTests/RPCServerBridgeTests.swift
+++ b/Tests/imsgTests/RPCServerBridgeTests.swift
@@ -41,6 +41,43 @@ func rpcSendUsesBridgeWhenReadyAndExistingDirectChatResolves() async throws {
 }
 
 @Test
+func rpcSendForwardsReplyTargetAliasesToBridge() async throws {
+  for alias in ["reply_to", "replyTo", "reply_to_guid", "message_guid"] {
+    let store = try CommandTestDatabase.makeStoreForRPCDirectChat()
+    let output = TestRPCOutput()
+    var appleScriptCalled = false
+    var capturedAction: BridgeAction?
+    var capturedParams: [String: Any] = [:]
+    let server = RPCServer(
+      store: store,
+      verbose: false,
+      output: output,
+      sendMessage: { _ in appleScriptCalled = true },
+      resolveSentMessage: { _, _, _, _ in nil },
+      invokeBridge: { action, params in
+        capturedAction = action
+        capturedParams = params
+        return ["messageGuid": "bridge-guid"]
+      },
+      isBridgeReady: { true }
+    )
+
+    let line =
+      #"{"jsonrpc":"2.0","id":"send-\#(alias)","method":"send","params":{"to":"+123","text":"yo","\#(alias)":"parent-guid"}}"#
+    await server.handleLineForTesting(line)
+
+    #expect(appleScriptCalled == false)
+    #expect(capturedAction == .sendMessage)
+    #expect(capturedParams["chatGuid"] as? String == "iMessage;-;+123")
+    #expect(capturedParams["message"] as? String == "yo")
+    #expect(capturedParams["selectedMessageGuid"] as? String == "parent-guid")
+    let result = output.responses.first?["result"] as? [String: Any]
+    #expect(result?["transport"] as? String == "bridge")
+    #expect(result?["guid"] as? String == "bridge-guid")
+  }
+}
+
+@Test
 func rpcSendAutoSMSDetectionKeepsAnyPrefixBridgeLookup() async throws {
   let store = try CommandTestDatabase.makeStoreForRPCDirectChat()
   try store.withConnection { db in
@@ -150,6 +187,68 @@ func rpcSendFallsBackToAppleScriptWhenAutoBridgeFails() async throws {
   #expect(result?["transport"] as? String == "applescript")
   #expect(result?["chat_guid"] as? String == "iMessage;-;+123")
   #expect(result?["service"] as? String == "iMessage")
+}
+
+@Test
+func rpcSendReplyTargetRejectsAppleScriptFallbackWhenBridgeUnavailable() async throws {
+  let store = try CommandTestDatabase.makeStoreForRPCDirectChat()
+  let output = TestRPCOutput()
+  var appleScriptCalled = false
+  var bridgeCalled = false
+  let server = RPCServer(
+    store: store,
+    verbose: false,
+    output: output,
+    sendMessage: { _ in appleScriptCalled = true },
+    resolveSentMessage: { _, _, _, _ in nil },
+    invokeBridge: { _, _ in
+      bridgeCalled = true
+      return [:]
+    },
+    isBridgeReady: { false }
+  )
+
+  let line =
+    #"{"jsonrpc":"2.0","id":"reply-no-bridge","method":"send","params":{"to":"+123","text":"yo","reply_to":"parent-guid"}}"#
+  await server.handleLineForTesting(line)
+
+  #expect(appleScriptCalled == false)
+  #expect(bridgeCalled == false)
+  #expect(output.responses.isEmpty)
+  let error = output.errors.first?["error"] as? [String: Any]
+  #expect(
+    error?["data"] as? String
+      == "reply_to requires bridge transport; AppleScript fallback cannot send threaded replies")
+}
+
+@Test
+func rpcSendReplyTargetDoesNotFallbackToAppleScriptWhenBridgeFails() async throws {
+  let store = try CommandTestDatabase.makeStoreForRPCDirectChat()
+  let output = TestRPCOutput()
+  var appleScriptCalled = false
+  var bridgeCalled = false
+  let server = RPCServer(
+    store: store,
+    verbose: false,
+    output: output,
+    sendMessage: { _ in appleScriptCalled = true },
+    resolveSentMessage: { _, _, _, _ in nil },
+    invokeBridge: { _, _ in
+      bridgeCalled = true
+      throw IMsgBridgeError.dylibReturnedError("bridge unavailable")
+    },
+    isBridgeReady: { true }
+  )
+
+  let line =
+    #"{"jsonrpc":"2.0","id":"reply-bridge-fails","method":"send","params":{"to":"+123","text":"yo","reply_to":"parent-guid"}}"#
+  await server.handleLineForTesting(line)
+
+  #expect(appleScriptCalled == false)
+  #expect(bridgeCalled == true)
+  #expect(output.responses.isEmpty)
+  let error = output.errors.first?["error"] as? [String: Any]
+  #expect((error?["data"] as? String)?.contains("bridge unavailable") == true)
 }
 
 @Test


### PR DESCRIPTION
Closes #144.

Plain RPC `send` now forwards reply target aliases into the bridge `selectedMessageGuid` payload, matching `send.rich` behavior.

Reply-target sends now fail instead of falling back to unthreaded AppleScript delivery when the bridge is unavailable or fails.

Proof note: on a macOS arm64 branch-built `imsg` with SIP enabled and no bridge helper (`bridge_version: 0`), RPC `send` with `reply_to` returns `Invalid params: reply_to requires bridge transport; AppleScript fallback cannot send threaded replies`, so the no-bridge path fails before AppleScript delivery. Positive threaded-send proof has been requested from Mantis because this local machine cannot inject the bridge.

Verified with focused RPC bridge coverage plus the full test and lint gates.
