### PR TITLE
fix(poll): make the poll question visible both directions (echo out, backfill in)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.12.3 - Unreleased
 
+### Native Polls
+- fix: show native poll questions by sending a plain caption after created polls and backfilling empty inbound questions from clean native caption rows (#155, thanks @omarshahine).
+
 ### Packaging
 - fix: include and validate an arm64e slice in the injected bridge helper for macOS 26 Messages compatibility (#156, thanks @omarshahine).
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Advanced IMCore (require `imsg launch` with SIP off — see
 - `imsg send-rich [--reply-to <guid>] [--file <path>]`,
   `imsg send-multipart`, `imsg send-attachment [--reply-to <guid>]`,
   `imsg tapback`
-- `imsg poll send (--chat <guid> | --chat-id <id>) --question <text> --option <text> --option <text> [--reply-to <guid>]`
+- `imsg poll send (--chat <guid> | --chat-id <id>) --question <text> [--comment <text>] --option <text> --option <text> [--reply-to <guid>]`
 - `imsg poll vote (--chat <guid> | --chat-id <id>) --poll <guid> (--option-id <id> | --option-index <n> | --option <text>)`
 - `imsg edit`, `imsg unsend`, `imsg delete-message`, `imsg notify-anyways`
 - `imsg chat-create`, `imsg chat-name`, `imsg chat-photo`,
@@ -139,6 +139,10 @@ Advanced IMCore (require `imsg launch` with SIP off — see
 `imsg status --json` reports native bridge selector capabilities. Poll creation
 requires `selectors.pollPayloadMessage`; poll voting requires
 `selectors.pollVoteMessage` plus `poll.vote` in `rpc_methods`.
+Messages does not render the poll payload title on the balloon, so `poll send`
+also sends a best-effort plain caption message right after the poll. The
+caption defaults to `--question`; use `--comment` when the visible text should
+be different from the stored question.
 
 `react` intentionally sends only the standard tapbacks Messages.app exposes
 reliably through automation. Custom emoji tapbacks can be read from

--- a/Sources/IMsgCore/MessagePolls.swift
+++ b/Sources/IMsgCore/MessagePolls.swift
@@ -327,6 +327,24 @@ extension MessagePollEvent {
       metadata: metadata
     )
   }
+
+  /// Returns a copy with `question` filled in. Used to backfill a native poll's
+  /// empty title (item.title) from its caption message so the poll is
+  /// self-describing to consumers.
+  func withQuestion(_ newQuestion: String) -> MessagePollEvent {
+    MessagePollEvent(
+      kind: kind,
+      pollGUID: pollGUID,
+      question: newQuestion,
+      options: options,
+      vote: vote,
+      votes: votes,
+      originalGUID: originalGUID,
+      creator: creator,
+      participants: participants,
+      metadata: metadata
+    )
+  }
 }
 
 private struct PollFacts {

--- a/Sources/IMsgCore/MessageStore+Polls.swift
+++ b/Sources/IMsgCore/MessageStore+Polls.swift
@@ -6,7 +6,25 @@ extension MessageStore {
     db: Connection,
     cache: inout PollOptionTextCache
   ) throws -> MessagePollEvent? {
-    guard let poll, poll.kind == .vote else { return poll }
+    guard let poll else { return nil }
+
+    // Native poll balloons carry no title (item.title is empty); a created
+    // poll's question is sent as a separate caption message that replies to the
+    // poll (the "comment or Send" field). Backfill an empty created-poll question
+    // from that caption so the poll is self-describing to consumers — e.g.
+    // openclaw renders "📊 Poll: <question>" only when the question is present.
+    if poll.kind == .created,
+      poll.question?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true,
+      let raw = poll.pollGUID
+    {
+      let pollGUID = normalizeAssociatedGUID(raw)
+      if !pollGUID.isEmpty, let caption = try pollCommentText(db, pollGUID: pollGUID) {
+        return poll.withQuestion(caption)
+      }
+      return poll
+    }
+
+    guard poll.kind == .vote else { return poll }
     let candidateGUIDs = [poll.originalGUID, poll.pollGUID]
       .compactMap { value -> String? in
         guard let value else { return nil }

--- a/Sources/IMsgCore/MessageStore+ReplyContext.swift
+++ b/Sources/IMsgCore/MessageStore+ReplyContext.swift
@@ -38,6 +38,30 @@ extension MessageStore {
     return (text: decoded.text, sender: decoded.sender)
   }
 
+  /// The caption text of a native poll: the earliest message whose
+  /// `reply_to_guid` targets the poll. Native poll comments (the "comment or
+  /// Send" field) carry the question in a separate reply message because the
+  /// poll balloon has no title, so this is how the question reaches us when the
+  /// poll's own `item.title` is empty. Decoded via `decodeMessageRow` for the
+  /// same attributedBody fallback as everywhere else.
+  func pollCommentText(_ db: Connection, pollGUID: String) throws -> String? {
+    guard !pollGUID.isEmpty else { return nil }
+    let selection = MessageRowSelection(store: self, includeChatID: false)
+    let sql = """
+      SELECT \(selection.selectList)
+      FROM message m
+      LEFT JOIN handle h ON m.handle_id = h.ROWID
+      WHERE m.reply_to_guid = ?
+      ORDER BY m.date ASC
+      LIMIT 1
+      """
+    let rows = try db.prepareRowIterator(sql, bindings: [pollGUID])
+    guard let row = try rows.failableNext() else { return nil }
+    let decoded = try decodeMessageRow(row, columns: selection.columns, fallbackChatID: nil)
+    let text = decoded.text.trimmingCharacters(in: .whitespacesAndNewlines)
+    return text.isEmpty ? nil : text
+  }
+
   /// Walks `threadOriginatorGUID` then `replyToGUID` and returns the first
   /// successful parent resolution, consulting `cache` to amortize repeated
   /// lookups within one query loop. Lookup failures (absent parent, SQLite

--- a/Sources/IMsgCore/MessageStore+ReplyContext.swift
+++ b/Sources/IMsgCore/MessageStore+ReplyContext.swift
@@ -46,6 +46,9 @@ extension MessageStore {
   /// same attributedBody fallback as everywhere else.
   func pollCommentText(_ db: Connection, pollGUID: String) throws -> String? {
     guard !pollGUID.isEmpty else { return nil }
+    // Older/synthetic message tables may lack reply_to_guid; without it a poll
+    // comment cannot be located, so skip the query rather than fail the pull.
+    guard schema.hasReplyToGUIDColumn else { return nil }
     let selection = MessageRowSelection(store: self, includeChatID: false)
     let sql = """
       SELECT \(selection.selectList)

--- a/Sources/IMsgCore/MessageStore+ReplyContext.swift
+++ b/Sources/IMsgCore/MessageStore+ReplyContext.swift
@@ -50,11 +50,23 @@ extension MessageStore {
     // comment cannot be located, so skip the query rather than fail the pull.
     guard schema.hasReplyToGUIDColumn else { return nil }
     let selection = MessageRowSelection(store: self, includeChatID: false)
+    // The question caption is a plain message (associated_message_type 0) with no
+    // thread metadata. A threaded inline reply to the poll (type 100, thread
+    // originator set) is NOT the question — exclude it so a reply is never
+    // mistaken for the caption. Both columns are schema-optional, so only add the
+    // filter when the column exists.
+    var conditions = ["m.reply_to_guid = ?"]
+    if schema.hasReactionColumns {
+      conditions.append("m.associated_message_type = 0")
+    }
+    if schema.hasThreadOriginatorGUIDColumn {
+      conditions.append("m.thread_originator_guid IS NULL")
+    }
     let sql = """
       SELECT \(selection.selectList)
       FROM message m
       LEFT JOIN handle h ON m.handle_id = h.ROWID
-      WHERE m.reply_to_guid = ?
+      WHERE \(conditions.joined(separator: " AND "))
       ORDER BY m.date ASC
       LIMIT 1
       """

--- a/Sources/IMsgCore/MessageStore+ReplyContext.swift
+++ b/Sources/IMsgCore/MessageStore+ReplyContext.swift
@@ -50,14 +50,15 @@ extension MessageStore {
     // comment cannot be located, so skip the query rather than fail the pull.
     guard schema.hasReplyToGUIDColumn else { return nil }
     let selection = MessageRowSelection(store: self, includeChatID: false)
-    // The question caption is a plain message (associated_message_type 0) with no
-    // thread metadata. A threaded inline reply to the poll (type 100, thread
-    // originator set) is NOT the question — exclude it so a reply is never
-    // mistaken for the caption. Both columns are schema-optional, so only add the
-    // filter when the column exists.
-    var conditions = ["m.reply_to_guid = ?"]
+    // The question caption is a plain message (associated_message_type 0 or NULL)
+    // with no thread metadata. A threaded inline reply to the poll (type 100,
+    // thread originator set) is NOT the question — exclude it so a reply is never
+    // mistaken for the caption. Reply references may use Apple's `p:<part>/GUID`
+    // form, so match both the bare and prefixed values. Both association columns
+    // are schema-optional, so only add their filters when they exist.
+    var conditions = ["(m.reply_to_guid = ? OR m.reply_to_guid LIKE '%/' || ?)"]
     if schema.hasReactionColumns {
-      conditions.append("m.associated_message_type = 0")
+      conditions.append("(m.associated_message_type IS NULL OR m.associated_message_type = 0)")
     }
     if schema.hasThreadOriginatorGUIDColumn {
       conditions.append("m.thread_originator_guid IS NULL")
@@ -67,10 +68,10 @@ extension MessageStore {
       FROM message m
       LEFT JOIN handle h ON m.handle_id = h.ROWID
       WHERE \(conditions.joined(separator: " AND "))
-      ORDER BY m.date ASC
+      ORDER BY m.date ASC, m.ROWID ASC
       LIMIT 1
       """
-    let rows = try db.prepareRowIterator(sql, bindings: [pollGUID])
+    let rows = try db.prepareRowIterator(sql, bindings: [pollGUID, pollGUID])
     guard let row = try rows.failableNext() else { return nil }
     let decoded = try decodeMessageRow(row, columns: selection.columns, fallbackChatID: nil)
     let text = decoded.text.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sources/imsg/Commands/PollCommand.swift
+++ b/Sources/imsg/Commands/PollCommand.swift
@@ -30,12 +30,15 @@ enum PollCommand {
           .make(
             label: "question", names: [.long("question")],
             help:
-              "poll question. Messages does not render the poll title on the balloon, so imsg sends this as a plain caption message right after the poll (the visible text) and also stores it as the payload title for agent readback"
+              "poll question. Messages does not render the poll title on the balloon, so imsg "
+              + "sends this as a plain caption message right after the poll (the visible text) "
+              + "and also stores it as the payload title for agent readback"
           ),
           .make(
             label: "comment", names: [.long("comment")],
             help:
-              "optional override for the caption text; defaults to --question. Sent as a plain message right after the poll, matching Messages' native 'comment or Send' field"
+              "optional override for the caption text; defaults to --question. Sent as a plain "
+              + "message right after the poll, matching Messages' native 'comment or Send' field"
           ),
           .make(label: "replyTo", names: [.long("reply-to")], help: "guid of message to reply to"),
           .make(

--- a/Sources/imsg/Commands/PollCommand.swift
+++ b/Sources/imsg/Commands/PollCommand.swift
@@ -12,11 +12,12 @@ enum PollCommand {
       action to cast a vote on an existing poll.
 
       Messages renders only the options on a poll balloon — the poll title is
-      never shown to recipients. So `send` automatically echoes `--question` as a
-      reply comment on the poll (a text whose reply_to is the poll guid), which
-      is exactly what the native "comment or Send" field produces. Callers pass
-      only `--question` and the visible caption appears for free; `--comment`
-      overrides the echoed text when the caption should differ from the title.
+      never shown to recipients. So `send` automatically sends `--question` as a
+      plain caption message right after the poll (matching how the native
+      "comment or Send" field renders — a message with no thread metadata, not a
+      threaded reply). Callers pass only `--question` and the visible caption
+      appears for free; `--comment` overrides the caption text when it should
+      differ from the title.
       """,
     signature: CommandSignatures.withRuntimeFlags(
       CommandSignature(
@@ -29,12 +30,12 @@ enum PollCommand {
           .make(
             label: "question", names: [.long("question")],
             help:
-              "poll question. Messages does not render the poll title on the balloon, so imsg echoes this as a reply comment on the poll (the visible caption) and also stores it as the payload title for agent readback"
+              "poll question. Messages does not render the poll title on the balloon, so imsg sends this as a plain caption message right after the poll (the visible text) and also stores it as the payload title for agent readback"
           ),
           .make(
             label: "comment", names: [.long("comment")],
             help:
-              "optional override for the visible comment text; defaults to --question. Sent as a reply to the poll, matching Messages' native 'comment or Send' field"
+              "optional override for the caption text; defaults to --question. Sent as a plain message right after the poll, matching Messages' native 'comment or Send' field"
           ),
           .make(label: "replyTo", names: [.long("reply-to")], help: "guid of message to reply to"),
           .make(
@@ -121,11 +122,14 @@ enum PollCommand {
 
     // Messages renders only the poll options on the balloon — the poll title
     // (payload item.title) is never shown to recipients. To make the poll's
-    // question visible we echo it as a reply comment on the poll, which is
-    // exactly what the native "comment or Send" field produces (a text message
-    // whose reply_to is the poll guid). Callers set only --question; the visible
-    // caption comes for free, so agents need no knowledge of this. --comment
-    // overrides the echoed text when the visible caption should differ.
+    // question visible we send it as a PLAIN caption message right after the
+    // poll, matching how the native "comment or Send" field renders. It is NOT
+    // a threaded reply: native poll comments carry no thread metadata, so a
+    // reply (which sets thread_originator) would decorate the poll balloon with
+    // a reply connector. Outbound (from_me) rows are cached and never
+    // re-processed downstream, so no poll<->comment link is needed on our sends.
+    // Callers set only --question; the caption comes for free, so agents need no
+    // knowledge of this. --comment overrides the echoed text.
     let comment = values.option("comment").flatMap { $0.isEmpty ? nil : $0 } ?? question
     let pollGuid = (data["messageGuid"] as? String) ?? ""
     if !comment.isEmpty, !pollGuid.isEmpty {
@@ -134,7 +138,6 @@ enum PollCommand {
         [
           "chatGuid": chat,
           "message": comment,
-          "selectedMessageGuid": pollGuid,
         ])
     }
   }

--- a/Sources/imsg/Commands/PollCommand.swift
+++ b/Sources/imsg/Commands/PollCommand.swift
@@ -10,6 +10,13 @@ enum PollCommand {
       Requires `imsg launch` (SIP-disabled, dylib injected). Use the `send`
       action to create a native Messages Polls extension balloon, or the `vote`
       action to cast a vote on an existing poll.
+
+      Messages renders only the options on a poll balloon — the poll title is
+      never shown to recipients. So `send` automatically echoes `--question` as a
+      reply comment on the poll (a text whose reply_to is the poll guid), which
+      is exactly what the native "comment or Send" field produces. Callers pass
+      only `--question` and the visible caption appears for free; `--comment`
+      overrides the echoed text when the caption should differ from the title.
       """,
     signature: CommandSignatures.withRuntimeFlags(
       CommandSignature(
@@ -19,7 +26,16 @@ enum PollCommand {
         options: CommandSignatures.baseOptions() + [
           .make(label: "chat", names: [.long("chat")], help: "chat guid or rowid"),
           .make(label: "chatID", names: [.long("chat-id")], help: "chat rowid"),
-          .make(label: "question", names: [.long("question")], help: "poll question"),
+          .make(
+            label: "question", names: [.long("question")],
+            help:
+              "poll question. Messages does not render the poll title on the balloon, so imsg echoes this as a reply comment on the poll (the visible caption) and also stores it as the payload title for agent readback"
+          ),
+          .make(
+            label: "comment", names: [.long("comment")],
+            help:
+              "optional override for the visible comment text; defaults to --question. Sent as a reply to the poll, matching Messages' native 'comment or Send' field"
+          ),
           .make(label: "replyTo", names: [.long("reply-to")], help: "guid of message to reply to"),
           .make(
             label: "option", names: [.long("option")],
@@ -38,6 +54,7 @@ enum PollCommand {
     ),
     usageExamples: [
       "imsg poll send --chat 'iMessage;-;+15551234567' --question 'Dinner?' --option 'Pizza' --option 'Sushi'",
+      "imsg poll send --chat 'iMessage;-;+15551234567' --question 'Dinner?' --comment 'Vote by 5pm 🍽️' --option 'Pizza' --option 'Sushi'",
       "imsg poll send --chat 'iMessage;-;+15551234567' --reply-to ABCD --question 'Approve?' --option 'Yes' --option 'No'",
       "imsg poll vote --chat 'iMessage;-;+15551234567' --poll ABCD --option-id 1B2C-...",
     ]
@@ -92,7 +109,7 @@ enum PollCommand {
       params["selectedMessageGuid"] = reply
     }
 
-    _ = try await BridgeOutput.invokeAndEmit(
+    let data = try await BridgeOutput.invokeAndEmit(
       action: .sendPoll,
       params: params,
       runtime: runtime,
@@ -100,6 +117,25 @@ enum PollCommand {
     ) { data in
       let guid = (data["messageGuid"] as? String) ?? ""
       return guid.isEmpty ? "poll: queued" : "poll: sent (guid=\(guid))"
+    }
+
+    // Messages renders only the poll options on the balloon — the poll title
+    // (payload item.title) is never shown to recipients. To make the poll's
+    // question visible we echo it as a reply comment on the poll, which is
+    // exactly what the native "comment or Send" field produces (a text message
+    // whose reply_to is the poll guid). Callers set only --question; the visible
+    // caption comes for free, so agents need no knowledge of this. --comment
+    // overrides the echoed text when the visible caption should differ.
+    let comment = values.option("comment").flatMap { $0.isEmpty ? nil : $0 } ?? question
+    let pollGuid = (data["messageGuid"] as? String) ?? ""
+    if !comment.isEmpty, !pollGuid.isEmpty {
+      _ = try await invokeBridge(
+        .sendMessage,
+        [
+          "chatGuid": chat,
+          "message": comment,
+          "selectedMessageGuid": pollGuid,
+        ])
     }
   }
 

--- a/Sources/imsg/Commands/PollCommand.swift
+++ b/Sources/imsg/Commands/PollCommand.swift
@@ -133,12 +133,20 @@ enum PollCommand {
     let comment = values.option("comment").flatMap { $0.isEmpty ? nil : $0 } ?? question
     let pollGuid = (data["messageGuid"] as? String) ?? ""
     if !comment.isEmpty, !pollGuid.isEmpty {
-      _ = try await invokeBridge(
-        .sendMessage,
-        [
-          "chatGuid": chat,
-          "message": comment,
-        ])
+      // Best-effort, mirroring the RPC path: the poll already delivered, so a
+      // caption failure must not exit nonzero — a retry would send a duplicate
+      // poll. Report the failure on stderr and leave the poll success intact.
+      do {
+        _ = try await invokeBridge(
+          .sendMessage,
+          [
+            "chatGuid": chat,
+            "message": comment,
+          ])
+      } catch {
+        FileHandle.standardError.write(
+          Data("[imsg] poll send: comment echo failed for poll \(pollGuid): \(error)\n".utf8))
+      }
     }
   }
 

--- a/Sources/imsg/Commands/PollCommand.swift
+++ b/Sources/imsg/Commands/PollCommand.swift
@@ -135,7 +135,7 @@ enum PollCommand {
     // knowledge of this. --comment overrides the echoed text.
     let comment = values.option("comment").flatMap { $0.isEmpty ? nil : $0 } ?? question
     let pollGuid = (data["messageGuid"] as? String) ?? ""
-    if !comment.isEmpty, !pollGuid.isEmpty {
+    if !comment.isEmpty {
       // Best-effort, mirroring the RPC path: the poll already delivered, so a
       // caption failure must not exit nonzero — a retry would send a duplicate
       // poll. Report the failure on stderr and leave the poll success intact.
@@ -147,8 +147,9 @@ enum PollCommand {
             "message": comment,
           ])
       } catch {
+        let pollDescription = pollGuid.isEmpty ? "queued poll" : "poll \(pollGuid)"
         FileHandle.standardError.write(
-          Data("[imsg] poll send: comment echo failed for poll \(pollGuid): \(error)\n".utf8))
+          Data("[imsg] poll send: comment echo failed for \(pollDescription): \(error)\n".utf8))
       }
     }
   }

--- a/Sources/imsg/RPCServer+BridgeMessageHandlers.swift
+++ b/Sources/imsg/RPCServer+BridgeMessageHandlers.swift
@@ -119,12 +119,15 @@ extension RPCServer {
       result["poll"] = poll
     }
 
-    // Messages never renders the poll title on the balloon, so echo the question
-    // (or an explicit `comment` override) as a reply comment on the poll — the
-    // same text-with-reply_to that the native "comment or Send" field produces.
-    // Callers pass only `question`; the visible caption appears for free and the
-    // agent needs no knowledge of this. Best-effort: the poll already succeeded,
-    // so a comment failure must not fail the RPC.
+    // Messages never renders the poll title on the balloon, so send the question
+    // (or an explicit `comment` override) as a PLAIN caption message right after
+    // the poll — matching how the native "comment or Send" field renders. Not a
+    // threaded reply: native poll comments carry no thread metadata, so a reply
+    // would decorate the balloon with a connector line. Outbound (from_me) rows
+    // are cached and never re-processed, so no poll<->comment link is needed.
+    // Callers pass only `question`; the caption appears for free and the agent
+    // needs no knowledge of this. Best-effort: the poll already succeeded, so a
+    // comment failure must not fail the RPC.
     let comment = stringParam(params["comment"]).flatMap { $0.isEmpty ? nil : $0 } ?? question
     if let pollGuid = data["messageGuid"] as? String, !pollGuid.isEmpty, !comment.isEmpty {
       do {
@@ -133,7 +136,6 @@ extension RPCServer {
           params: [
             "chatGuid": chatGUID,
             "message": comment,
-            "selectedMessageGuid": pollGuid,
           ])
       } catch {
         FileHandle.standardError.write(

--- a/Sources/imsg/RPCServer+BridgeMessageHandlers.swift
+++ b/Sources/imsg/RPCServer+BridgeMessageHandlers.swift
@@ -129,7 +129,7 @@ extension RPCServer {
     // needs no knowledge of this. Best-effort: the poll already succeeded, so a
     // comment failure must not fail the RPC.
     let comment = stringParam(params["comment"]).flatMap { $0.isEmpty ? nil : $0 } ?? question
-    if let pollGuid = data["messageGuid"] as? String, !pollGuid.isEmpty, !comment.isEmpty {
+    if !comment.isEmpty {
       do {
         _ = try await invokeBridge(
           action: .sendMessage,
@@ -138,8 +138,10 @@ extension RPCServer {
             "message": comment,
           ])
       } catch {
+        let pollGuid = (data["messageGuid"] as? String) ?? ""
+        let pollDescription = pollGuid.isEmpty ? "queued poll" : "poll \(pollGuid)"
         FileHandle.standardError.write(
-          Data("[imsg] poll.send: comment echo failed for poll \(pollGuid): \(error)\n".utf8))
+          Data("[imsg] poll.send: comment echo failed for \(pollDescription): \(error)\n".utf8))
       }
     }
     respond(id: id, result: result)

--- a/Sources/imsg/RPCServer+BridgeMessageHandlers.swift
+++ b/Sources/imsg/RPCServer+BridgeMessageHandlers.swift
@@ -118,6 +118,28 @@ extension RPCServer {
     if let poll = data["poll"] as? [String: Any] {
       result["poll"] = poll
     }
+
+    // Messages never renders the poll title on the balloon, so echo the question
+    // (or an explicit `comment` override) as a reply comment on the poll — the
+    // same text-with-reply_to that the native "comment or Send" field produces.
+    // Callers pass only `question`; the visible caption appears for free and the
+    // agent needs no knowledge of this. Best-effort: the poll already succeeded,
+    // so a comment failure must not fail the RPC.
+    let comment = stringParam(params["comment"]).flatMap { $0.isEmpty ? nil : $0 } ?? question
+    if let pollGuid = data["messageGuid"] as? String, !pollGuid.isEmpty, !comment.isEmpty {
+      do {
+        _ = try await invokeBridge(
+          action: .sendMessage,
+          params: [
+            "chatGuid": chatGUID,
+            "message": comment,
+            "selectedMessageGuid": pollGuid,
+          ])
+      } catch {
+        FileHandle.standardError.write(
+          Data("[imsg] poll.send: comment echo failed for poll \(pollGuid): \(error)\n".utf8))
+      }
+    }
     respond(id: id, result: result)
   }
 

--- a/Tests/IMsgCoreTests/MessagePollTests.swift
+++ b/Tests/IMsgCoreTests/MessagePollTests.swift
@@ -406,8 +406,9 @@ func messageStoreAttachesDecodedPollMetadata() throws {
 /// ignores a threaded reply.
 private func backfilledPollQuestion(
   replyText: String,
-  replyAssociatedType: Int,
-  replyThreadOriginator: String?
+  replyAssociatedType: Int?,
+  replyThreadOriginator: String?,
+  replyToGUID: String = "poll-row-guid"
 ) throws -> String? {
   let db = try Connection(.inMemory)
   var options = MessageDatabaseFixture.SchemaOptions()
@@ -465,10 +466,11 @@ private func backfilledPollQuestion(
       balloon_bundle_id, payload_data, message_summary_info, reply_to_guid,
       thread_originator_guid, date, is_from_me, service
     )
-    VALUES (2, 1, ?, 'reply-row-guid', NULL, ?, NULL, NULL, NULL, 'poll-row-guid', ?, ?, 0, 'iMessage')
+    VALUES (2, 1, ?, 'reply-row-guid', NULL, ?, NULL, NULL, NULL, ?, ?, ?, 0, 'iMessage')
     """,
     replyText,
-    replyAssociatedType,
+    replyAssociatedType.map { Int64($0) },
+    replyToGUID,
     replyThreadOriginator,
     TestDatabase.appleEpoch(now.addingTimeInterval(1))
   )
@@ -489,6 +491,27 @@ func messageStorePollBackfillsQuestionFromCleanCaption() throws {
   let question = try backfilledPollQuestion(
     replyText: "What is for dinner?",
     replyAssociatedType: 0,
+    replyThreadOriginator: nil
+  )
+  #expect(question == "What is for dinner?")
+}
+
+@Test
+func messageStorePollBackfillsQuestionFromPrefixedCaptionReference() throws {
+  let question = try backfilledPollQuestion(
+    replyText: "What is for dinner?",
+    replyAssociatedType: 0,
+    replyThreadOriginator: nil,
+    replyToGUID: "p:0/poll-row-guid"
+  )
+  #expect(question == "What is for dinner?")
+}
+
+@Test
+func messageStorePollBackfillsQuestionFromNullAssociationType() throws {
+  let question = try backfilledPollQuestion(
+    replyText: "What is for dinner?",
+    replyAssociatedType: nil,
     replyThreadOriginator: nil
   )
   #expect(question == "What is for dinner?")

--- a/Tests/IMsgCoreTests/MessagePollTests.swift
+++ b/Tests/IMsgCoreTests/MessagePollTests.swift
@@ -400,6 +400,113 @@ func messageStoreAttachesDecodedPollMetadata() throws {
   #expect(normalMessage.poll == nil)
 }
 
+/// Builds a title-less created poll (native polls carry no `item.title`) plus a
+/// single reply row, and returns the enriched poll's question after a full
+/// `messages()` read. Used to prove caption backfill picks a clean caption and
+/// ignores a threaded reply.
+private func backfilledPollQuestion(
+  replyText: String,
+  replyAssociatedType: Int,
+  replyThreadOriginator: String?
+) throws -> String? {
+  let db = try Connection(.inMemory)
+  var options = MessageDatabaseFixture.SchemaOptions()
+  options.includeReactionColumns = true
+  options.includeBalloonBundleID = true
+  options.includePayloadData = true
+  options.includeMessageSummaryInfo = true
+  options.includeReplyToGUID = true
+  options.includeThreadOriginatorGUID = true
+  try MessageDatabaseFixture.createSchema(db, options: options)
+
+  try db.run(
+    """
+    INSERT INTO chat(ROWID, chat_identifier, guid, display_name, service_name)
+    VALUES (1, '+15550001000', 'iMessage;+;chat-test', 'Poll Test', 'iMessage')
+    """
+  )
+  try db.run("INSERT INTO handle(ROWID, id) VALUES (1, '+15550001000')")
+
+  // Native created poll: empty title, so the question must come from a caption.
+  let definition: [String: Any] = [
+    "title": "",
+    "orderedPollOptions": [
+      ["optionIdentifier": "choice-a", "pollOptionText": "A"],
+      ["optionIdentifier": "choice-b", "pollOptionText": "B"],
+    ],
+  ]
+  let pollPayload = try PropertyListSerialization.data(
+    fromPropertyList: [
+      "url": try pollURL(queryName: "definition", object: definition).absoluteString
+    ],
+    format: .binary,
+    options: 0
+  )
+  let pollBlob = Blob(bytes: [UInt8](pollPayload))
+  let now = Date(timeIntervalSince1970: 1_700_000_000)
+
+  try db.run(
+    """
+    INSERT INTO message(
+      ROWID, handle_id, text, guid, associated_message_guid, associated_message_type,
+      balloon_bundle_id, payload_data, message_summary_info, reply_to_guid,
+      thread_originator_guid, date, is_from_me, service
+    )
+    VALUES (1, 1, '', 'poll-row-guid', NULL, NULL, ?, ?, NULL, NULL, NULL, ?, 0, 'iMessage')
+    """,
+    testPollBundleID,
+    pollBlob,
+    TestDatabase.appleEpoch(now)
+  )
+  try db.run(
+    """
+    INSERT INTO message(
+      ROWID, handle_id, text, guid, associated_message_guid, associated_message_type,
+      balloon_bundle_id, payload_data, message_summary_info, reply_to_guid,
+      thread_originator_guid, date, is_from_me, service
+    )
+    VALUES (2, 1, ?, 'reply-row-guid', NULL, ?, NULL, NULL, NULL, 'poll-row-guid', ?, ?, 0, 'iMessage')
+    """,
+    replyText,
+    replyAssociatedType,
+    replyThreadOriginator,
+    TestDatabase.appleEpoch(now.addingTimeInterval(1))
+  )
+  try db.run("INSERT INTO chat_message_join(chat_id, message_id) VALUES (1, 1)")
+  try db.run("INSERT INTO chat_message_join(chat_id, message_id) VALUES (1, 2)")
+
+  let store = try MessageStore(connection: db, path: ":memory:")
+  let messages = try store.messages(chatID: 1, limit: 10)
+  let pollMessage = try #require(messages.first { $0.guid == "poll-row-guid" })
+  #expect(pollMessage.poll?.kind == .created)
+  return pollMessage.poll?.question
+}
+
+@Test
+func messageStorePollBackfillsQuestionFromCleanCaption() throws {
+  // A plain caption (associated_message_type 0, no thread originator) is the
+  // native poll question and must backfill the empty created-poll title.
+  let question = try backfilledPollQuestion(
+    replyText: "What is for dinner?",
+    replyAssociatedType: 0,
+    replyThreadOriginator: nil
+  )
+  #expect(question == "What is for dinner?")
+}
+
+@Test
+func messageStorePollBackfillIgnoresThreadedReply() throws {
+  // A threaded inline reply to the poll (type 100, thread originator set) is NOT
+  // the question; with no clean caption the question must stay empty rather than
+  // adopt the reply text.
+  let question = try backfilledPollQuestion(
+    replyText: "just a reply, not the question",
+    replyAssociatedType: 100,
+    replyThreadOriginator: "poll-row-guid"
+  )
+  #expect((question ?? "").isEmpty)
+}
+
 @Test
 func messageStoreDecodesPollVoteRowsWithPayloadGate() throws {
   let db = try Connection(.inMemory)

--- a/Tests/imsgTests/BridgeRichCommandTests.swift
+++ b/Tests/imsgTests/BridgeRichCommandTests.swift
@@ -177,6 +177,39 @@ func pollCommandSendInvokesPollBridge() async throws {
 }
 
 @Test
+func pollCommandSendUsesCommentOverrideForVisibleCaption() async throws {
+  let values = ParsedValues(
+    positional: ["send"],
+    options: [
+      "chat": ["iMessage;-;+15551234567"],
+      "question": ["Dinner?"],
+      "comment": ["Vote by 5pm"],
+      "option": ["Pizza", "Sushi"],
+    ],
+    flags: []
+  )
+  let runtime = RuntimeOptions(parsedValues: values)
+  var calls: [(action: BridgeAction, params: [String: Any])] = []
+
+  _ = try await StdoutCapture.capture {
+    try await PollCommand.run(
+      values: values,
+      runtime: runtime,
+      invokeBridge: { action, params in
+        calls.append((action, params))
+        return ["messageGuid": "poll-guid"]
+      }
+    )
+  }
+
+  #expect(calls.count == 2)
+  #expect(calls.first?.action == .sendPoll)
+  #expect(calls.first?.params["question"] as? String == "Dinner?")
+  #expect(calls.last?.action == .sendMessage)
+  #expect(calls.last?.params["message"] as? String == "Vote by 5pm")
+}
+
+@Test
 func pollCommandSendResolvesChatID() async throws {
   let values = ParsedValues(
     positional: ["send"],

--- a/Tests/imsgTests/BridgeRichCommandTests.swift
+++ b/Tests/imsgTests/BridgeRichCommandTests.swift
@@ -177,7 +177,7 @@ func pollCommandSendInvokesPollBridge() async throws {
 }
 
 @Test
-func pollCommandSendUsesCommentOverrideForVisibleCaption() async throws {
+func pollCommandSendUsesCommentOverrideWithoutPollGuid() async throws {
   let values = ParsedValues(
     positional: ["send"],
     options: [
@@ -197,7 +197,7 @@ func pollCommandSendUsesCommentOverrideForVisibleCaption() async throws {
       runtime: runtime,
       invokeBridge: { action, params in
         calls.append((action, params))
-        return ["messageGuid": "poll-guid"]
+        return [:]
       }
     )
   }

--- a/Tests/imsgTests/BridgeRichCommandTests.swift
+++ b/Tests/imsgTests/BridgeRichCommandTests.swift
@@ -149,26 +149,30 @@ func pollCommandSendInvokesPollBridge() async throws {
     flags: []
   )
   let runtime = RuntimeOptions(parsedValues: values)
-  var capturedAction: BridgeAction?
-  var capturedParams: [String: Any] = [:]
+  var calls: [(action: BridgeAction, params: [String: Any])] = []
 
   let (output, _) = try await StdoutCapture.capture {
     try await PollCommand.run(
       values: values,
       runtime: runtime,
       invokeBridge: { action, params in
-        capturedAction = action
-        capturedParams = params
+        calls.append((action, params))
         return ["messageGuid": "poll-guid"]
       }
     )
   }
 
-  #expect(capturedAction == .sendPoll)
-  #expect(capturedParams["chatGuid"] as? String == "iMessage;-;+15551234567")
-  #expect(capturedParams["question"] as? String == "Dinner?")
-  #expect(capturedParams["options"] as? [String] == ["Pizza", "Sushi"])
-  #expect(capturedParams["selectedMessageGuid"] as? String == "parent-guid")
+  // First call sends the poll…
+  #expect(calls.first?.action == .sendPoll)
+  #expect(calls.first?.params["chatGuid"] as? String == "iMessage;-;+15551234567")
+  #expect(calls.first?.params["question"] as? String == "Dinner?")
+  #expect(calls.first?.params["options"] as? [String] == ["Pizza", "Sushi"])
+  #expect(calls.first?.params["selectedMessageGuid"] as? String == "parent-guid")
+  // …then echoes the question as a plain caption so it is visible on the balloon.
+  #expect(calls.count == 2)
+  #expect(calls.last?.action == .sendMessage)
+  #expect(calls.last?.params["chatGuid"] as? String == "iMessage;-;+15551234567")
+  #expect(calls.last?.params["message"] as? String == "Dinner?")
   #expect(output.contains("poll: sent (guid=poll-guid)"))
 }
 

--- a/Tests/imsgTests/RPCBridgeMessageHandlersTests.swift
+++ b/Tests/imsgTests/RPCBridgeMessageHandlersTests.swift
@@ -80,15 +80,13 @@ func rpcPollVoteRejectsOptionOutsidePoll() async throws {
 func rpcPollSendInvokesBridgeWithResolvedChat() async throws {
   let store = try CommandTestDatabase.makeStoreForRPC()
   let output = TestRPCOutput()
-  var capturedAction: BridgeAction?
-  var capturedParams: [String: Any] = [:]
+  var calls: [(action: BridgeAction, params: [String: Any])] = []
   let server = RPCServer(
     store: store,
     verbose: false,
     output: output,
     invokeBridge: { action, params in
-      capturedAction = action
-      capturedParams = params
+      calls.append((action, params))
       return [
         "messageGuid": "poll-guid",
         "poll": [
@@ -104,11 +102,17 @@ func rpcPollSendInvokesBridgeWithResolvedChat() async throws {
     #"{"jsonrpc":"2.0","id":"poll","method":"poll.send","params":{"chat_id":1,"question":"Dinner?","options":["Pizza","Sushi"],"reply_to":"parent-guid"}}"#
   )
 
-  #expect(capturedAction == .sendPoll)
-  #expect(capturedParams["chatGuid"] as? String == "iMessage;+;chat123")
-  #expect(capturedParams["question"] as? String == "Dinner?")
-  #expect(capturedParams["options"] as? [String] == ["Pizza", "Sushi"])
-  #expect(capturedParams["selectedMessageGuid"] as? String == "parent-guid")
+  // First call sends the poll…
+  #expect(calls.first?.action == .sendPoll)
+  #expect(calls.first?.params["chatGuid"] as? String == "iMessage;+;chat123")
+  #expect(calls.first?.params["question"] as? String == "Dinner?")
+  #expect(calls.first?.params["options"] as? [String] == ["Pizza", "Sushi"])
+  #expect(calls.first?.params["selectedMessageGuid"] as? String == "parent-guid")
+  // …then echoes the question as a plain caption so it is visible on the balloon.
+  #expect(calls.count == 2)
+  #expect(calls.last?.action == .sendMessage)
+  #expect(calls.last?.params["chatGuid"] as? String == "iMessage;+;chat123")
+  #expect(calls.last?.params["message"] as? String == "Dinner?")
   let result = output.responses.first?["result"] as? [String: Any]
   #expect(result?["event"] as? String == "imessage.poll.created")
   #expect(result?["guid"] as? String == "poll-guid")

--- a/Tests/imsgTests/RPCBridgeMessageHandlersTests.swift
+++ b/Tests/imsgTests/RPCBridgeMessageHandlersTests.swift
@@ -122,7 +122,7 @@ func rpcPollSendInvokesBridgeWithResolvedChat() async throws {
 }
 
 @Test
-func rpcPollSendUsesCommentOverrideForVisibleCaption() async throws {
+func rpcPollSendUsesCommentOverrideWithoutPollGuid() async throws {
   let store = try CommandTestDatabase.makeStoreForRPC()
   let output = TestRPCOutput()
   var calls: [(action: BridgeAction, params: [String: Any])] = []
@@ -132,7 +132,7 @@ func rpcPollSendUsesCommentOverrideForVisibleCaption() async throws {
     output: output,
     invokeBridge: { action, params in
       calls.append((action, params))
-      return ["messageGuid": "poll-guid"]
+      return [:]
     }
   )
 

--- a/Tests/imsgTests/RPCBridgeMessageHandlersTests.swift
+++ b/Tests/imsgTests/RPCBridgeMessageHandlersTests.swift
@@ -99,7 +99,9 @@ func rpcPollSendInvokesBridgeWithResolvedChat() async throws {
   )
 
   await server.handleLineForTesting(
-    #"{"jsonrpc":"2.0","id":"poll","method":"poll.send","params":{"chat_id":1,"question":"Dinner?","options":["Pizza","Sushi"],"reply_to":"parent-guid"}}"#
+    #"{"jsonrpc":"2.0","id":"poll","method":"poll.send","params":{"#
+      + #""chat_id":1,"question":"Dinner?","options":["Pizza","Sushi"],"#
+      + #""reply_to":"parent-guid"}}"#
   )
 
   // First call sends the poll…
@@ -117,6 +119,34 @@ func rpcPollSendInvokesBridgeWithResolvedChat() async throws {
   #expect(result?["event"] as? String == "imessage.poll.created")
   #expect(result?["guid"] as? String == "poll-guid")
   #expect((result?["poll"] as? [String: Any])?["kind"] as? String == "created")
+}
+
+@Test
+func rpcPollSendUsesCommentOverrideForVisibleCaption() async throws {
+  let store = try CommandTestDatabase.makeStoreForRPC()
+  let output = TestRPCOutput()
+  var calls: [(action: BridgeAction, params: [String: Any])] = []
+  let server = RPCServer(
+    store: store,
+    verbose: false,
+    output: output,
+    invokeBridge: { action, params in
+      calls.append((action, params))
+      return ["messageGuid": "poll-guid"]
+    }
+  )
+
+  await server.handleLineForTesting(
+    #"{"jsonrpc":"2.0","id":"poll","method":"poll.send","params":{"#
+      + #""chat_id":1,"question":"Dinner?","comment":"Vote by 5pm","#
+      + #""options":["Pizza","Sushi"]}}"#
+  )
+
+  #expect(calls.count == 2)
+  #expect(calls.first?.action == .sendPoll)
+  #expect(calls.first?.params["question"] as? String == "Dinner?")
+  #expect(calls.last?.action == .sendMessage)
+  #expect(calls.last?.params["message"] as? String == "Vote by 5pm")
 }
 
 @Test

--- a/docs/history.md
+++ b/docs/history.md
@@ -65,7 +65,7 @@ Tapback rows (`Liked "..."`, `Loved "..."`, etc.) are hidden from `history` outp
 
 ## Native polls
 
-Native Apple Messages polls are decoded when Messages stores them as the Polls extension balloon (`com.apple.messages.Polls`). Creation rows include `poll.kind == "created"` with the question and options when available. Vote update rows include `poll.kind == "vote"` and `poll.original_guid` pointing back to the poll message.
+Native Apple Messages polls are decoded when Messages stores them as the Polls extension balloon (`com.apple.messages.Polls`). Creation rows include `poll.kind == "created"` with the question and options when available. Native poll payload titles are often empty because Messages shows the question as a separate caption row; imsg backfills an empty created-poll `question` from the earliest clean caption that replies to the poll. Vote update rows include `poll.kind == "vote"` and `poll.original_guid` pointing back to the poll message.
 
 ```bash
 imsg history --chat-id 42 --json \
@@ -83,7 +83,10 @@ imsg poll send --chat 'iMessage;-;+15551234567' \
   --option 'Sushi'
 ```
 
-You can also use `--chat-id <id>` from `imsg chats`.
+You can also use `--chat-id <id>` from `imsg chats`. Because Messages does not
+render the poll title on the balloon, `poll send` sends `--question` as a
+best-effort plain caption message right after the poll. Use `--comment` to show
+different visible text while keeping `--question` as the poll payload title.
 
 Cast a vote using one selector. The index is 1-based; `imsg` resolves it to the
 poll's stable option identifier before sending:
@@ -101,7 +104,7 @@ vote row without the Polls payload, so the recipient's poll did not update.
 2. Run `imsg history --chat-id <chat-id> --json | jq -c 'select(.poll != null) | {id, guid, poll}'` and verify the creation row has `poll.kind == "created"` with decoded question/options.
 3. Vote on the poll from another participant/device.
 4. Run `imsg watch --chat-id <chat-id> --json | jq -c 'select(.poll != null)'` while the vote happens, or re-run history, and verify the vote row has `poll.kind == "vote"`, `poll.original_guid` set to the original poll GUID, and `poll.vote.option_id` set.
-5. Send a poll with `imsg poll send --chat-id <id> --question "..." --option "A" --option "B"` and verify it renders as a native Messages poll on iOS/macOS.
+5. Send a poll with `imsg poll send --chat-id <id> --question "..." --option "A" --option "B"` and verify it renders as a native Messages poll on iOS/macOS with the question visible as the plain caption below it.
 6. Vote with `imsg poll vote --chat-id <id> --poll <poll-guid> --option-index 2`, then verify the new row has `poll.kind == "vote"`, the original GUID, and the selected option.
 7. If Apple changes the private Polls payload shape, verify the row still emits `poll.kind == "unknown"` with metadata and no raw payload bytes.
 

--- a/docs/json.md
+++ b/docs/json.md
@@ -89,14 +89,14 @@ Present on `imsg watch --reactions` events:
 
 ### Native poll extension
 
-Native Apple Messages polls are emitted as normal messages with a `poll` object. Existing message fields stay present and unchanged; poll rows often have an empty `text` field because the useful data is stored in the Messages extension payload.
+Native Apple Messages polls are emitted as normal messages with a `poll` object. Existing message fields stay present and unchanged; poll rows often have an empty `text` field because the useful data is stored in the Messages extension payload. When a native created-poll payload has no title, imsg may backfill `poll.question` from the earliest clean caption row that replies to the poll.
 
 | Field | Type | Notes |
 |-------|------|-------|
 | `kind` | string | `created`, `vote`, or `unknown`. |
 | `event` | string | Route-friendly value: `imessage.poll.created`, `imessage.poll.voted`, or `imessage.poll.unknown`. |
 | `poll_guid` | string | The poll's source message GUID when known. |
-| `question` | string | Poll title or question when decoded. |
+| `question` | string | Poll title or question when decoded. For native created polls with an empty payload title, this may be backfilled from the poll's plain caption row. |
 | `options` | array | Poll options, each with `id` and `text`. |
 | `vote` | object | First decoded vote update, with `option_id`, `participant`, and `event_type` when present. |
 | `votes` | array | All decoded vote entries when the payload carries more than one. |

--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -204,12 +204,18 @@ Result:
 
 ### Native polls
 
-`poll.send` creates a native Apple Messages Polls extension balloon through the IMCore bridge. The bridge must be injected with `imsg launch`; the AppleScript transport cannot send native extension payloads.
+`poll.send` creates a native Apple Messages Polls extension balloon through the IMCore bridge. The bridge must be injected with `imsg launch`; the AppleScript transport cannot send native extension payloads. Messages does not render the poll payload title on the balloon, so `poll.send` also sends a best-effort plain caption message right after the poll. The caption defaults to `question`; pass `comment` when the visible caption should differ from the stored poll question.
 
 Request:
 
 ```json
 {"jsonrpc":"2.0","id":"poll","method":"poll.send","params":{"chat_id":42,"question":"Dinner?","options":["Pizza","Sushi"]}}
+```
+
+With a caption override:
+
+```json
+{"jsonrpc":"2.0","id":"poll","method":"poll.send","params":{"chat_id":42,"question":"Dinner?","comment":"Vote by 5pm","options":["Pizza","Sushi"]}}
 ```
 
 Response:
@@ -218,7 +224,7 @@ Response:
 {"ok":true,"event":"imessage.poll.created","guid":"...","message_id":"...","poll":{"kind":"created","event":"imessage.poll.created","question":"Dinner?","options":[{"id":"...","text":"Pizza"},{"id":"...","text":"Sushi"}]}}
 ```
 
-`messages.poll.send` is accepted as an alias for `poll.send`.
+`messages.poll.send` is accepted as an alias for `poll.send`. The caption echo is deliberately best-effort: if the poll is created but the follow-up caption send fails, the RPC still returns the poll result to avoid retrying and creating a duplicate poll.
 
 ## Objects
 
@@ -230,7 +236,7 @@ See [JSON output → Chat](json.md#chat). Every field documented there appears i
 
 See [JSON output → Message](json.md#message). When `include_reactions: true`, message notifications also include the reaction extension fields (`is_reaction`, `reaction_type`, `reaction_emoji`, `is_reaction_add`, `reacted_to_guid`).
 
-Native Apple Messages polls are emitted by `messages.history` and `watch.subscribe` with the same `poll` object documented in [JSON output → Native poll extension](json.md#native-poll-extension).
+Native Apple Messages polls are emitted by `messages.history` and `watch.subscribe` with the same `poll` object documented in [JSON output → Native poll extension](json.md#native-poll-extension). For inbound native polls whose payload title is empty, imsg backfills `poll.question` from the earliest clean caption row that replies to the poll.
 
 `account_id`, `account_login`, `last_addressed_handle`, and outgoing `destination_caller_id` are read-only routing diagnostics; the AppleScript send API does not expose a `from` selector.
 

--- a/docs/watch.md
+++ b/docs/watch.md
@@ -60,7 +60,7 @@ Attachment metadata is reported the same way as [`history`](history.md). `--conv
 
 ## Native polls
 
-Native Apple Messages poll creation and vote updates are emitted without a separate flag. Poll vote rows are not tapbacks, so they do not require `--reactions`.
+Native Apple Messages poll creation and vote updates are emitted without a separate flag. Poll vote rows are not tapbacks, so they do not require `--reactions`. When a native created poll has no payload title, watch output uses the same caption backfill as history so `poll.question` can still contain the visible poll question.
 
 ```bash
 imsg watch --chat-id 42 --json \


### PR DESCRIPTION
## What Problem This Solves

Native iMessage poll balloons have **no title** — `item.title` is empty and Messages never renders it. The question you see on a native poll lives in a **separate caption message** whose `reply_to` is the poll guid (the composer's "comment or Send" field). imsg ignored this on both sides:

- **Outbound:** `poll send --question 'X'` stored `X` in the invisible `item.title`, so agent-created polls rendered as bare options with no question.
- **Inbound:** a native poll decoded from `chat.db` had `question=nil`, so agents saw a title-less `Poll — options: …`.

## Why This Change Was Made

Make the poll question visible in both directions, matching native behavior, with no consumer changes required (OpenClaw already renders `📊 Poll: <question>` when the field is present, and passes `--question` on send).

## User Impact

- **Outbound** — `poll send` / `poll.send` RPC now send `--question` as a **plain caption message** right after the poll — `associated_message_type = 0`, `thread_originator_guid = None`, i.e. **not a threaded reply**, so it renders as a normal caption bubble instead of the "reply connector" a threaded reply would draw. `--comment` overrides the echoed text; the echo is best-effort so a caption failure never fails an already-delivered poll. Agents keep passing only `--question`.
- **Inbound** — `enrichedPollEvent` **backfills** an empty created-poll question from its caption (earliest reply-to-the-poll message), so inbound native polls surface their question. imsg-created polls with a real title are unchanged; vote enrichment untouched.

## Evidence

Verified end-to-end on macOS 26 through a **live v2 bridge**, sending with this branch's build (`swift build --product imsg`).

**Outbound — live send** to a test group:
```
$ imsg poll send --chat-id 22 --question "PR#155 proof: which crustacean?" \
      --option Lobster --option Crab --option Shrimp --json
{"poll":{"kind":"created","question":"PR#155 proof: which crustacean?",
 "options":[Lobster,Crab,Shrimp]},"event":"imessage.poll.created",
 "messageGuid":"EAE66DE7-…","balloonBundleID":"…Polls"}
```

**Visual** — confirmed in the Messages UI on the receiving device: the poll shows the three options (Lobster / Crab / Shrimp), and directly beneath it the question appears as an ordinary caption bubble ("PR#155 proof: which crustacean?") — no threaded-reply connector line. (Screenshot available; can be attached to this PR.)

**Structural proof (chat.db)** — my sent caption is byte-for-byte the same shape as a **natively-composed** poll's caption, and differs from the earlier threaded-reply attempt that drew the connector:

```
poll_guid  origin          caption   assoc_type  thread_originator
EAE66DE7   this PR (sent)   01E1505B  0           NULL   ← clean, matches native
2E97B312   native (recv)    CCBD34D4  0           NULL   ← native reference
AC8A8E5B   native (recv)    1ECFCA87  0           NULL   ← native reference
A3DDC24F   old threaded try C615FCEF  100         A3DDC24F ← the rejected reply connector
```

Note: this bridge auto-populates `reply_to_guid` on every send (the poll itself got a `reply_to` although no `--reply-to` was passed), so both native and PR captions carry `reply_to`; the connector is driven by `thread_originator`/`assoc_type=100`, which the PR caption does **not** set — matching native exactly.

**Inbound — backfill** via `imsg history` (chat.db read, no bridge), native `[recv]` polls that decoded as `question=None` now surface their question:
```
[recv] [poll created] Favorite crustacean friend of a Lobster?: Lobster 🦞 / Crab 🦀 / Shrimp 🦐
[recv] [poll created] What color pill?: Red / Blue
[recv] [poll created] Pick a color: Black / White
```

**Review follow-ups addressed** (ClawSweeper P2s): CLI caption echo is now best-effort (`do/catch`, matching the RPC path); `pollCommentText` is guarded on `schema.hasReplyToGUIDColumn` so schemas without the column degrade to nil instead of throwing; poll-send tests record the full bridge call sequence and assert both `.sendPoll` and the `.sendMessage` caption echo. macOS + Linux CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
