### PR TITLE
fix(bridge): restore chat deletion on macOS 26

### DIFF
--- a/Sources/IMsgHelper/IMsgInjected.m
+++ b/Sources/IMsgHelper/IMsgInjected.m
@@ -814,7 +814,11 @@ static NSDictionary* handleStatus(NSInteger requestId, NSDictionary *params) {
         @"retractMessagePart": @(gHasRetractMessagePart),
         @"sendMessageReason": @(gHasSendMessageReason),
         @"pollPayloadMessage": @(pollPayloadMessageInitializerAvailable()),
-        @"pollVoteMessage": @(pollVoteMessageInitializerAvailable())
+        @"pollVoteMessage": @(pollVoteMessageInitializerAvailable()),
+        @"deleteChat": @(hasRegistry &&
+            [registryClass instancesRespondToSelector:NSSelectorFromString(@"deleteChat:")]),
+        @"removeChat": @(hasRegistry &&
+            [registryClass instancesRespondToSelector:NSSelectorFromString(@"_chat_remove:")])
     };
 
     return successResponse(requestId, @{
@@ -3995,14 +3999,28 @@ static NSDictionary *handleDeleteChat(NSInteger requestId, NSDictionary *params)
     if (!chat) return errorResponse(requestId, @"Chat not found");
     Class regClass = NSClassFromString(@"IMChatRegistry");
     id reg = regClass ? [regClass performSelector:@selector(sharedInstance)] : nil;
-    SEL sel = @selector(deleteChat:);
-    if (!reg || ![reg respondsToSelector:sel]) {
-        return errorResponse(requestId, @"deleteChat: not available");
+    SEL deleteSelector = NSSelectorFromString(@"deleteChat:");
+    SEL removeSelector = NSSelectorFromString(@"_chat_remove:");
+    SEL selectedSelector = NULL;
+    if ([reg respondsToSelector:deleteSelector]) {
+        selectedSelector = deleteSelector;
+    } else if ([reg respondsToSelector:removeSelector]) {
+        // macOS 26 removed deleteChat:, while Messages still uses the
+        // daemon-aware registry removal path exposed as _chat_remove:.
+        selectedSelector = removeSelector;
+    }
+    if (!reg || selectedSelector == NULL) {
+        return errorResponse(requestId,
+            @"Chat deletion is unavailable (deleteChat: and _chat_remove: missing)");
     }
     @try {
-        [reg performSelector:sel withObject:chat];
+        [reg performSelector:selectedSelector withObject:chat];
     } @catch (NSException *ex) { return errorResponse(requestId, ex.reason ?: @"failed"); }
-    return successResponse(requestId, @{@"chatGuid": chatGuid, @"deleted": @YES});
+    return successResponse(requestId, @{
+        @"chatGuid": chatGuid,
+        @"deleted": @YES,
+        @"method": NSStringFromSelector(selectedSelector)
+    });
 }
 
 /// `create-chat`: vend handles for each address, ask the registry for a chat

--- a/Tests/imsgTests/BridgeCommandRegistrationTests.swift
+++ b/Tests/imsgTests/BridgeCommandRegistrationTests.swift
@@ -174,6 +174,25 @@ func injectedHelperWiresFailClosedNativePollVote() throws {
 }
 
 @Test
+func injectedHelperFallsBackToMacOS26ChatRemovalSelector() throws {
+  let testFile = URL(fileURLWithPath: #filePath)
+  let repoRoot =
+    testFile
+    .deletingLastPathComponent()
+    .deletingLastPathComponent()
+    .deletingLastPathComponent()
+  let helper = repoRoot.appendingPathComponent("Sources/IMsgHelper/IMsgInjected.m")
+  let source = stripObjectiveCComments(try String(contentsOf: helper, encoding: .utf8))
+  let deleteBody = try #require(functionBody(named: "handleDeleteChat", in: source))
+
+  #expect(source.contains(#"@"deleteChat""#))
+  #expect(source.contains(#"@"removeChat""#))
+  #expect(deleteBody.contains(#"NSSelectorFromString(@"deleteChat:")"#))
+  #expect(deleteBody.contains(#"NSSelectorFromString(@"_chat_remove:")"#))
+  #expect(deleteBody.contains("NSStringFromSelector(selectedSelector)"))
+}
+
+@Test
 func injectedHelperConstructorOnlySchedulesDelayedBootstrap() throws {
   let testFile = URL(fileURLWithPath: #filePath)
   let repoRoot =


### PR DESCRIPTION
## What Problem This Solves

`chat-delete` fails on macOS 26 because `IMChatRegistry` no longer exposes the older `deleteChat:` selector. This fixes #146.

## Why This Change Was Made

The injected helper now prefers the existing `deleteChat:` path when present and falls back to the macOS 26 `_chat_remove:` registry path. It fails closed when neither selector exists, advertises both capabilities in bridge status, and reports the method used for diagnostics.

## User Impact

Users on macOS 26 can delete chats through the existing bridge command again. Older macOS behavior remains unchanged.

## Evidence

- Live Objective-C runtime probe on macOS 26.5.2: `deleteChat:` absent; `_chat_remove:` present on `IMChatRegistry` with the expected one-object argument signature.
- [BlueBubbles IMCore documentation](https://docs.bluebubbles.app/private-api/imcore-documentation) independently identifies `_chat_remove:` as the registry chat-deletion path.
- `make lint` — passed (existing warnings only).
- `make test` — 363 tests passed.
- `make build-dylib` — passed (one existing deprecation warning).
- Fresh autoreview — no actionable findings, 0.94 confidence.

A destructive live delete was intentionally not run because this host has no disposable conversation and SIP is enabled, so the injected bridge cannot be launched here. The runtime selector proof is live and non-destructive.
