### PR TITLE
fix: resolve poll update option text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.12.2 - Unreleased
 
 ### Native Polls
+- fix: resolve native poll vote option text from Add Choice update rows when votes still reference the original poll message (#152, #153, thanks @veteranbv).
 - fix: restore native poll vote delivery on macOS 26.4 by persisting the Polls balloon and payload across the responding message objects (#150, thanks @omarshahine).
 
 ## 0.12.1 - 2026-07-02

--- a/Sources/IMsgCore/MessagePolls.swift
+++ b/Sources/IMsgCore/MessagePolls.swift
@@ -309,6 +309,24 @@ extension MessagePollEvent {
       metadata: metadata
     )
   }
+
+  func resolvingPollReference(pollGUID: String?, originalGUID: String?) -> MessagePollEvent {
+    if self.pollGUID == pollGUID, self.originalGUID == originalGUID {
+      return self
+    }
+    return MessagePollEvent(
+      kind: kind,
+      pollGUID: pollGUID,
+      question: question,
+      options: options,
+      vote: vote,
+      votes: votes,
+      originalGUID: originalGUID,
+      creator: creator,
+      participants: participants,
+      metadata: metadata
+    )
+  }
 }
 
 private struct PollFacts {

--- a/Sources/IMsgCore/MessageStore+Polls.swift
+++ b/Sources/IMsgCore/MessageStore+Polls.swift
@@ -24,8 +24,9 @@ extension MessageStore {
   }
 
   /// Ordered options of the poll identified by `guid`, decoded from its
-  /// creation message. Used by `poll vote` to resolve a 1-based option index
-  /// or option text into the stable optionIdentifier the bridge needs.
+  /// creation message and any native option update rows. Used by `poll vote`
+  /// to resolve a 1-based option index or option text into the stable
+  /// optionIdentifier the bridge needs.
   public func pollOptions(guid: String) throws -> [MessagePollOption] {
     let normalized = normalizeAssociatedGUID(guid)
     let target = normalized.isEmpty ? guid : normalized
@@ -63,20 +64,49 @@ extension MessageStore {
 
   private func decodedPollOptions(guid: String, db: Connection) throws -> [MessagePollOption] {
     let selection = MessageRowSelection(store: self, includeChatID: false)
-    let sql = """
-      SELECT \(selection.selectList)
-      FROM message m
-      LEFT JOIN handle h ON m.handle_id = h.ROWID
-      WHERE m.guid = ?
-      LIMIT 1
-      """
-    let rows = try db.prepareRowIterator(sql, bindings: [guid])
-    guard let row = try rows.failableNext() else { return [] }
-    let decoded = try decodeMessageRow(
-      row,
-      columns: selection.columns,
-      fallbackChatID: nil
-    )
-    return decoded.poll?.options ?? []
+    let sql: String
+    let bindings: [Binding?]
+    if schema.hasReactionColumns {
+      sql = """
+        SELECT \(selection.selectList)
+        FROM message m
+        LEFT JOIN handle h ON m.handle_id = h.ROWID
+        WHERE m.guid = ?
+           OR (
+             m.associated_message_type = ?
+             AND (
+               m.associated_message_guid = ?
+               OR m.associated_message_guid LIKE '%/' || ?
+             )
+           )
+        ORDER BY m.date ASC, m.ROWID ASC
+        """
+      bindings = [guid, MessagePollDecoder.updateAssociatedMessageType, guid, guid]
+    } else {
+      sql = """
+        SELECT \(selection.selectList)
+        FROM message m
+        LEFT JOIN handle h ON m.handle_id = h.ROWID
+        WHERE m.guid = ?
+        ORDER BY m.date ASC, m.ROWID ASC
+        """
+      bindings = [guid]
+    }
+    let rows = try db.prepareRowIterator(
+      sql,
+      bindings: bindings)
+    var options: [MessagePollOption] = []
+    var seenIDs = Set<String>()
+    while let row = try rows.failableNext() {
+      let decoded = try decodeMessageRow(
+        row,
+        columns: selection.columns,
+        fallbackChatID: nil
+      )
+      for option in decoded.poll?.options ?? [] where seenIDs.insert(option.id).inserted {
+        options.append(option)
+      }
+    }
+    return options
   }
 }

--- a/Sources/IMsgCore/MessageStore+Polls.swift
+++ b/Sources/IMsgCore/MessageStore+Polls.swift
@@ -15,12 +15,17 @@ extension MessageStore {
       }
     guard let pollGUID = candidateGUIDs.first else { return poll }
 
+    let sourcePollGUID = try sourcePollGUID(forAny: candidateGUIDs, db: db) ?? pollGUID
     let optionTexts = try pollOptionTextsByID(
-      pollGUID: pollGUID,
+      pollGUID: sourcePollGUID,
       db: db,
       cache: &cache
     )
-    return poll.resolvingVoteOptionTexts(optionTexts)
+    let resolvedPoll = poll.resolvingVoteOptionTexts(optionTexts)
+    return resolvedPoll.resolvingPollReference(
+      pollGUID: sourcePollGUID,
+      originalGUID: sourcePollGUID
+    )
   }
 
   /// Ordered options of the poll identified by `guid`, decoded from its
@@ -108,5 +113,38 @@ extension MessageStore {
       }
     }
     return options
