### PR TITLE
docs(skill): expand imsg agent skill with full CLI surface

### DIFF
--- a/.agents/skills/imsg/SKILL.md
+++ b/.agents/skills/imsg/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: imsg
-description: "iMessage/SMS via the imsg CLI: read local Messages history, search, stream live, resolve contacts, and send (sends only when explicitly requested). Use for any Messages.app / chat.db task."
+description: "iMessage/SMS: local history, contacts, live watch, and requested sends."
 ---
 
 # imsg
@@ -72,10 +72,12 @@ Only after `imsg status` confirms the bridge is loaded (`imsg launch` injects it
 
 ```bash
 imsg send-rich --chat 'iMessage;-;+15551234567' --text 'hi' --reply-to MSG_GUID   # replies, effects, subjects
-imsg poll send --chat GUID --question 'Dinner?' --option 'Pizza' --option 'Sushi'  # native Messages poll; --question + 2+ --option
+imsg poll send --chat GUID --question 'Dinner?' --option 'Pizza' --option 'Sushi' --comment 'Vote by 5pm'
 imsg edit --chat GUID --message MSG_GUID --new-text 'updated'                     # macOS 13+
 imsg chat-create --addresses '+15551234567,+15559876543' --name 'Crew'
 ```
+
+`poll send` echoes `--question` as a best-effort plain caption after the Polls balloon; `--comment` overrides that caption. Do not retry automatically when only the caption fails: the poll may already be delivered. `history` and `watch` backfill a title-less inbound native poll's `poll.question` from its clean caption row.
 
 Destructive bridge commands — `unsend`, `delete-message`, `chat-delete`, `chat-leave`, `chat-remove-member` — need per-action user confirmation.
 

--- a/.agents/skills/imsg/SKILL.md
+++ b/.agents/skills/imsg/SKILL.md
@@ -77,7 +77,7 @@ imsg edit --chat GUID --message MSG_GUID --new-text 'updated'                   
 imsg chat-create --addresses '+15551234567,+15559876543' --name 'Crew'
 ```
 
-`poll send` echoes `--question` as a reply comment on the poll (the visible caption) — Messages never renders the poll title on the balloon, so this is what recipients actually see. `--comment` overrides the echoed text.
+Native poll balloons show no title, so `poll send` sends `--question` as a plain caption message right after the poll — what recipients actually see (`--comment` overrides). The reverse holds on read: `imsg history`/`watch` backfill an inbound native poll's `question` from its caption, so a received poll surfaces its real question instead of an empty one.
 
 Destructive bridge commands — `unsend`, `delete-message`, `chat-delete`, `chat-leave`, `chat-remove-member` — need per-action user confirmation.
 

--- a/.agents/skills/imsg/SKILL.md
+++ b/.agents/skills/imsg/SKILL.md
@@ -72,12 +72,10 @@ Only after `imsg status` confirms the bridge is loaded (`imsg launch` injects it
 
 ```bash
 imsg send-rich --chat 'iMessage;-;+15551234567' --text 'hi' --reply-to MSG_GUID   # replies, effects, subjects
-imsg poll send --chat GUID --question 'Dinner?' --option 'Pizza' --option 'Sushi'  # --question auto-shows as a poll comment
+imsg poll send --chat GUID --question 'Dinner?' --option 'Pizza' --option 'Sushi'  # native Messages poll; --question + 2+ --option
 imsg edit --chat GUID --message MSG_GUID --new-text 'updated'                     # macOS 13+
 imsg chat-create --addresses '+15551234567,+15559876543' --name 'Crew'
 ```
-
-Native poll balloons show no title, so `poll send` sends `--question` as a plain caption message right after the poll — what recipients actually see (`--comment` overrides). The reverse holds on read: `imsg history`/`watch` backfill an inbound native poll's `question` from its caption, so a received poll surfaces its real question instead of an empty one.
 
 Destructive bridge commands — `unsend`, `delete-message`, `chat-delete`, `chat-leave`, `chat-remove-member` — need per-action user confirmation.
 

--- a/.agents/skills/imsg/SKILL.md
+++ b/.agents/skills/imsg/SKILL.md
@@ -11,8 +11,8 @@ description: "iMessage/SMS via the imsg CLI: read local Messages history, search
 
 - Every read command supports `--json` and emits **NDJSON** (one object per line). Pipe to `jq -s` to get an array. Stdout carries only JSON; progress and warnings go to stderr.
 - Two capability tiers:
-  - **Standard** (normal permissions): `chats`, `group`, `history`, `watch`, `search`, `send`, `react`, `nickname`, `account --local`, `whois --local`.
-  - **Bridge** (SIP disabled + `imsg launch` dylib injection): `send-rich`, `send-multipart`, `send-attachment`, `tapback`, `poll`, `edit`, `unsend`, `delete-message`, `read`, `typing`, `notify-anyways`, `chat-*`, and default-mode `account`/`whois`.
+  - **Standard** (normal permissions): `chats`, `group`, `history`, `watch`, `search`, `send`, `react`, `nickname --local`, `account --local`, `whois --local`.
+  - **Bridge** (SIP disabled + `imsg launch` dylib injection): `send-rich`, `send-multipart`, `send-attachment`, `tapback`, `poll`, `edit`, `unsend`, `delete-message`, `read`, `typing`, `notify-anyways`, `chat-*`, and default-mode `account`/`whois`/`nickname`.
 - Check availability with `imsg status --json` before using bridge commands. If the bridge is down, fall back to the standard equivalent (`send` for `send-rich`, `react` for `tapback`, `--local` flags) — never suggest disabling SIP unprompted.
 - Full command and flag reference: `imsg completions llm`.
 
@@ -43,7 +43,7 @@ imsg history --chat-id ID --start 2025-01-01T00:00:00Z --end 2025-02-01T00:00:00
 - `--start` is inclusive, `--end` exclusive; both take ISO8601. Use absolute timestamps for date-scoped questions.
 - `--attachments` adds attachment metadata; `--convert-attachments` converts CAF→M4A / GIF→PNG for model consumption.
 - `imsg search --query "pizza tonight" --json` searches message bodies only (`--match contains` default, `exact` available).
-- SIP-free lookups: `imsg whois --address "+15551234567" --type phone --local`, `imsg nickname --address "+15551234567" --json`, `imsg account --local --json`.
+- SIP-free lookups: `imsg whois --address "+15551234567" --type phone --local`, `imsg nickname --address "+15551234567" --local --json`, `imsg account --local --json`. Note `nickname --local` returns *your* AddressBook label for the handle; the iMessage-shared nickname needs default-mode `nickname` via the bridge.
 - Direct `sqlite3` queries are a last resort; the `handle` table lacks the resolved names `imsg chats` provides.
 
 ## Streaming

--- a/.agents/skills/imsg/SKILL.md
+++ b/.agents/skills/imsg/SKILL.md
@@ -1,62 +1,83 @@
 ---
 name: imsg
-description: "iMessage/SMS: local archive, contacts, chat history, watch, requested sends."
+description: "iMessage/SMS via the imsg CLI: read local Messages history, search, stream live, resolve contacts, and send (sends only when explicitly requested). Use for any Messages.app / chat.db task."
 ---
 
 # imsg
 
-Use this for Messages.app history, chat lookup, streaming, visible UI contact lookup, and sends. Reading is local DB access; sending uses Messages automation and must be explicitly requested.
+`imsg` reads `~/Library/Messages/chat.db` directly and sends through Messages.app automation. Reading is local and safe. **Sending, reacting, marking read, typing indicators, and any chat mutation require an explicit user request** — confirm recipient, service, and content in your final summary.
 
-## Sources
+## Ground rules
 
-- DB: `~/Library/Messages/chat.db`
-- Repo: `~/Projects/imsg`
-- CLI: `imsg`
-- JSON output is NDJSON; pipe to `jq -s` for arrays.
+- Every read command supports `--json` and emits **NDJSON** (one object per line). Pipe to `jq -s` to get an array. Stdout carries only JSON; progress and warnings go to stderr.
+- Two capability tiers:
+  - **Standard** (normal permissions): `chats`, `group`, `history`, `watch`, `search`, `send`, `react`, `nickname`, `account --local`, `whois --local`.
+  - **Bridge** (SIP disabled + `imsg launch` dylib injection): `send-rich`, `send-multipart`, `send-attachment`, `tapback`, `poll`, `edit`, `unsend`, `delete-message`, `read`, `typing`, `notify-anyways`, `chat-*`, and default-mode `account`/`whois`.
+- Check availability with `imsg status --json` before using bridge commands. If the bridge is down, fall back to the standard equivalent (`send` for `send-rich`, `react` for `tapback`, `--local` flags) — never suggest disabling SIP unprompted.
+- Full command and flag reference: `imsg completions llm`.
 
-## Read Workflow
-
-Check DB access:
+## Preconditions
 
 ```bash
-sqlite3 ~/Library/Messages/chat.db 'pragma quick_check;'
+imsg status --json                                        # feature availability + setup hints
+sqlite3 ~/Library/Messages/chat.db 'pragma quick_check;'  # fails => terminal lacks Full Disk Access
 ```
 
-For a visible Messages.app person/name, start with chats. The UI-resolved name usually appears as `contact_name`; it may not appear in `imsg search`, raw `message.text`, or the `handle` table.
+## Reading
+
+Resolve a person visible in the Messages.app UI from `chats`, not `search`. The UI name usually surfaces as `contact_name` (Contacts permission); it does not appear in `imsg search` results, raw `message.text`, or the DB `handle` table. **No search hits is not proof the contact doesn't exist.**
 
 ```bash
 imsg chats --limit 200 --json | jq -s '.[] | select((.contact_name // .display_name // .name // .identifier // "" | ascii_downcase) | contains("beatrix"))'
 ```
 
-Then read the chat by id:
+Then inspect and read the chat by rowid:
 
 ```bash
-imsg history --chat-id ID --json | jq -s
+imsg group --chat-id ID --json                 # identity + participants; check before automating
+imsg history --chat-id ID --limit 50 --json | jq -s
+imsg history --chat-id ID --start 2025-01-01T00:00:00Z --end 2025-02-01T00:00:00Z --json
 ```
 
-Use `imsg search --query ... --json` for message-body search only; do not treat no search hits as proof that a visible UI contact does not exist. Use `--attachments` when attachment metadata matters. Use `--start`/`--end` with absolute timestamps for date-scoped questions.
+- Chat `id` is the `chat.db` rowid: stable on one machine, the preferred `--chat-id` handle. `identifier` and `guid` are portable across machines.
+- `--start` is inclusive, `--end` exclusive; both take ISO8601. Use absolute timestamps for date-scoped questions.
+- `--attachments` adds attachment metadata; `--convert-attachments` converts CAF→M4A / GIF→PNG for model consumption.
+- `imsg search --query "pizza tonight" --json` searches message bodies only (`--match contains` default, `exact` available).
+- SIP-free lookups: `imsg whois --address "+15551234567" --type phone --local`, `imsg nickname --address "+15551234567" --json`, `imsg account --local --json`.
+- Direct `sqlite3` queries are a last resort; the `handle` table lacks the resolved names `imsg chats` provides.
 
-Useful current commands:
+## Streaming
 
 ```bash
-imsg search --query "pizza tonight" --match contains --json | jq -s
-imsg status --json
-imsg account --json
-imsg whois --address "+15551234567" --type phone --json
-imsg nickname --address "+15551234567" --json
+imsg watch --chat-id ID --json                 # filesystem events with polling fallback
+imsg watch --since-rowid N --json              # resume from a message id cursor
 ```
 
-Direct DB checks are only a fallback. The `handle` table is keyed by phone/email and often lacks the contact display name that `imsg chats` resolves.
+Message `id` doubles as the watch cursor: persist the last-seen id and pass it back via `--since-rowid`. Add `--reactions` for tapback add/remove events and `--attachments` for attachment metadata.
 
-## Sends
-
-Only send, react, mark read, or show typing when the user explicitly asks. Prefer dry wording in the final confirmation: recipient, service, and what was sent.
-
-Common send command:
+## Sending (explicit request only)
 
 ```bash
 imsg send --to "+15551234567" --text "message" --service auto
+imsg send --chat-id ID --text "message"        # prefer for groups: no address ambiguity
+imsg send --to "+15551234567" --file ~/Desktop/pic.jpg
 ```
+
+- `--service auto` prefers iMessage and falls back to SMS for text-only phone sends; `--no-sms-fallback` disables that.
+- `imsg react --chat-id ID --reaction like` (AppleScript) only targets the **most recent incoming message** and needs Accessibility permission. To react to a specific message by GUID, use bridge `tapback`.
+
+## Bridge extras
+
+Only after `imsg status` confirms the bridge is loaded (`imsg launch` injects it; refuses when SIP is on; macOS 26 entitlement gates can block features even with SIP off):
+
+```bash
+imsg send-rich --chat 'iMessage;-;+15551234567' --text 'hi' --reply-to MSG_GUID   # replies, effects, subjects
+imsg poll send --chat GUID --question 'Dinner?' --option 'Pizza' --option 'Sushi'
+imsg edit --chat GUID --message MSG_GUID --new-text 'updated'                     # macOS 13+
+imsg chat-create --addresses '+15551234567,+15559876543' --name 'Crew'
+```
+
+Destructive bridge commands — `unsend`, `delete-message`, `chat-delete`, `chat-leave`, `chat-remove-member` — need per-action user confirmation.
 
 ## Verification
 
@@ -65,10 +86,5 @@ For repo edits:
 ```bash
 make test
 make build
-```
-
-For live read proof:
-
-```bash
-imsg chats --limit 3 --json | jq -s
+./bin/imsg chats --limit 3 --json | jq -s      # live read proof against the local DB
 ```

--- a/.agents/skills/imsg/SKILL.md
+++ b/.agents/skills/imsg/SKILL.md
@@ -72,10 +72,12 @@ Only after `imsg status` confirms the bridge is loaded (`imsg launch` injects it
 
 ```bash
 imsg send-rich --chat 'iMessage;-;+15551234567' --text 'hi' --reply-to MSG_GUID   # replies, effects, subjects
-imsg poll send --chat GUID --question 'Dinner?' --option 'Pizza' --option 'Sushi'
+imsg poll send --chat GUID --question 'Dinner?' --option 'Pizza' --option 'Sushi'  # --question auto-shows as a poll comment
 imsg edit --chat GUID --message MSG_GUID --new-text 'updated'                     # macOS 13+
 imsg chat-create --addresses '+15551234567,+15559876543' --name 'Crew'
 ```
+
+`poll send` echoes `--question` as a reply comment on the poll (the visible caption) — Messages never renders the poll title on the balloon, so this is what recipients actually see. `--comment` overrides the echoed text.
 
 Destructive bridge commands — `unsend`, `delete-message`, `chat-delete`, `chat-leave`, `chat-remove-member` — need per-action user confirmation.
 

--- a/.agents/skills/imsg/SKILL.md
+++ b/.agents/skills/imsg/SKILL.md
@@ -13,7 +13,7 @@ description: "iMessage/SMS: local history, contacts, live watch, and requested s
 - Two capability tiers:
   - **Standard** (normal permissions): `chats`, `group`, `history`, `watch`, `search`, `send`, `react`, `nickname --local`, `account --local`, `whois --local`.
   - **Bridge** (SIP disabled + `imsg launch` dylib injection): `send-rich`, `send-multipart`, `send-attachment`, `tapback`, `poll`, `edit`, `unsend`, `delete-message`, `read`, `typing`, `notify-anyways`, `chat-*`, and default-mode `account`/`whois`/`nickname`.
-- Check availability with `imsg status --json` before using bridge commands. If the bridge is down, fall back to the standard equivalent (`send` for `send-rich`, `react` for `tapback`, `--local` flags) — never suggest disabling SIP unprompted.
+- Check availability with `imsg status --json` before using bridge commands. If the bridge is down, use a standard command only when it preserves the requested semantics; otherwise stop and explain. Never turn a reply/effect/subject into a plain send or a GUID-targeted tapback into `react`, and never suggest disabling SIP unprompted.
 - Full command and flag reference: `imsg completions llm`.
 
 ## Preconditions


### PR DESCRIPTION
## Summary

Rewrites `.agents/skills/imsg/SKILL.md` so agents get an accurate, complete picture of the CLI. The previous version covered only chats/history/search/send, hardcoded a machine-specific repo path (`~/Projects/imsg`), and never mentioned the standard-vs-bridge capability split.

Changes (verified against `imsg completions llm` and `docs/`):

- **Two-tier capability model up front**: standard commands (chats/group/history/watch/search/send/react + `--local` lookups) vs bridge commands (send-rich, tapback, poll, edit/unsend, chat-*), gated on `imsg status --json`, with explicit guidance to fall back to standard equivalents rather than suggest disabling SIP.
- **Progressive disclosure**: points agents at `imsg completions llm` for the full flag reference so the skill stays short.
- Keeps the original's key insight (resolve UI-visible people via `chats`/`contact_name`, not `search`) and adds what was missing: `group` before automating, `--start`/`--end` inclusive/exclusive semantics, `--since-rowid` as the watch cursor, `--convert-attachments`, SMS fallback behavior, and `react`'s most-recent-message-only limitation with `tapback` as the bridge alternative.
- Requires per-action user confirmation for destructive bridge commands (`unsend`, `delete-message`, `chat-delete`, `chat-leave`, `chat-remove-member`).
- Verification now uses `./bin/imsg` (the source-build output) for live read proof.

Review fix (540c803): default `nickname` moved to the bridge tier; the SIP-free tier and example now use `nickname --local`, with a note that `--local` returns your own AddressBook label rather than the iMessage-shared nickname. Matches `Sources/imsg/Commands/BridgeIntroCommands.swift` and the CLI help below.

**Poll docs scope (decoupled from #155):** an earlier revision documented the poll question echoing as a visible caption, the `--comment` override, and inbound question backfill. That behavior lives in #155, not on shipped `main` — `imsg poll --help` on 0.12.2 exposes only `--question`/`--option`, no `--comment`. Those claims were removed so this skill documents only shipped behavior and merges independently; #157 tracks re-adding them once #155 lands.

## Validation transcript

Run against imsg 0.12.2 (Homebrew) on macOS:

```console
$ imsg --version
0.12.2

$ imsg completions llm | grep -c "^### "   # command sections in the agent reference
33

$ imsg poll --help | grep -E '^\s+--'      # shipped poll surface: no --comment
  --db <value>	Path to chat.db (defaults to ~/Library/Messages/chat.db)
  --chat <value>	chat guid or rowid
  --chat-id <value>	chat rowid
  --question <value>	poll question
  --option <value>	poll option text; pass at least twice
  --option-id <value>	vote: UUID of the option to select
  --option-index <value>	vote: 1-based option number to select

$ imsg nickname --help | head -11
imsg nickname
Show contact-card / nickname info for a handle

The default mode reads the contact-card nickname the correspondent shared
over iMessage via the IMCore bridge (requires `imsg launch`, SIP disabled).

--local is a SIP-free alternative that returns YOUR local AddressBook
contact name for the handle. NOTE: this is a different datum — it is your
own contact label, not the iMessage-shared nickname/photo, which is only
available through the bridge.

$ imsg status --json | jq '{sip, v2_ready, basic_features, typing_indicators, read_receipts}'
{
  "sip": "enabled",
  "v2_ready": false,
  "basic_features": true,
  "typing_indicators": false,
  "read_receipts": false
}
```

(The `status` output above is from a SIP-enabled machine — exactly the state where the skill's fallback guidance applies.)

jq chat-filter example validated against synthetic NDJSON matching `docs/json.md`'s Chat schema:

```console
$ printf '%s\n' '{"id":1,"contact_name":"Beatrix Smith","identifier":"+15551234567"}' '{"id":2,"name":"Other"}' \
    | jq -s '.[] | select((.contact_name // .display_name // .name // .identifier // "" | ascii_downcase) | contains("beatrix")) | .id'
1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
