### PR TITLE
fix(poll): stamp vote balloon/payload on each responding target (macOS 26.4 regression)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.12.2 - Unreleased
 
+### Native Polls
+- fix: restore native poll vote delivery on macOS 26.4 by persisting the Polls balloon and payload across the responding message objects (#150, thanks @omarshahine).
+
 ## 0.12.1 - 2026-07-02
 
 ### Packaging

--- a/Sources/IMsgHelper/IMsgInjected.m
+++ b/Sources/IMsgHelper/IMsgInjected.m
@@ -2815,15 +2815,9 @@ static id buildPollVoteIMMessage(NSAttributedString *body,
     Class messageClass = NSClassFromString(@"IMMessage");
     if (!messageClass) return nil;
 
-    // No macOS 26 IMMessage initializer carries balloon + payload AND
-    // association together (verified by selector probe). Reactions prove the
-    // associated-message initializer persists association atomically, and
-    // balloon/payload set on the backing IMMessageItem persist (verified: an
-    // earlier item-first vote landed with the balloon intact, only the
-    // association — set via the wrap — was lost). So: init with association
-    // atomically, then stamp balloonBundleID + payloadData onto the message's
-    // own backing item (a real item from a direct init, not the transient one
-    // the messageFromIMMessageItem: wrap returns).
+    // No macOS 26 initializer carries the payload and association together.
+    // Build the association atomically, then stamp payload metadata across the
+    // message and backing item; macOS 26.4 splits the setters between them.
     SEL sel = @selector(initWithSender:time:text:messageSubject:fileTransferGUIDs:flags:error:guid:subject:associatedMessageGUID:associatedMessageType:associatedMessageRange:messageSummaryInfo:);
     if (![messageClass instancesRespondToSelector:sel]) return nil;
 
@@ -2857,8 +2851,6 @@ static id buildPollVoteIMMessage(NSAttributedString *body,
     id result = invokeReturningObject(inv);
     if (!result) return nil;
 
-    // Both values must land on one object. A partial stamp can emit an
-    // associated message that Messages cannot decode as a poll vote.
     NSString *balloonID = pollsBalloonBundleIdentifier();
     NSArray<id> *targets = @[result];
     SEL itemSel = NSSelectorFromString(@"_imMessageItem");
@@ -2868,14 +2860,19 @@ static id buildPollVoteIMMessage(NSAttributedString *body,
             if (item) targets = @[item, result];
         } @catch (__unused NSException *e) {}
     }
+    BOOL balloonStamped = NO;
+    BOOL payloadStamped = NO;
     for (id target in targets) {
-        if (![target respondsToSelector:@selector(setBalloonBundleID:)]
-            || ![target respondsToSelector:@selector(setPayloadData:)]) continue;
-        [target performSelector:@selector(setBalloonBundleID:) withObject:balloonID];
-        [target performSelector:@selector(setPayloadData:) withObject:payloadData];
-        return result;
+        if ([target respondsToSelector:@selector(setBalloonBundleID:)]) {
+            [target performSelector:@selector(setBalloonBundleID:) withObject:balloonID];
+            balloonStamped = YES;
+        }
+        if ([target respondsToSelector:@selector(setPayloadData:)]) {
+            [target performSelector:@selector(setPayloadData:) withObject:payloadData];
+            payloadStamped = YES;
+        }
     }
-    return nil;
+    return (balloonStamped && payloadStamped) ? result : nil;
 }
 
 /// `send-poll-vote`: cast a vote on an existing poll. Builds a Polls balloon

--- a/Tests/imsgTests/BridgeCommandRegistrationTests.swift
+++ b/Tests/imsgTests/BridgeCommandRegistrationTests.swift
@@ -150,7 +150,7 @@ func injectedHelperWiresNativePollSend() throws {
 }
 
 @Test
-func injectedHelperWiresFailClosedNativePollVote() throws {
+func injectedHelperBroadcastsFailClosedNativePollVoteMetadata() throws {
   let testFile = URL(fileURLWithPath: #filePath)
   let repoRoot =
     testFile
@@ -168,9 +168,17 @@ func injectedHelperWiresFailClosedNativePollVote() throws {
   #expect(sendVoteBody.contains("pollVoteMessageInitializerAvailable()"))
   #expect(!sendVoteBody.contains("pollPayloadMessageInitializerAvailable()"))
   #expect(voteBody.contains("associatedMessageType"))
-  #expect(voteBody.contains("setBalloonBundleID:"))
-  #expect(voteBody.contains("setPayloadData:"))
-  #expect(voteBody.contains("return nil;"))
+  #expect(voteBody.contains("BOOL balloonStamped = NO;"))
+  #expect(voteBody.contains("BOOL payloadStamped = NO;"))
+  #expect(
+    voteBody.contains("if ([target respondsToSelector:@selector(setBalloonBundleID:)])")
+  )
+  #expect(voteBody.contains("if ([target respondsToSelector:@selector(setPayloadData:)])"))
+  #expect(voteBody.contains("return (balloonStamped && payloadStamped) ? result : nil;"))
+  #expect(
+    !voteBody.contains(
+      "|| ![target respondsToSelector:@selector(setPayloadData:)]"
+    ))
 }
 
 @Test

--- a/docs/history.md
+++ b/docs/history.md
@@ -92,6 +92,9 @@ poll's stable option identifier before sending:
 imsg poll vote --chat-id <id> --poll <poll-guid> --option-index 2
 ```
 
+On macOS 26.4, use imsg 0.12.2 or later. Earlier builds could create a local
+vote row without the Polls payload, so the recipient's poll did not update.
+
 ### Manual native poll test plan
 
 1. Create a native poll in Messages from an iPhone or Mac.


### PR DESCRIPTION
## Problem

Casting a vote on a native Messages poll silently produced a vote with **no balloon payload** on macOS 26.4.x, so the associated `4000` message shipped (`is_sent=1`) but never delivered (`is_delivered=0`) and never registered on the recipient's poll.

## Cause

`buildPollVoteIMMessage` stamps `balloonBundleID` + `payloadData` onto the message after constructing it with the association-atomic initializer. The stamping loop required a **single** target to respond to *both* setters, otherwise it `continue`d:

```objc
for (id target in targets) {
    if (![target respondsToSelector:@selector(setBalloonBundleID:)]
        || ![target respondsToSelector:@selector(setPayloadData:)]) continue;
    [target setBalloonBundleID:balloonID];
    [target setPayloadData:payloadData];
    return result;
}
return nil;
```

On macOS 26.4.x the backing `_imMessageItem` does not respond to both, so the loop fell through to the transient `IMMessage` wrapper — whose stamped values do not persist to the serialized item. The vote was emitted without the payload.

## Fix

Stamp each setter on **every** target that responds to it (item and/or wrapper), so both values land on whatever object serializes. Fail only if a value could not be stamped anywhere:

```objc
BOOL balloonStamped = NO, payloadStamped = NO;
for (id target in targets) {
    if ([target respondsToSelector:@selector(setBalloonBundleID:)]) { ...; balloonStamped = YES; }
    if ([target respondsToSelector:@selector(setPayloadData:)])     { ...; payloadStamped = YES; }
}
return (balloonStamped && payloadStamped) ? result : nil;
```

## Evidence (macOS 26.4.1)

`chat.db`, same machine, before vs after:

```
before:  VOTE(4000)  is_delivered=0  payload=NONE   → never registered
after:   VOTE(4000)  is_delivered=1  payload=7333b  → registers on the poll
```

Confirmed live: the vote now carries the 7333-byte Polls payload, delivers, and is associated to the poll (bare poll GUID).