+  }
+
+  private func sourcePollGUID(forAny candidates: [String], db: Connection) throws -> String? {
+    guard schema.hasReactionColumns else { return nil }
+    for candidate in candidates {
+      if let source = try sourcePollGUID(forUpdateRow: candidate, db: db) {
+        return source
+      }
+    }
+    return candidates.first
+  }
+
+  private func sourcePollGUID(forUpdateRow guid: String, db: Connection) throws -> String? {
+    let rows = try db.prepareRowIterator(
+      """
+      SELECT associated_message_guid
+      FROM message
+      WHERE guid = ?
+        AND associated_message_type = ?
+        AND IFNULL(associated_message_guid, '') != ''
+      LIMIT 1
+      """,
+      bindings: [guid, MessagePollDecoder.updateAssociatedMessageType]
+    )
+    guard
+      let row = try rows.failableNext(),
+      let associatedGUID = try row.get(Expression<String?>("associated_message_guid"))
+    else {
+      return nil
+    }
+
+    let normalized = normalizeAssociatedGUID(associatedGUID)
+    return normalized.isEmpty ? nil : normalized
   }
 }

--- a/Tests/IMsgCoreTests/MessagePollTests.swift
+++ b/Tests/IMsgCoreTests/MessagePollTests.swift
@@ -549,7 +549,8 @@ func messageStoreResolvesVoteOptionTextFromPollUpdateRows() throws {
   #expect(updateMessage.poll?.originalGUID == "original-poll-guid")
   #expect(updateMessage.poll?.options?.map(\.text) == ["A", "Custom choice"])
   #expect(voteMessage.poll?.kind == .vote)
-  #expect(voteMessage.poll?.originalGUID == "updated-poll-guid")
+  #expect(voteMessage.poll?.pollGUID == "original-poll-guid")
+  #expect(voteMessage.poll?.originalGUID == "original-poll-guid")
   #expect(voteMessage.poll?.vote?.optionID == "choice-custom")
   #expect(voteMessage.poll?.vote?.optionText == "Custom choice")
 }

--- a/Tests/IMsgCoreTests/MessagePollTests.swift
+++ b/Tests/IMsgCoreTests/MessagePollTests.swift
@@ -555,6 +555,112 @@ func messageStoreResolvesVoteOptionTextFromPollUpdateRows() throws {
 }
 
 @Test
