### PR TITLE
[codex] Include arm64e slice in imsg bridge helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.12.3 - Unreleased
 
+### Packaging
+- fix: include and validate an arm64e slice in the injected bridge helper for macOS 26 Messages compatibility (#156, thanks @omarshahine).
+
 ## 0.12.2 - 2026-07-04
 
 ### Native Polls

--- a/Tests/imsgTests/ReleasePackagingTests.swift
+++ b/Tests/imsgTests/ReleasePackagingTests.swift
@@ -34,11 +34,18 @@ func universalBuildScriptShipsArm64eHelperSlice() throws {
 func signAndNotarizeScriptDefaultsHelperToArm64e() throws {
   let script = try readRepositoryFile("scripts/sign-and-notarize.sh")
 
-  // The notarize path defaults the helper to arm64e as well, and validates the
-  // shipped slices against the HELPER arch list (not the CLI ARCH_LIST).
+  // The notarize path defaults the helper to arm64e as well, and its lipo guard
+  // must validate the HELPER arch list — not the CLI ARCH_LIST, which omits
+  // arm64e. Assert the loop and its lipo check as one contiguous block so this
+  // can't pass by matching the separate clang-args HELPER_ARCH_LIST loop.
   #expect(script.contains(#"HELPER_ARCHES_VALUE=${HELPER_ARCHES:-"arm64e arm64 x86_64"}"#))
-  #expect(script.contains(#"for ARCH in "${HELPER_ARCH_LIST[@]}"; do"#))
-  #expect(script.contains("Helper missing required architecture slice"))
+  #expect(
+    script.contains(
+      """
+      for ARCH in "${HELPER_ARCH_LIST[@]}"; do
+        if ! lipo -archs "$DIST_DIR/$HELPER_NAME" | tr ' ' '\\n' | grep -Fxq "$ARCH"; then
+          echo "Helper missing required architecture slice: $ARCH" >&2
+      """))
 }
 
 @Test

--- a/Tests/imsgTests/ReleasePackagingTests.swift
+++ b/Tests/imsgTests/ReleasePackagingTests.swift
@@ -23,7 +23,9 @@ func universalBuildScriptShipsArm64eHelperSlice() throws {
   #expect(script.contains("lipo -create"))
   #expect(script.contains("imsg-bridge-helper.dylib"))
   // release.yml ships via this script only, so it must guard every helper slice.
-  #expect(script.contains(#"if ! lipo -archs "${DIST_DIR}/${HELPER_NAME}" | tr ' ' '\n' | grep -Fxq "$ARCH"; then"#))
+  #expect(
+    script.contains(
+      #"if ! lipo -archs "${DIST_DIR}/${HELPER_NAME}" | tr ' ' '\n' | grep -Fxq "$ARCH"; then"#))
   #expect(script.contains("Helper missing required architecture slice"))
   #expect(script.contains(#"codesign --force --sign -"#))
   #expect(script.contains(#"cp "${DIST_DIR}/${APP_NAME}" "$OUTPUT_DIR/$APP_NAME""#))

--- a/Tests/imsgTests/ReleasePackagingTests.swift
+++ b/Tests/imsgTests/ReleasePackagingTests.swift
@@ -13,16 +13,32 @@ func releaseWorkflowPackagesUniversalBuildOutput() throws {
 }
 
 @Test
-func universalBuildScriptDefaultsToBothMacArchitectures() throws {
+func universalBuildScriptShipsArm64eHelperSlice() throws {
   let script = try readRepositoryFile("scripts/build-universal.sh")
 
   #expect(script.contains(#"ARCHES_VALUE=${ARCHES:-"arm64 x86_64"}"#))
-  #expect(script.contains(#"HELPER_ARCHES_VALUE=${HELPER_ARCHES:-"$ARCHES_VALUE"}"#))
+  // The injected helper must default to arm64e — macOS 26 Messages refuses to
+  // load an arm64-only dylib, which silently kills the bridge.
+  #expect(script.contains(#"HELPER_ARCHES_VALUE=${HELPER_ARCHES:-"arm64e arm64 x86_64"}"#))
   #expect(script.contains("lipo -create"))
   #expect(script.contains("imsg-bridge-helper.dylib"))
+  // release.yml ships via this script only, so it must guard every helper slice.
+  #expect(script.contains(#"if ! lipo -archs "${DIST_DIR}/${HELPER_NAME}" | tr ' ' '\n' | grep -Fxq "$ARCH"; then"#))
+  #expect(script.contains("Helper missing required architecture slice"))
   #expect(script.contains(#"codesign --force --sign -"#))
   #expect(script.contains(#"cp "${DIST_DIR}/${APP_NAME}" "$OUTPUT_DIR/$APP_NAME""#))
   #expect(script.contains(#"cp "${DIST_DIR}/${HELPER_NAME}" "$OUTPUT_DIR/$HELPER_NAME""#))
+}
+
+@Test
+func signAndNotarizeScriptDefaultsHelperToArm64e() throws {
+  let script = try readRepositoryFile("scripts/sign-and-notarize.sh")
+
+  // The notarize path defaults the helper to arm64e as well, and validates the
+  // shipped slices against the HELPER arch list (not the CLI ARCH_LIST).
+  #expect(script.contains(#"HELPER_ARCHES_VALUE=${HELPER_ARCHES:-"arm64e arm64 x86_64"}"#))
+  #expect(script.contains(#"for ARCH in "${HELPER_ARCH_LIST[@]}"; do"#))
+  #expect(script.contains("Helper missing required architecture slice"))
 }
 
 @Test

--- a/scripts/build-universal.sh
+++ b/scripts/build-universal.sh
@@ -8,7 +8,10 @@ ENTITLEMENTS="${ROOT}/Resources/imsg.entitlements"
 OUTPUT_DIR="${OUTPUT_DIR:-${ROOT}/bin}"
 ARCHES_VALUE=${ARCHES:-"arm64 x86_64"}
 ARCH_LIST=( ${ARCHES_VALUE} )
-HELPER_ARCHES_VALUE=${HELPER_ARCHES:-"$ARCHES_VALUE"}
+# The injected helper must include arm64e: macOS 26 Messages refuses to load an
+# arm64-only dylib, which silently kills the bridge. Keep this ahead of the CLI
+# arches so a release never ships an arm64-only helper.
+HELPER_ARCHES_VALUE=${HELPER_ARCHES:-"arm64e arm64 x86_64"}
 HELPER_ARCH_LIST=( ${HELPER_ARCHES_VALUE} )
 BUILD_MODE=${BUILD_MODE:-release}
 CODESIGN_IDENTITY=${CODESIGN_IDENTITY:-"-"}
@@ -38,6 +41,16 @@ clang -dynamiclib "${HELPER_CLANG_ARCH_ARGS[@]}" -fobjc-arc \
   -framework AppKit \
   -o "${DIST_DIR}/${HELPER_NAME}" \
   "${ROOT}/Sources/IMsgHelper/IMsgInjected.m"
+
+# This is the shipping path (release.yml runs only this script), so fail the
+# build if any required helper slice is missing — a dropped arm64e slice
+# silently kills the bridge on macOS 26 Messages.
+for ARCH in "${HELPER_ARCH_LIST[@]}"; do
+  if ! lipo -archs "${DIST_DIR}/${HELPER_NAME}" | tr ' ' '\n' | grep -Fxq "$ARCH"; then
+    echo "Helper missing required architecture slice: $ARCH" >&2
+    exit 1
+  fi
+done
 
 if [[ "$CODESIGN_IDENTITY" == "-" ]]; then
   codesign --force --sign - \

--- a/scripts/sign-and-notarize.sh
+++ b/scripts/sign-and-notarize.sh
@@ -55,7 +55,10 @@ clang -dynamiclib "${HELPER_CLANG_ARCH_ARGS[@]}" -fobjc-arc \
   -o "$DIST_DIR/$HELPER_NAME" \
   "$ROOT/Sources/IMsgHelper/IMsgInjected.m"
 
-for ARCH in "${ARCH_LIST[@]}"; do
+# Validate the HELPER slices, not the CLI ARCH_LIST — the helper defaults to a
+# superset (arm64e) that the CLI list does not contain, so ARCH_LIST here would
+# silently skip the arm64e check macOS 26 Messages depends on.
+for ARCH in "${HELPER_ARCH_LIST[@]}"; do
   if ! lipo -archs "$DIST_DIR/$HELPER_NAME" | tr ' ' '\n' | grep -Fxq "$ARCH"; then
     echo "Helper missing required architecture slice: $ARCH" >&2
     exit 1

--- a/scripts/sign-and-notarize.sh
+++ b/scripts/sign-and-notarize.sh
@@ -12,7 +12,10 @@ OUTPUT_DIR="${OUTPUT_DIR:-/tmp}"
 ZIP_PATH="${OUTPUT_DIR}/imsg-macos.zip"
 ARCHES_VALUE=${ARCHES:-"arm64 x86_64"}
 ARCH_LIST=( ${ARCHES_VALUE} )
-HELPER_ARCHES_VALUE=${HELPER_ARCHES:-"$ARCHES_VALUE"}
+# arm64e is mandatory for the helper: macOS 26 Messages will not load an
+# arm64-only dylib. The HELPER_ARCH_LIST validation below fails the notarize run
+# if any slice (incl. arm64e) is missing.
+HELPER_ARCHES_VALUE=${HELPER_ARCHES:-"arm64e arm64 x86_64"}
 HELPER_ARCH_LIST=( ${HELPER_ARCHES_VALUE} )
 DIST_DIR="$(mktemp -d "/tmp/${APP_NAME}-dist.XXXXXX")"
 API_KEY_FILE="$(mktemp "/tmp/${APP_NAME}-notary.XXXXXX.p8")"


### PR DESCRIPTION
## Summary

- build the injected `imsg-bridge-helper.dylib` with an `arm64e` slice by default, while leaving the CLI default at `arm64 x86_64`
- validate every configured helper architecture slice in both local universal builds and the release/notarization path
- update the release packaging test to lock in the new helper architecture default and slice check

## Root Cause

On Apple Silicon/macOS 26, `/System/Applications/Messages.app/Contents/MacOS/Messages` runs as `arm64e`. The released Homebrew helper only had `x86_64 arm64`, so `DYLD_INSERT_LIBRARIES` was set correctly but dyld refused to load the helper before the bridge constructor could run.

Observed failure before the fix:

```text
dyld: inserted dylib ... imsg-bridge-helper.dylib could not be loaded ... fat file, but missing compatible architecture (have x86_64,arm64, need arm64e)
```

## Proof

- `bash -n scripts/build-universal.sh scripts/sign-and-notarize.sh` passed.
- Rebuilt a proof helper with `-arch arm64e -arch arm64 -arch x86_64`; `lipo -info` reported `x86_64 arm64 arm64e`.
- Verified each helper slice explicitly: `arm64e`, `arm64`, and `x86_64`.
- Installed the rebuilt helper locally over the Homebrew 0.12.2 helper and ran `imsg launch --json`; launch succeeded.
- `lsof -p $(pgrep -x Messages)` showed Messages mapped `/opt/homebrew/Cellar/imsg/0.12.2/libexec/imsg-bridge-helper.dylib`.
- `imsg status --json` reported `advanced_features: true`, `v2_ready: true`, and `bridge_version: 2`.

## Test Note

`swift test --filter ReleasePackagingTests` is blocked on this local machine before reaching the packaging test because the active developer directory is Command Line Tools only and test compilation fails with `no such module Testing`. That was pre-existing during the health check; CI/full Xcode should exercise the updated test.
