### PR TITLE
feat(poll): cast votes on native Messages polls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Send
 - fix: thread attributed-text formatting through the RPC `send` bridge path, not just `send-rich`, so direct/handle sends render **bold**/*italic*/etc. on macOS 15+. `handleSend` now forwards format ranges to the bridge, accepting `formatting` (the key OpenClaw's `message` tool emits) alongside `text_formatting`/`textFormatting` (#143, thanks @omarshahine).
+- feat: add bridge-backed native poll voting through `imsg poll vote`, `poll.vote`, and `messages.poll.vote` (#148, thanks @omarshahine).
 
 ## 0.11.1 - 2026-06-10
 

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Advanced IMCore (require `imsg launch` with SIP off — see
   `imsg send-multipart`, `imsg send-attachment [--reply-to <guid>]`,
   `imsg tapback`
 - `imsg poll send (--chat <guid> | --chat-id <id>) --question <text> --option <text> --option <text> [--reply-to <guid>]`
+- `imsg poll vote (--chat <guid> | --chat-id <id>) --poll <guid> (--option-id <id> | --option-index <n> | --option <text>)`
 - `imsg edit`, `imsg unsend`, `imsg delete-message`, `imsg notify-anyways`
 - `imsg chat-create`, `imsg chat-name`, `imsg chat-photo`,
   `imsg chat-add-member`, `imsg chat-remove-member`, `imsg chat-leave`,

--- a/README.md
+++ b/README.md
@@ -136,6 +136,10 @@ Advanced IMCore (require `imsg launch` with SIP off — see
   `imsg chat-delete`, `imsg chat-mark`
 - `imsg account`, `imsg whois`, `imsg nickname`
 
+`imsg status --json` reports native bridge selector capabilities. Poll creation
+requires `selectors.pollPayloadMessage`; poll voting requires
+`selectors.pollVoteMessage` plus `poll.vote` in `rpc_methods`.
+
 `react` intentionally sends only the standard tapbacks Messages.app exposes
 reliably through automation. Custom emoji tapbacks can be read from
 history/watch output, but are sent through the bridge `tapback` command.

--- a/Sources/IMsgCore/IMsgBridgeProtocol.swift
+++ b/Sources/IMsgCore/IMsgBridgeProtocol.swift
@@ -31,8 +31,8 @@ public enum IMsgBridgeProtocol {
 
   public static func defaultResponseTimeout(for action: BridgeAction) -> TimeInterval {
     switch action {
-    case .sendMessage, .sendMultipart, .sendAttachment, .sendPoll, .sendReaction,
-      .createChat:
+    case .sendMessage, .sendMultipart, .sendAttachment, .sendPoll, .sendPollVote,
+      .sendReaction, .createChat:
       return defaultSendResponseTimeout
     default:
       return defaultResponseTimeout
@@ -65,6 +65,7 @@ public enum BridgeAction: String, Sendable, CaseIterable {
   case sendMultipart = "send-multipart"
   case sendAttachment = "send-attachment"
   case sendPoll = "send-poll"
+  case sendPollVote = "send-poll-vote"
   case sendReaction = "send-reaction"
   case notifyAnyways = "notify-anyways"
 

--- a/Sources/IMsgCore/MessageStore+Polls.swift
+++ b/Sources/IMsgCore/MessageStore+Polls.swift
@@ -31,18 +31,7 @@ extension MessageStore {
     let target = normalized.isEmpty ? guid : normalized
     guard !target.isEmpty else { return [] }
     return try withConnection { db in
-      let selection = MessageRowSelection(store: self, includeChatID: false)
-      let sql = """
-        SELECT \(selection.selectList)
-        FROM message m
-        LEFT JOIN handle h ON m.handle_id = h.ROWID
-        WHERE m.guid = ?
-        LIMIT 1
-        """
-      let rows = try db.prepareRowIterator(sql, bindings: [target])
-      guard let row = try rows.failableNext() else { return [] }
-      let decoded = try decodeMessageRow(row, columns: selection.columns, fallbackChatID: nil)
-      return decoded.poll?.options ?? []
+      try decodedPollOptions(guid: target, db: db)
     }
   }
 
@@ -58,25 +47,8 @@ extension MessageStore {
       return [:]
     }
 
-    let selection = MessageRowSelection(store: self, includeChatID: false)
-    let sql = """
-      SELECT \(selection.selectList)
-      FROM message m
-      LEFT JOIN handle h ON m.handle_id = h.ROWID
-      WHERE m.guid = ?
-      LIMIT 1
-      """
-    let rows = try db.prepareRowIterator(sql, bindings: [pollGUID])
-    guard let row = try rows.failableNext() else {
-      cache.missingPollGUIDs.insert(pollGUID)
-      return [:]
-    }
-    let decoded = try decodeMessageRow(
-      row,
-      columns: selection.columns,
-      fallbackChatID: nil
-    )
-    guard let options = decoded.poll?.options, !options.isEmpty else {
+    let options = try decodedPollOptions(guid: pollGUID, db: db)
+    guard !options.isEmpty else {
       cache.missingPollGUIDs.insert(pollGUID)
       return [:]
     }
@@ -87,5 +59,24 @@ extension MessageStore {
     }
     cache.optionsByPollGUID[pollGUID] = optionTexts
     return optionTexts
+  }
+
+  private func decodedPollOptions(guid: String, db: Connection) throws -> [MessagePollOption] {
+    let selection = MessageRowSelection(store: self, includeChatID: false)
+    let sql = """
+      SELECT \(selection.selectList)
+      FROM message m
+      LEFT JOIN handle h ON m.handle_id = h.ROWID
+      WHERE m.guid = ?
+      LIMIT 1
+      """
+    let rows = try db.prepareRowIterator(sql, bindings: [guid])
+    guard let row = try rows.failableNext() else { return [] }
+    let decoded = try decodeMessageRow(
+      row,
+      columns: selection.columns,
+      fallbackChatID: nil
+    )
+    return decoded.poll?.options ?? []
   }
 }

--- a/Sources/IMsgCore/MessageStore+Polls.swift
+++ b/Sources/IMsgCore/MessageStore+Polls.swift
@@ -23,6 +23,29 @@ extension MessageStore {
     return poll.resolvingVoteOptionTexts(optionTexts)
   }
 
+  /// Ordered options of the poll identified by `guid`, decoded from its
+  /// creation message. Used by `poll vote` to resolve a 1-based option index
+  /// or option text into the stable optionIdentifier the bridge needs.
+  public func pollOptions(guid: String) throws -> [MessagePollOption] {
+    let normalized = normalizeAssociatedGUID(guid)
+    let target = normalized.isEmpty ? guid : normalized
+    guard !target.isEmpty else { return [] }
+    return try withConnection { db in
+      let selection = MessageRowSelection(store: self, includeChatID: false)
+      let sql = """
+        SELECT \(selection.selectList)
+        FROM message m
+        LEFT JOIN handle h ON m.handle_id = h.ROWID
+        WHERE m.guid = ?
+        LIMIT 1
+        """
+      let rows = try db.prepareRowIterator(sql, bindings: [target])
+      guard let row = try rows.failableNext() else { return [] }
+      let decoded = try decodeMessageRow(row, columns: selection.columns, fallbackChatID: nil)
+      return decoded.poll?.options ?? []
+    }
+  }
+
   private func pollOptionTextsByID(
     pollGUID: String,
     db: Connection,

--- a/Sources/IMsgHelper/IMsgInjected.m
+++ b/Sources/IMsgHelper/IMsgInjected.m
@@ -1639,6 +1639,12 @@ static BOOL pollPayloadMessageInitializerAvailable(void) {
     return messageClass && [messageClass instancesRespondToSelector:sel];
 }
 
+static BOOL pollVoteMessageInitializerAvailable(void) {
+    Class messageClass = NSClassFromString(@"IMMessage");
+    SEL sel = @selector(initWithSender:time:text:messageSubject:fileTransferGUIDs:flags:error:guid:subject:associatedMessageGUID:associatedMessageType:associatedMessageRange:messageSummaryInfo:);
+    return messageClass && [messageClass instancesRespondToSelector:sel];
+}
+
 static NSString *trimmedPollString(id value) {
     if (![value isKindOfClass:[NSString class]]) return nil;
     NSString *trimmed = [(NSString *)value stringByTrimmingCharactersInSet:
@@ -2767,6 +2773,10 @@ static NSData *buildPollVotePayloadData(NSString *optionIdentifier,
         if (outError) *outError = jsonError.localizedDescription ?: @"Could not encode vote payload";
         return nil;
     }
+    if (jsonData.length > 4096) {
+        if (outError) *outError = @"Poll vote payload exceeds 4096 bytes";
+        return nil;
+    }
     NSString *encoded = [jsonData base64EncodedStringWithOptions:0];
     NSString *urlString = [NSString stringWithFormat:@"data:,%@", encoded];
     NSURL *url = [NSURL URLWithString:urlString];
@@ -2788,13 +2798,9 @@ static NSData *buildPollVotePayloadData(NSString *optionIdentifier,
 /// 4000. Native votes (verified against chat.db) use a bare poll GUID, not the
 /// `p:<part>/<guid>` form tapbacks use.
 ///
-/// A vote is the one message that needs balloon + payload AND an associated
-/// message atomically. The IMMessageItem-first path can't persist associated
-/// fields through the IMMessage wrap (see buildIMMessage), and the macOS 26
-/// 13-arg reaction initializer has no balloonBundleID/payloadData slots. The
-/// legacy `initIMMessageWith…` 17-arg initializer is the only one exposing
-/// balloon, payload, and association together, so votes use it directly — the
-/// same family as the working poll-send balloon path.
+/// The associated-message initializer persists the poll link atomically. Its
+/// backing item then receives the balloon payload; wrapping an item first loses
+/// the association on macOS 26.
 static id buildPollVoteIMMessage(NSAttributedString *body,
                                  NSData *payloadData,
                                  NSDictionary *summaryInfo,
@@ -2844,9 +2850,8 @@ static id buildPollVoteIMMessage(NSAttributedString *body,
     id result = invokeReturningObject(inv);
     if (!result) return nil;
 
-    // Stamp the balloon payload onto the message's backing item. Try the
-    // message directly first (some IMMessage builds forward these), then the
-    // underlying item.
+    // Both values must land on one object. A partial stamp can emit an
+    // associated message that Messages cannot decode as a poll vote.
     NSString *balloonID = pollsBalloonBundleIdentifier();
     NSArray<id> *targets = @[result];
     SEL itemSel = NSSelectorFromString(@"_imMessageItem");
@@ -2857,14 +2862,13 @@ static id buildPollVoteIMMessage(NSAttributedString *body,
         } @catch (__unused NSException *e) {}
     }
     for (id target in targets) {
-        if ([target respondsToSelector:@selector(setBalloonBundleID:)]) {
-            [target performSelector:@selector(setBalloonBundleID:) withObject:balloonID];
-        }
-        if ([target respondsToSelector:@selector(setPayloadData:)]) {
-            [target performSelector:@selector(setPayloadData:) withObject:payloadData];
-        }
+        if (![target respondsToSelector:@selector(setBalloonBundleID:)]
+            || ![target respondsToSelector:@selector(setPayloadData:)]) continue;
+        [target performSelector:@selector(setBalloonBundleID:) withObject:balloonID];
+        [target performSelector:@selector(setPayloadData:) withObject:payloadData];
+        return result;
     }
-    return result;
+    return nil;
 }
 
 /// `send-poll-vote`: cast a vote on an existing poll. Builds a Polls balloon
@@ -2876,13 +2880,12 @@ static NSDictionary *handleSendPollVote(NSInteger requestId, NSDictionary *param
     NSString *pollMessageGuid = trimmedPollString(params[@"pollMessageGuid"]);
     NSString *optionIdentifier = trimmedPollString(params[@"optionIdentifier"]);
     NSString *optionText = trimmedPollString(params[@"optionText"]);
-    NSString *voterHandle = trimmedPollString(params[@"voterHandle"]);
 
     if (!chatGuid.length) return errorResponse(requestId, @"Missing chatGuid");
     if (!pollMessageGuid.length) return errorResponse(requestId, @"Missing pollMessageGuid");
     if (!optionIdentifier.length) return errorResponse(requestId, @"Missing optionIdentifier");
-    if (!pollPayloadMessageInitializerAvailable()) {
-        return errorResponse(requestId, @"Poll IMMessage initializer unavailable on this macOS");
+    if (!pollVoteMessageInitializerAvailable()) {
+        return errorResponse(requestId, @"Poll vote IMMessage initializer unavailable on this macOS");
     }
 
     IMChat *chat = resolveChatByGuid(chatGuid);
@@ -2891,9 +2894,7 @@ static NSDictionary *handleSendPollVote(NSInteger requestId, NSDictionary *param
             [NSString stringWithFormat:@"Chat not found: %@", chatGuid]);
     }
 
-    if (!voterHandle.length) {
-        voterHandle = activeIMessageSenderHandle();
-    }
+    NSString *voterHandle = activeIMessageSenderHandle();
     if (!voterHandle.length) {
         return errorResponse(requestId,
             @"Could not resolve active iMessage sender handle for vote payload");

--- a/Sources/IMsgHelper/IMsgInjected.m
+++ b/Sources/IMsgHelper/IMsgInjected.m
@@ -208,6 +208,7 @@ static BOOL gHasRetractMessagePart = NO;     // retractMessagePart:
 static BOOL gHasSendMessageReason = NO;      // sendMessage:reason:
 
 static BOOL pollPayloadMessageInitializerAvailable(void);
+static BOOL pollVoteMessageInitializerAvailable(void);
 
 static void probeSelectors(void) {
     Class chatClass = NSClassFromString(@"IMChat");
@@ -812,7 +813,8 @@ static NSDictionary* handleStatus(NSInteger requestId, NSDictionary *params) {
         @"editMessage": @(gHasEditMessage),
         @"retractMessagePart": @(gHasRetractMessagePart),
         @"sendMessageReason": @(gHasSendMessageReason),
-        @"pollPayloadMessage": @(pollPayloadMessageInitializerAvailable())
+        @"pollPayloadMessage": @(pollPayloadMessageInitializerAvailable()),
+        @"pollVoteMessage": @(pollVoteMessageInitializerAvailable())
     };
 
     return successResponse(requestId, @{

--- a/Sources/IMsgHelper/IMsgInjected.m
+++ b/Sources/IMsgHelper/IMsgInjected.m
@@ -2745,6 +2745,191 @@ static NSDictionary *handleSendPoll(NSInteger requestId, NSDictionary *params) {
     }
 }
 
+/// Build the vote payload: a data URL carrying the vote JSON, wrapped in the
+/// same archived envelope as poll creation. Mirrors Apple's native vote shape
+/// (verified against a real received vote): {"version":1,"item":{"votes":
+/// [{"voteOptionIdentifier":...,"participantHandle":...}]}}. Unlike poll
+/// creation the data URL carries no `?src=p&c=` suffix.
+static NSData *buildPollVotePayloadData(NSString *optionIdentifier,
+                                        NSString *voterHandle,
+                                        NSString **outError) {
+    NSDictionary *vote = @{
+        @"voteOptionIdentifier": optionIdentifier,
+        @"participantHandle": voterHandle ?: @""
+    };
+    NSDictionary *root = @{
+        @"version": @1,
+        @"item": @{ @"votes": @[vote] }
+    };
+    NSError *jsonError = nil;
+    NSData *jsonData = [NSJSONSerialization dataWithJSONObject:root options:0 error:&jsonError];
+    if (!jsonData) {
+        if (outError) *outError = jsonError.localizedDescription ?: @"Could not encode vote payload";
+        return nil;
+    }
+    NSString *encoded = [jsonData base64EncodedStringWithOptions:0];
+    NSString *urlString = [NSString stringWithFormat:@"data:,%@", encoded];
+    NSURL *url = [NSURL URLWithString:urlString];
+    if (!url) {
+        if (outError) *outError = @"Could not create vote URL";
+        return nil;
+    }
+    NSUUID *sessionIdentifier = [NSUUID UUID];
+    NSError *archiveError = nil;
+    NSData *payload = archivePollPayloadEnvelope(url, sessionIdentifier, &archiveError);
+    if (!payload && outError) {
+        *outError = archiveError.localizedDescription ?: @"Could not archive vote payload";
+    }
+    return payload;
+}
+
+/// Construct a poll-vote IMMessage: a Polls balloon carrying the vote payload,
+/// associated to the original poll via a bare poll GUID + associatedMessageType
+/// 4000. Native votes (verified against chat.db) use a bare poll GUID, not the
+/// `p:<part>/<guid>` form tapbacks use.
+///
+/// A vote is the one message that needs balloon + payload AND an associated
+/// message atomically. The IMMessageItem-first path can't persist associated
+/// fields through the IMMessage wrap (see buildIMMessage), and the macOS 26
+/// 13-arg reaction initializer has no balloonBundleID/payloadData slots. The
+/// legacy `initIMMessageWith…` 17-arg initializer is the only one exposing
+/// balloon, payload, and association together, so votes use it directly — the
+/// same family as the working poll-send balloon path.
+static id buildPollVoteIMMessage(NSAttributedString *body,
+                                 NSData *payloadData,
+                                 NSDictionary *summaryInfo,
+                                 NSString *pollMessageGuid) {
+    Class messageClass = NSClassFromString(@"IMMessage");
+    if (!messageClass) return nil;
+
+    // No macOS 26 IMMessage initializer carries balloon + payload AND
+    // association together (verified by selector probe). Reactions prove the
+    // associated-message initializer persists association atomically, and
+    // balloon/payload set on the backing IMMessageItem persist (verified: an
+    // earlier item-first vote landed with the balloon intact, only the
+    // association — set via the wrap — was lost). So: init with association
+    // atomically, then stamp balloonBundleID + payloadData onto the message's
+    // own backing item (a real item from a direct init, not the transient one
+    // the messageFromIMMessageItem: wrap returns).
+    SEL sel = @selector(initWithSender:time:text:messageSubject:fileTransferGUIDs:flags:error:guid:subject:associatedMessageGUID:associatedMessageType:associatedMessageRange:messageSummaryInfo:);
+    if (![messageClass instancesRespondToSelector:sel]) return nil;
+
+    id msg = [messageClass alloc];
+    NSMethodSignature *sig = [messageClass instanceMethodSignatureForSelector:sel];
+    NSInvocation *inv = [NSInvocation invocationWithMethodSignature:sig];
+    [inv setSelector:sel];
+    [inv setTarget:msg];
+
+    id nilObj = nil;
+    NSDate *now = [NSDate date];
+    NSArray *fileTransferGuids = @[];
+    unsigned long long flags = flagsForAssociatedMessagePayload(nil, fileTransferGuids, NO);
+    long long associatedType = 4000;
+    NSRange associatedRange = NSMakeRange(0, 1);
+
+    [inv setArgument:&nilObj atIndex:2];            // sender
+    [inv setArgument:&now atIndex:3];               // time
+    [inv setArgument:&body atIndex:4];              // text
+    [inv setArgument:&nilObj atIndex:5];            // messageSubject
+    [inv setArgument:&fileTransferGuids atIndex:6];
+    [inv setArgument:&flags atIndex:7];
+    [inv setArgument:&nilObj atIndex:8];            // error
+    [inv setArgument:&nilObj atIndex:9];            // guid
+    [inv setArgument:&nilObj atIndex:10];           // subject (string)
+    [inv setArgument:&pollMessageGuid atIndex:11];
+    [inv setArgument:&associatedType atIndex:12];
+    [inv setArgument:&associatedRange atIndex:13];
+    [inv setArgument:&summaryInfo atIndex:14];
+    [inv retainArguments];
+    id result = invokeReturningObject(inv);
+    if (!result) return nil;
+
+    // Stamp the balloon payload onto the message's backing item. Try the
+    // message directly first (some IMMessage builds forward these), then the
+    // underlying item.
+    NSString *balloonID = pollsBalloonBundleIdentifier();
+    NSArray<id> *targets = @[result];
+    SEL itemSel = NSSelectorFromString(@"_imMessageItem");
+    if ([result respondsToSelector:itemSel]) {
+        @try {
+            id item = [result performSelector:itemSel];
+            if (item) targets = @[item, result];
+        } @catch (__unused NSException *e) {}
+    }
+    for (id target in targets) {
+        if ([target respondsToSelector:@selector(setBalloonBundleID:)]) {
+            [target performSelector:@selector(setBalloonBundleID:) withObject:balloonID];
+        }
+        if ([target respondsToSelector:@selector(setPayloadData:)]) {
+            [target performSelector:@selector(setPayloadData:) withObject:payloadData];
+        }
+    }
+    return result;
+}
+
+/// `send-poll-vote`: cast a vote on an existing poll. Builds a Polls balloon
+/// carrying the vote payload, associated to the poll message via type 4000.
+/// The caller passes the original poll message GUID and the chosen option's
+/// UUID (resolved CLI-side from the poll's decoded options).
+static NSDictionary *handleSendPollVote(NSInteger requestId, NSDictionary *params) {
+    NSString *chatGuid = params[@"chatGuid"];
+    NSString *pollMessageGuid = trimmedPollString(params[@"pollMessageGuid"]);
+    NSString *optionIdentifier = trimmedPollString(params[@"optionIdentifier"]);
+    NSString *optionText = trimmedPollString(params[@"optionText"]);
+    NSString *voterHandle = trimmedPollString(params[@"voterHandle"]);
+
+    if (!chatGuid.length) return errorResponse(requestId, @"Missing chatGuid");
+    if (!pollMessageGuid.length) return errorResponse(requestId, @"Missing pollMessageGuid");
+    if (!optionIdentifier.length) return errorResponse(requestId, @"Missing optionIdentifier");
+    if (!pollPayloadMessageInitializerAvailable()) {
+        return errorResponse(requestId, @"Poll IMMessage initializer unavailable on this macOS");
+    }
+
+    IMChat *chat = resolveChatByGuid(chatGuid);
+    if (!chat) {
+        return errorResponse(requestId,
+            [NSString stringWithFormat:@"Chat not found: %@", chatGuid]);
+    }
+
+    if (!voterHandle.length) {
+        voterHandle = activeIMessageSenderHandle();
+    }
+    if (!voterHandle.length) {
+        return errorResponse(requestId,
+            @"Could not resolve active iMessage sender handle for vote payload");
+    }
+
+    NSString *payloadError = nil;
+    NSData *payloadData = buildPollVotePayloadData(optionIdentifier, voterHandle, &payloadError);
+    if (!payloadData) {
+        return errorResponse(requestId, payloadError ?: @"Could not build vote payload");
+    }
+
+    NSDictionary *summary = @{ @"amc": @0, @"ust": @YES };
+    NSAttributedString *body = buildPollBreadcrumbAttributed();
+
+    @try {
+        clearThreadContextForChat(chat, nil);
+        id imMessage = buildPollVoteIMMessage(body, payloadData, summary, pollMessageGuid);
+        if (!imMessage) {
+            return errorResponse(requestId, @"Could not construct vote IMMessage");
+        }
+        [chat performSelector:@selector(sendMessage:) withObject:imMessage];
+        NSString *guid = lastSentMessageGuid(chat);
+        return successResponse(requestId, @{
+            @"chatGuid": chatGuid,
+            @"messageGuid": guid ?: @"",
+            @"pollMessageGuid": pollMessageGuid,
+            @"optionIdentifier": optionIdentifier,
+            @"optionText": optionText ?: @"",
+            @"balloonBundleID": pollsBalloonBundleIdentifier()
+        });
+    } @catch (NSException *exception) {
+        return errorResponse(requestId,
+            [NSString stringWithFormat:@"send-poll-vote failed: %@", exception.reason]);
+    }
+}
+
 /// `send-multipart`: at minimum, sends an attributedBody composed of multiple
 /// text parts. v1 supports text-only multipart; mention/file parts can land in
 /// a follow-up.
@@ -4061,6 +4246,7 @@ static NSDictionary* dispatchAction(NSInteger legacyId, NSString *action,
     if ([action isEqualToString:@"send-multipart"]) return handleSendMultipart(legacyId, params);
     if ([action isEqualToString:@"send-attachment"]) return handleSendAttachment(legacyId, params);
     if ([action isEqualToString:@"send-poll"]) return handleSendPoll(legacyId, params);
+    if ([action isEqualToString:@"send-poll-vote"]) return handleSendPollVote(legacyId, params);
     if ([action isEqualToString:@"send-reaction"]) return handleSendReaction(legacyId, params);
     if ([action isEqualToString:@"notify-anyways"]) return handleNotifyAnyways(legacyId, params);
     if ([action isEqualToString:@"edit-message"]) return handleEditMessage(legacyId, params);

--- a/Sources/imsg/Commands/PollCommand.swift
+++ b/Sources/imsg/Commands/PollCommand.swift
@@ -8,12 +8,13 @@ enum PollCommand {
     abstract: "Send a native Apple Messages poll",
     discussion: """
       Requires `imsg launch` (SIP-disabled, dylib injected). Use the `send`
-      action to create a native Messages Polls extension balloon.
+      action to create a native Messages Polls extension balloon, or the `vote`
+      action to cast a vote on an existing poll.
       """,
     signature: CommandSignatures.withRuntimeFlags(
       CommandSignature(
         arguments: [
-          .make(label: "action", help: "send", isOptional: false)
+          .make(label: "action", help: "send|vote", isOptional: false)
         ],
         options: CommandSignatures.baseOptions() + [
           .make(label: "chat", names: [.long("chat")], help: "chat guid or rowid"),
@@ -23,12 +24,22 @@ enum PollCommand {
           .make(
             label: "option", names: [.long("option")],
             help: "poll option text; pass at least twice"),
+          .make(
+            label: "poll", names: [.long("poll")],
+            help: "vote: guid of the poll message to vote on"),
+          .make(
+            label: "optionID", names: [.long("option-id")],
+            help: "vote: UUID of the option to select"),
+          .make(
+            label: "optionIndex", names: [.long("option-index")],
+            help: "vote: 1-based option number to select"),
         ]
       )
     ),
     usageExamples: [
       "imsg poll send --chat 'iMessage;-;+15551234567' --question 'Dinner?' --option 'Pizza' --option 'Sushi'",
       "imsg poll send --chat 'iMessage;-;+15551234567' --reply-to ABCD --question 'Approve?' --option 'Yes' --option 'No'",
+      "imsg poll vote --chat 'iMessage;-;+15551234567' --poll ABCD --option-id 1B2C-...",
     ]
   ) { values, runtime in
     try await run(values: values, runtime: runtime)
@@ -43,9 +54,24 @@ enum PollCommand {
       try await IMsgBridgeClient.shared.invoke(action: action, params: params)
     }
   ) async throws {
-    guard values.argument(0) == "send" else {
+    switch values.argument(0) {
+    case "send":
+      try await runSend(
+        values: values, runtime: runtime, storeFactory: storeFactory, invokeBridge: invokeBridge)
+    case "vote":
+      try await runVote(
+        values: values, runtime: runtime, storeFactory: storeFactory, invokeBridge: invokeBridge)
+    default:
       throw ParsedValuesError.invalidOption("action")
     }
+  }
+
+  private static func runSend(
+    values: ParsedValues,
+    runtime: RuntimeOptions,
+    storeFactory: @escaping (String) throws -> MessageStore,
+    invokeBridge: @escaping (BridgeAction, [String: Any]) async throws -> [String: Any]
+  ) async throws {
     let chat = try resolveChatGUID(values: values, storeFactory: storeFactory)
     guard let question = values.option("question"), !question.isEmpty else {
       throw ParsedValuesError.missingOption("question")
@@ -77,6 +103,103 @@ enum PollCommand {
     }
   }
 
+  private static func runVote(
+    values: ParsedValues,
+    runtime: RuntimeOptions,
+    storeFactory: @escaping (String) throws -> MessageStore,
+    invokeBridge: @escaping (BridgeAction, [String: Any]) async throws -> [String: Any]
+  ) async throws {
+    let chat = try resolveChatGUID(values: values, storeFactory: storeFactory)
+    guard let pollGuid = values.option("poll")?.trimmingCharacters(in: .whitespacesAndNewlines),
+      !pollGuid.isEmpty
+    else {
+      throw ParsedValuesError.missingOption("poll")
+    }
+    let resolved = try resolveOptionID(
+      values: values, pollGuid: pollGuid, storeFactory: storeFactory)
+
+    var params: [String: Any] = [
+      "chatGuid": chat,
+      // Native votes associate to the BARE poll GUID; strip a leading
+      // `p:<part>/` reference so the bridge never sends the invalid form.
+      "pollMessageGuid": barePollGuid(pollGuid),
+      "optionIdentifier": resolved.id,
+    ]
+    // Carry the resolved option text so callers (OpenClaw's echo guard) can
+    // suppress a redundant text reply that just restates the vote.
+    if let text = resolved.text, !text.isEmpty {
+      params["optionText"] = text
+    }
+
+    do {
+      let data = try await invokeBridge(.sendPollVote, params)
+      // Merge the CLI-resolved option label into the emitted result so callers
+      // get it regardless of the injected dylib version (older bridges don't
+      // echo optionText). OpenClaw's echo guard reads this to drop a redundant
+      // text reply that just restates the vote.
+      var merged = data
+      if let text = resolved.text, !text.isEmpty,
+        (merged["optionText"] as? String)?.isEmpty != false
+      {
+        merged["optionText"] = text
+      }
+      let guid = (merged["messageGuid"] as? String) ?? ""
+      BridgeOutput.emit(
+        merged, runtime: runtime,
+        summary: guid.isEmpty ? "vote: queued" : "vote: sent (guid=\(guid))")
+    } catch {
+      BridgeOutput.emitError(String(describing: error), runtime: runtime)
+      throw BridgeOutput.EmittedError()
+    }
+  }
+
+  /// Resolve the option to vote for. A direct `--option-id` UUID wins; otherwise
+  /// decode the poll's options and map a 1-based `--option-index` or an
+  /// `--option` text (case-insensitive) onto the stable optionIdentifier.
+  private static func resolveOptionID(
+    values: ParsedValues,
+    pollGuid: String,
+    storeFactory: (String) throws -> MessageStore
+  ) throws -> (id: String, text: String?) {
+    let directID = values.option("optionID")?.trimmingCharacters(in: .whitespacesAndNewlines)
+    let indexValue = values.optionInt64("optionIndex")
+    let textValue = values.option("option")?.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard (directID?.isEmpty == false) || indexValue != nil || (textValue?.isEmpty == false) else {
+      throw ParsedValuesError.missingOption("option-id")
+    }
+    let dbPath = values.option("db") ?? MessageStore.defaultPath
+    let store = try storeFactory(dbPath)
+    let options = try store.pollOptions(guid: pollGuid)
+    guard !options.isEmpty else {
+      throw ParsedValuesError.invalidOption("poll (could not decode options for \(pollGuid))")
+    }
+
+    // A direct UUID must still be a real option of the decoded poll — otherwise
+    // we would "send" a vote for an arbitrary GUID that is not a poll here.
+    if let direct = directID, !direct.isEmpty {
+      guard let match = options.first(where: { $0.id == direct }) else {
+        throw ParsedValuesError.invalidOption(
+          "option-id \(direct) is not an option of poll \(pollGuid)")
+      }
+      return (match.id, match.text)
+    }
+    if let index = indexValue {
+      guard index >= 1, Int(index) <= options.count else {
+        throw ParsedValuesError.invalidOption(
+          "option-index \(index) out of range (1...\(options.count))")
+      }
+      let option = options[Int(index) - 1]
+      return (option.id, option.text)
+    }
+    let text = textValue ?? ""
+    guard let match = options.first(where: { $0.text.caseInsensitiveCompare(text) == .orderedSame })
+    else {
+      let available = options.map { $0.text }.joined(separator: ", ")
+      throw ParsedValuesError.invalidOption("option \"\(text)\" (available: \(available))")
+    }
+    return (match.id, match.text)
+  }
+
   private static func resolveChatGUID(
     values: ParsedValues,
     storeFactory: (String) throws -> MessageStore
@@ -96,4 +219,14 @@ enum PollCommand {
     }
     return chatValue
   }
+}
+
+/// The bare poll GUID a native vote associates to. Strips a leading
+/// `p:<part>/` reference (the tapback-style form) if present; a plain GUID is
+/// returned unchanged. Shared by the CLI and RPC vote paths.
+func barePollGuid(_ guid: String) -> String {
+  guard let slash = guid.lastIndex(of: "/") else { return guid }
+  let next = guid.index(after: slash)
+  guard next < guid.endIndex else { return guid }
+  return String(guid[next...])
 }

--- a/Sources/imsg/Commands/PollCommand.swift
+++ b/Sources/imsg/Commands/PollCommand.swift
@@ -153,9 +153,7 @@ enum PollCommand {
     }
   }
 
-  /// Resolve the option to vote for. A direct `--option-id` UUID wins; otherwise
-  /// decode the poll's options and map a 1-based `--option-index` or an
-  /// `--option` text (case-insensitive) onto the stable optionIdentifier.
+  /// Resolve exactly one option selector against the poll's stable options.
   private static func resolveOptionID(
     values: ParsedValues,
     pollGuid: String,
@@ -164,8 +162,13 @@ enum PollCommand {
     let directID = values.option("optionID")?.trimmingCharacters(in: .whitespacesAndNewlines)
     let indexValue = values.optionInt64("optionIndex")
     let textValue = values.option("option")?.trimmingCharacters(in: .whitespacesAndNewlines)
-    guard (directID?.isEmpty == false) || indexValue != nil || (textValue?.isEmpty == false) else {
+    let selectors = [directID?.isEmpty == false, indexValue != nil, textValue?.isEmpty == false]
+    guard selectors.contains(true) else {
       throw ParsedValuesError.missingOption("option-id")
+    }
+    guard selectors.filter({ $0 }).count == 1 else {
+      throw ParsedValuesError.invalidOption(
+        "choose exactly one of --option-id, --option-index, or --option")
     }
     let dbPath = values.option("db") ?? MessageStore.defaultPath
     let store = try storeFactory(dbPath)

--- a/Sources/imsg/RPCServer+BridgeMessageHandlers.swift
+++ b/Sources/imsg/RPCServer+BridgeMessageHandlers.swift
@@ -121,6 +121,62 @@ extension RPCServer {
     respond(id: id, result: result)
   }
 
+  func handlePollVote(params: [String: Any], id: Any?) async throws {
+    let chatGUID = try await resolveChatGUIDParam(params)
+    guard
+      let pollGUID = stringParam(
+        params["poll_guid"] ?? params["pollGuid"] ?? params["poll_message_guid"]
+          ?? params["message_guid"] ?? params["message_id"]), !pollGUID.isEmpty
+    else {
+      throw RPCError.invalidParams("poll_guid is required")
+    }
+    guard
+      let optionID = stringParam(
+        params["option_id"] ?? params["optionId"] ?? params["optionIdentifier"]),
+      !optionID.isEmpty
+    else {
+      throw RPCError.invalidParams("option_id is required")
+    }
+    // Validate the poll exists and the option belongs to it (mirrors the CLI),
+    // so an API caller can't cast a vote against an arbitrary non-poll GUID.
+    let pollOptions = try store.pollOptions(guid: pollGUID)
+    guard !pollOptions.isEmpty else {
+      throw RPCError.invalidParams("poll \(pollGUID) not found or not decodable")
+    }
+    guard let matchedOption = pollOptions.first(where: { $0.id == optionID }) else {
+      throw RPCError.invalidParams("option_id \(optionID) is not an option of poll \(pollGUID)")
+    }
+    var bridgeParams: [String: Any] = [
+      "chatGuid": chatGUID,
+      // Native votes associate to the bare poll GUID (strip a leading p:<part>/).
+      "pollMessageGuid": barePollGuid(pollGUID),
+      "optionIdentifier": optionID,
+    ]
+    let optionText = stringParam(params["option_text"] ?? params["optionText"]) ?? matchedOption.text
+    if !optionText.isEmpty {
+      bridgeParams["optionText"] = optionText
+    }
+    if let voter = stringParam(params["voter_handle"] ?? params["voterHandle"]), !voter.isEmpty {
+      bridgeParams["voterHandle"] = voter
+    }
+
+    let data = try await invokeBridge(action: .sendPollVote, params: bridgeParams)
+    var result: [String: Any] = [
+      "ok": true,
+      "event": "imessage.poll.voted",
+      // Callers use the resolved option to suppress a redundant text reply that
+      // just restates the vote, so return it alongside the poll linkage.
+      "poll_guid": barePollGuid(pollGUID),
+      "option_id": matchedOption.id,
+      "option_text": matchedOption.text,
+    ]
+    if let guid = data["messageGuid"] as? String, !guid.isEmpty {
+      result["guid"] = guid
+      result["message_id"] = guid
+    }
+    respond(id: id, result: result)
+  }
+
   func handleTapback(params: [String: Any], id: Any?) async throws {
     let chatGUID = try await resolveChatGUIDParam(params)
     guard let messageGUID = rpcMessageGUIDParam(params) else {

--- a/Sources/imsg/RPCServer+BridgeMessageHandlers.swift
+++ b/Sources/imsg/RPCServer+BridgeMessageHandlers.swift
@@ -152,12 +152,8 @@ extension RPCServer {
       "pollMessageGuid": barePollGuid(pollGUID),
       "optionIdentifier": optionID,
     ]
-    let optionText = stringParam(params["option_text"] ?? params["optionText"]) ?? matchedOption.text
-    if !optionText.isEmpty {
-      bridgeParams["optionText"] = optionText
-    }
-    if let voter = stringParam(params["voter_handle"] ?? params["voterHandle"]), !voter.isEmpty {
-      bridgeParams["voterHandle"] = voter
+    if !matchedOption.text.isEmpty {
+      bridgeParams["optionText"] = matchedOption.text
     }
 
     let data = try await invokeBridge(action: .sendPollVote, params: bridgeParams)

--- a/Sources/imsg/RPCServer.swift
+++ b/Sources/imsg/RPCServer.swift
@@ -39,6 +39,8 @@ let kSupportedRPCMethods: [String] = [
   "send.attachment",
   "poll.send",
   "messages.poll.send",
+  "poll.vote",
+  "messages.poll.vote",
   "tapback",
   "typing",
   "read",
@@ -154,6 +156,8 @@ final class RPCServer {
         try await handleSendAttachment(params: params, id: id)
       case "poll.send", "messages.poll.send":
         try await handlePollSend(params: params, id: id)
+      case "poll.vote", "messages.poll.vote":
+        try await handlePollVote(params: params, id: id)
       case "tapback":
         try await handleTapback(params: params, id: id)
       case "typing":

--- a/Tests/imsgTests/BridgeCommandRegistrationTests.swift
+++ b/Tests/imsgTests/BridgeCommandRegistrationTests.swift
@@ -127,6 +127,7 @@ func injectedHelperWiresNativePollSend() throws {
   #expect(source.contains("pollPreviewImageData"))
   #expect(sendPollBody.contains("buildPollCreationPayloadData"))
   #expect(sendPollBody.contains("buildPollIMMessage"))
+  #expect(sendPollBody.contains("pollPayloadMessageInitializerAvailable()"))
   #expect(!sendPollBody.contains(#"selectedMessageGuid.length ? @"" : question"#))
   #expect(sendPollBody.contains("buildPollCreationPayloadData(question,"))
   #expect(sendPollBody.contains(#"@{ @"enc": @YES, @"ust": @YES }"#))
@@ -146,6 +147,29 @@ func injectedHelperWiresNativePollSend() throws {
     source.contains(
       "initWithSender:time:text:messageSubject:fileTransferGUIDs:flags:error:guid:subject:balloonBundleID:payloadData:expressiveSendStyleID:threadIdentifier:scheduleType:scheduleState:messageSummaryInfo:"
     ))
+}
+
+@Test
+func injectedHelperWiresFailClosedNativePollVote() throws {
+  let testFile = URL(fileURLWithPath: #filePath)
+  let repoRoot =
+    testFile
+    .deletingLastPathComponent()
+    .deletingLastPathComponent()
+    .deletingLastPathComponent()
+  let helper = repoRoot.appendingPathComponent("Sources/IMsgHelper/IMsgInjected.m")
+  let source = stripObjectiveCComments(try String(contentsOf: helper, encoding: .utf8))
+  let voteBody = try #require(functionBody(named: "buildPollVoteIMMessage", in: source))
+  let sendVoteBody = try #require(functionBody(named: "handleSendPollVote", in: source))
+
+  #expect(source.contains("send-poll-vote"))
+  #expect(source.contains("Poll vote payload exceeds 4096 bytes"))
+  #expect(sendVoteBody.contains("pollVoteMessageInitializerAvailable()"))
+  #expect(!sendVoteBody.contains("pollPayloadMessageInitializerAvailable()"))
+  #expect(voteBody.contains("associatedMessageType"))
+  #expect(voteBody.contains("setBalloonBundleID:"))
+  #expect(voteBody.contains("setPayloadData:"))
+  #expect(voteBody.contains("return nil;"))
 }
 
 @Test

--- a/Tests/imsgTests/BridgeCommandRegistrationTests.swift
+++ b/Tests/imsgTests/BridgeCommandRegistrationTests.swift
@@ -164,6 +164,7 @@ func injectedHelperWiresFailClosedNativePollVote() throws {
 
   #expect(source.contains("send-poll-vote"))
   #expect(source.contains("Poll vote payload exceeds 4096 bytes"))
+  #expect(source.contains(#"@"pollVoteMessage": @(pollVoteMessageInitializerAvailable())"#))
   #expect(sendVoteBody.contains("pollVoteMessageInitializerAvailable()"))
   #expect(!sendVoteBody.contains("pollPayloadMessageInitializerAvailable()"))
   #expect(voteBody.contains("associatedMessageType"))

--- a/Tests/imsgTests/BridgeRichCommandTests.swift
+++ b/Tests/imsgTests/BridgeRichCommandTests.swift
@@ -201,3 +201,64 @@ func pollCommandSendResolvesChatID() async throws {
 
   #expect(capturedParams["chatGuid"] as? String == "iMessage;+;chat123")
 }
+
+@Test
+func pollCommandVoteResolvesOptionIndex() async throws {
+  let values = ParsedValues(
+    positional: ["vote"],
+    options: [
+      "chatID": ["1"],
+      "poll": ["p:0/poll-guid-6"],
+      "optionIndex": ["2"],
+    ],
+    flags: ["jsonOutput"]
+  )
+  let runtime = RuntimeOptions(parsedValues: values)
+  let store = try CommandTestDatabase.makeStoreForRPCWithPollVote()
+  var capturedAction: BridgeAction?
+  var capturedParams: [String: Any] = [:]
+
+  let (output, _) = try await StdoutCapture.capture {
+    try await PollCommand.run(
+      values: values,
+      runtime: runtime,
+      storeFactory: { _ in store },
+      invokeBridge: { action, params in
+        capturedAction = action
+        capturedParams = params
+        return ["messageGuid": "vote-guid"]
+      }
+    )
+  }
+
+  #expect(capturedAction == .sendPollVote)
+  #expect(capturedParams["chatGuid"] as? String == "iMessage;+;chat123")
+  #expect(capturedParams["pollMessageGuid"] as? String == "poll-guid-6")
+  #expect(capturedParams["optionIdentifier"] as? String == "choice-no")
+  #expect(capturedParams["optionText"] as? String == "No")
+  let data = try #require(output.data(using: .utf8))
+  let result = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+  #expect(result["optionText"] as? String == "No")
+}
+
+@Test
+func pollCommandVoteRejectsConflictingSelectors() async throws {
+  let values = ParsedValues(
+    positional: ["vote"],
+    options: [
+      "chat": ["iMessage;-;+15551234567"],
+      "poll": ["poll-guid-6"],
+      "optionID": ["choice-yes"],
+      "optionIndex": ["1"],
+    ],
+    flags: []
+  )
+  let runtime = RuntimeOptions(parsedValues: values)
+
+  do {
+    try await PollCommand.run(values: values, runtime: runtime)
+    #expect(Bool(false))
+  } catch let error as ParsedValuesError {
+    #expect(error.description.contains("choose exactly one"))
+  }
+}

--- a/Tests/imsgTests/RPCBridgeMessageHandlersTests.swift
+++ b/Tests/imsgTests/RPCBridgeMessageHandlersTests.swift
@@ -13,6 +13,8 @@ func rpcStatusAdvertisesBridgeMessageMethods() {
     "send.attachment",
     "poll.send",
     "messages.poll.send",
+    "poll.vote",
+    "messages.poll.vote",
     "tapback",
     "message.edit",
     "message.unsend",
@@ -22,6 +24,56 @@ func rpcStatusAdvertisesBridgeMessageMethods() {
   ] {
     #expect(methods.contains(method))
   }
+}
+
+@Test
+func rpcPollVoteValidatesAndResolvesOption() async throws {
+  let store = try CommandTestDatabase.makeStoreForRPCWithPollVote()
+  let output = TestRPCOutput()
+  var capturedAction: BridgeAction?
+  var capturedParams: [String: Any] = [:]
+  let server = RPCServer(
+    store: store,
+    verbose: false,
+    output: output,
+    invokeBridge: { action, params in
+      capturedAction = action
+      capturedParams = params
+      return ["messageGuid": "vote-guid"]
+    }
+  )
+
+  let request =
+    #"{"jsonrpc":"2.0","id":"vote","method":"poll.vote","params":{"chat_id":1,"#
+    + #""poll_guid":"p:0/poll-guid-6","option_id":"choice-no","option_text":"spoofed","#
+    + #""voter_handle":"spoofed"}}"#
+  await server.handleLineForTesting(request)
+
+  #expect(capturedAction == .sendPollVote)
+  #expect(capturedParams["chatGuid"] as? String == "iMessage;+;chat123")
+  #expect(capturedParams["pollMessageGuid"] as? String == "poll-guid-6")
+  #expect(capturedParams["optionIdentifier"] as? String == "choice-no")
+  #expect(capturedParams["optionText"] as? String == "No")
+  #expect(capturedParams["voterHandle"] == nil)
+  let result = output.responses.first?["result"] as? [String: Any]
+  #expect(result?["event"] as? String == "imessage.poll.voted")
+  #expect(result?["option_text"] as? String == "No")
+  #expect(result?["message_id"] as? String == "vote-guid")
+}
+
+@Test
+func rpcPollVoteRejectsOptionOutsidePoll() async throws {
+  let store = try CommandTestDatabase.makeStoreForRPCWithPollVote()
+  let output = TestRPCOutput()
+  let server = RPCServer(store: store, verbose: false, output: output)
+
+  await server.handleLineForTesting(
+    #"{"jsonrpc":"2.0","id":"vote","method":"poll.vote","params":{"chat_id":1,"poll_guid":"poll-guid-6","option_id":"not-an-option"}}"#
+  )
+
+  let error = output.errors.first?["error"] as? [String: Any]
+  #expect((error?["code"] as? Int) == -32602)
+  #expect((error?["data"] as? String)?.contains("not an option") == true)
 }
 
 @Test

--- a/docs/history.md
+++ b/docs/history.md
@@ -85,6 +85,13 @@ imsg poll send --chat 'iMessage;-;+15551234567' \
 
 You can also use `--chat-id <id>` from `imsg chats`.
 
+Cast a vote using one selector. The index is 1-based; `imsg` resolves it to the
+poll's stable option identifier before sending:
+
+```bash
+imsg poll vote --chat-id <id> --poll <poll-guid> --option-index 2
+```
+
 ### Manual native poll test plan
 
 1. Create a native poll in Messages from an iPhone or Mac.
@@ -92,7 +99,8 @@ You can also use `--chat-id <id>` from `imsg chats`.
 3. Vote on the poll from another participant/device.
 4. Run `imsg watch --chat-id <chat-id> --json | jq -c 'select(.poll != null)'` while the vote happens, or re-run history, and verify the vote row has `poll.kind == "vote"`, `poll.original_guid` set to the original poll GUID, and `poll.vote.option_id` set.
 5. Send a poll with `imsg poll send --chat-id <id> --question "..." --option "A" --option "B"` and verify it renders as a native Messages poll on iOS/macOS.
-6. If Apple changes the private Polls payload shape, verify the row still emits `poll.kind == "unknown"` with metadata and no raw payload bytes.
+6. Vote with `imsg poll vote --chat-id <id> --poll <poll-guid> --option-index 2`, then verify the new row has `poll.kind == "vote"`, the original GUID, and the selected option.
+7. If Apple changes the private Polls payload shape, verify the row still emits `poll.kind == "unknown"` with metadata and no raw payload bytes.
 
 ## Performance
 


### PR DESCRIPTION
# feat(poll): cast votes on native Messages polls

## What & why

`imsg` could create and read native Apple Messages polls but not **vote** on them.
This adds `imsg poll vote`, the `poll.vote` RPC method, and the `send-poll-vote`
bridge action. Additive only — existing `poll send` / `poll.send` behavior and
its response are unchanged.

## How it works

A vote is an *associated message* (`associatedMessageType 4000`, bare poll GUID)
that also carries the Polls balloon payload. macOS 26 exposes no IMMessage
initializer that carries a balloon payload AND an associated message together, so
the vote is built with the associated-message initializer (the path reactions use,
which persists the association) and `balloonBundleID`/`payloadData` are then stamped
onto the message's backing item — the one place they survive `[chat sendMessage:]`.

Option selection resolves a 1-based `--option-index`, an `--option` text
(case-insensitive), or a direct `--option-id` UUID to the stable optionIdentifier
via a new `MessageStore.pollOptions(guid:)`, which also validates the poll exists
and the option belongs to it. The CLI and the RPC response return the resolved
option id/text so callers can suppress a redundant reply that restates the vote.
Both paths normalize a `p:<part>/<guid>` reference down to the bare poll GUID.

## Surface added

- CLI: `imsg poll vote --chat <c> --poll <guid> (--option-index N | --option TEXT | --option-id UUID)`
- RPC: `poll.vote` / `messages.poll.vote` (response includes `option_id`, `option_text`, `poll_guid`)
- Bridge action: `send-poll-vote`
- `MessageStore.pollOptions(guid:)`

## Evidence — real behavior proof (macOS 26.4.1, redacted)

Live CLI vote from this branch's build (GUIDs truncated, chat/handles omitted):

```text
$ imsg poll vote --chat <redacted> --poll 465DCEE3… --option-index 1 --json
{
  "messageGuid": "21265724…",
  "pollMessageGuid": "465DCEE3…",
  "optionIdentifier": "8675F837…",
  "optionText": "Red"
}
```

Decode readback of the sent vote:

```text
decoded kind: vote | option_text: Red | associated_type: 4000
```

Multiple live votes, from `chat.db` (GUIDs truncated, handles omitted). Each vote is
an associated message (type 4000) whose `assoc` GUID is the originating poll's GUID,
delivered with no error:

```text
row  6478   me VOTE(4000) guid=DF8089B9… assoc=465DCEE3… sent=1 delivered=1 err=0
row  6476 peer POLL       guid=465DCEE3… assoc=None     sent=0 delivered=1 err=0
row  6475   me VOTE(4000) guid=3D30828C… assoc=7AB94568… sent=1 delivered=1 err=0
row  6471 peer POLL       guid=7AB94568… assoc=None     sent=0 delivered=1 err=0
row  6470   me VOTE(4000) guid=B1563D7E… assoc=4C511F80… sent=1 delivered=1 err=0
row  6466 peer POLL       guid=4C511F80… assoc=None     sent=0 delivered=1 err=0
```

- `swift build` — Build complete.
- Votes by index, text, and UUID all land as `associated_message_type=4000` linked
  to the poll, `is_delivered=1 error=0`, and decode back to the selected option.

## Addressed from ClawSweeper/Codex review
- **[P1] Preserve poll-send semantics** — removed the extra question-text send from
  `handleSendPoll`; this PR no longer changes `poll send` behavior (additive only).
- **[P2] Return the option from RPC votes** — `poll.vote` now returns `option_id` /
  `option_text` / `poll_guid`.
- **RPC poll validation** — the RPC vote path now decodes the poll and rejects an
  unknown poll or an `option_id` not belonging to it, matching the CLI.

## Codex review (independent, gpt-5.4)
Reviewed to READY over 3 rounds (non-bare GUID, `--option-id` validation, RPC
validation all resolved). The private-API "associated init then stamp balloon
fields" construction was validated as sound.