+func messageStoreResolvesOriginalPollVoteOptionTextFromSlashUpdateRows() throws {
+  try assertOriginalPollVoteOptionTextResolvesFromUpdateRow(
+    updateAssociatedGUID: "p/original-poll-guid")
+}
+
+@Test
+func messageStoreResolvesOriginalPollVoteOptionTextFromPartPrefixedUpdateRows() throws {
+  try assertOriginalPollVoteOptionTextResolvesFromUpdateRow(
+    updateAssociatedGUID: "p:0/original-poll-guid")
+}
+
+private func assertOriginalPollVoteOptionTextResolvesFromUpdateRow(
+  updateAssociatedGUID: String
+) throws {
+  let db = try Connection(.inMemory)
+  var options = MessageDatabaseFixture.SchemaOptions()
+  options.includeReactionColumns = true
+  options.includeBalloonBundleID = true
+  options.includePayloadData = true
+  options.includeMessageSummaryInfo = true
+  try MessageDatabaseFixture.createSchema(db, options: options)
+
+  try db.run(
+    """
+    INSERT INTO chat(ROWID, chat_identifier, guid, display_name, service_name)
+    VALUES (1, '+15550001000', 'iMessage;+;chat-test', 'Poll Test', 'iMessage')
+    """
+  )
+  try db.run(
+    "INSERT INTO handle(ROWID, id) VALUES (1, '+15550002000'), (2, '+15550001000')")
+
+  let poll: [String: Any] = [
+    "question": "Dinner?",
+    "orderedPollOptions": [
+      ["optionIdentifier": "choice-a", "pollOptionText": "A"],
+      ["optionIdentifier": "choice-b", "pollOptionText": "B"],
+    ],
+  ]
+  let pollBlob = Blob(bytes: [UInt8](try applePollEnvelopePayload(jsonObject: poll)))
+  let update: [String: Any] = [
+    "orderedPollOptions": [
+      ["optionIdentifier": "choice-a", "pollOptionText": "A"],
+      ["optionIdentifier": "choice-b", "pollOptionText": "B"],
+      ["optionIdentifier": "choice-custom", "pollOptionText": "Custom choice"],
+    ]
+  ]
+  let updateBlob = Blob(bytes: [UInt8](try applePollEnvelopePayload(jsonObject: update)))
+  let vote: [String: Any] = [
+    "votes": [
+      ["voteOptionIdentifier": "choice-custom"]
+    ]
+  ]
+  let voteBlob = Blob(bytes: [UInt8](try applePollEnvelopePayload(jsonObject: vote)))
+  let now = Date(timeIntervalSince1970: 1_700_000_000)
+
+  try db.run(
+    """
+    INSERT INTO message(
+      ROWID, handle_id, text, guid, associated_message_guid, associated_message_type,
+      balloon_bundle_id, payload_data, message_summary_info, date, is_from_me, service
+    )
+    VALUES (1, 2, '', 'original-poll-guid', NULL, NULL, ?, ?, NULL, ?, 1, 'iMessage')
+    """,
+    testPollBundleID,
+    pollBlob,
+    TestDatabase.appleEpoch(now)
+  )
+  try db.run(
+    """
+    INSERT INTO message(
+      ROWID, handle_id, text, guid, associated_message_guid, associated_message_type,
+      balloon_bundle_id, payload_data, message_summary_info, date, is_from_me, service
+    )
+    VALUES (2, 1, '', 'updated-poll-guid', ?, 2, ?, ?, NULL, ?, 0, 'iMessage')
+    """,
+    updateAssociatedGUID,
+    testPollBundleID,
+    updateBlob,
+    TestDatabase.appleEpoch(now.addingTimeInterval(1))
+  )
+  try db.run(
+    """
+    INSERT INTO message(
+      ROWID, handle_id, text, guid, associated_message_guid, associated_message_type,
+      balloon_bundle_id, payload_data, message_summary_info, date, is_from_me, service
+    )
+    VALUES (3, 1, '', 'vote-row-guid', 'p/original-poll-guid', 4000, NULL, ?, NULL, ?, 0, 'iMessage')
+    """,
+    voteBlob,
+    TestDatabase.appleEpoch(now.addingTimeInterval(2))
+  )
+  try db.run("INSERT INTO chat_message_join(chat_id, message_id) VALUES (1, 1)")
+  try db.run("INSERT INTO chat_message_join(chat_id, message_id) VALUES (1, 2)")
+  try db.run("INSERT INTO chat_message_join(chat_id, message_id) VALUES (1, 3)")
+
+  let store = try MessageStore(connection: db, path: ":memory:")
+  let messages = try store.messagesAfter(afterRowID: 0, chatID: 1, limit: 10)
+  let voteMessage = try #require(messages.first { $0.guid == "vote-row-guid" })
+
+  #expect(voteMessage.poll?.kind == .vote)
+  #expect(voteMessage.poll?.originalGUID == "original-poll-guid")
+  #expect(voteMessage.poll?.vote?.optionID == "choice-custom")
+  #expect(voteMessage.poll?.vote?.optionText == "Custom choice")
+}
+
+@Test
 func messageRowSelectionGatesPollPayloadBlobs() throws {
   let db = try Connection(.inMemory)
   var options = MessageDatabaseFixture.SchemaOptions()

--- a/Tests/IMsgCoreTests/MessagePollTests.swift
+++ b/Tests/IMsgCoreTests/MessagePollTests.swift
@@ -652,6 +652,11 @@ private func assertOriginalPollVoteOptionTextResolvesFromUpdateRow(
   try db.run("INSERT INTO chat_message_join(chat_id, message_id) VALUES (1, 3)")
 
   let store = try MessageStore(connection: db, path: ":memory:")
+  #expect(
+    try store.pollOptions(guid: "original-poll-guid").map(\.text) == [
+      "A", "B", "Custom choice",
+    ])
+
   let messages = try store.messagesAfter(afterRowID: 0, chatID: 1, limit: 10)
   let voteMessage = try #require(messages.first { $0.guid == "vote-row-guid" })
 


### PR DESCRIPTION
Fixes #152.

Native poll choices added after creation are stored in poll update rows. A vote row can still point back to the original poll GUID, so resolving option text from only the original creation row can leave `poll.vote.option_text` empty even though `poll.vote.option_id` is present.

This updates poll option resolution to read the original poll row plus native option update rows associated to that poll, then merge option IDs in database order. If the schema does not expose associated-message columns, it keeps the existing exact-GUID lookup path.

Tests add the missing shape: original poll row, later native Add Choice update row, and a vote row associated to the original poll GUID selecting the added option.

Verification:

- `swift format lint --recursive Sources Tests TestsLinux`
- `swift test --filter MessagePollTests`
- `swift test`
- `make test`

Local note: `make lint` could not complete because this machine does not have `swiftlint` installed (`make: swiftlint: No such file or directory`). The `swift format` portion passes.