### PR TITLE
Add unread_count and read state for chats/messages

### DIFF
--- a/Sources/IMsgCore/MessageStore+Chats.swift
+++ b/Sources/IMsgCore/MessageStore+Chats.swift
@@ -19,8 +19,10 @@ private struct ListChatsQuery {
   let sql: String
   let bindings: [Binding?]
 
-  init(limit: Int, schema: MessageStoreSchema) {
+  init(limit: Int, unreadOnly: Bool, schema: MessageStoreSchema) {
     let routing = ChatRoutingSelection(schema: schema)
+    let unreadCountColumn = Self.unreadCountColumn(schema: schema)
+    let havingClause = unreadOnly ? "HAVING unread_count > 0" : ""
     if schema.hasChatMessageJoinMessageDateColumn {
       self.sql = """
         SELECT c.ROWID AS chat_rowid, IFNULL(c.display_name, c.chat_identifier) AS name,
@@ -28,10 +30,12 @@ private struct ListChatsQuery {
                MAX(cmj.message_date) AS last_date,
                \(routing.accountIDColumn) AS account_id,
                \(routing.accountLoginColumn) AS account_login,
-               \(routing.lastAddressedHandleColumn) AS last_addressed_handle
+               \(routing.lastAddressedHandleColumn) AS last_addressed_handle,
+               \(unreadCountColumn)
         FROM chat c
         JOIN chat_message_join cmj ON c.ROWID = cmj.chat_id
         GROUP BY c.ROWID
+        \(havingClause)
         ORDER BY last_date DESC
         LIMIT ?
         """
@@ -42,16 +46,31 @@ private struct ListChatsQuery {
                MAX(m.date) AS last_date,
                \(routing.accountIDColumn) AS account_id,
                \(routing.accountLoginColumn) AS account_login,
-               \(routing.lastAddressedHandleColumn) AS last_addressed_handle
+               \(routing.lastAddressedHandleColumn) AS last_addressed_handle,
+               \(unreadCountColumn)
         FROM chat c
         JOIN chat_message_join cmj ON c.ROWID = cmj.chat_id
         JOIN message m ON m.ROWID = cmj.message_id
         GROUP BY c.ROWID
+        \(havingClause)
         ORDER BY last_date DESC
         LIMIT ?
         """
     }
     self.bindings = [limit]
+  }
+
+  private static func unreadCountColumn(schema: MessageStoreSchema) -> String {
+    guard schema.hasIsReadColumn else {
+      return "0 AS unread_count"
+    }
+    return """
+      (SELECT COUNT(*) FROM chat_message_join cmj_unread
+       JOIN message m_unread ON m_unread.ROWID = cmj_unread.message_id
+       WHERE cmj_unread.chat_id = c.ROWID
+         AND m_unread.is_from_me = 0
+         AND m_unread.is_read = 0) AS unread_count
+      """
   }
 }
 
@@ -91,8 +110,8 @@ private struct ParticipantsQuery {
 }
 
 extension MessageStore {
-  public func listChats(limit: Int) throws -> [Chat] {
-    let query = ListChatsQuery(limit: limit, schema: schema)
+  public func listChats(limit: Int, unreadOnly: Bool = false) throws -> [Chat] {
+    let query = ListChatsQuery(limit: limit, unreadOnly: unreadOnly, schema: schema)
     return try withConnection { db in
       var chats: [Chat] = []
       let rows = try db.prepareRowIterator(query.sql, bindings: query.bindings)
@@ -106,7 +125,8 @@ extension MessageStore {
             lastMessageAt: try appleDate(from: int64Value(row, "last_date")),
             accountID: try stringValue(row, "account_id").nilIfEmpty,
             accountLogin: try stringValue(row, "account_login").nilIfEmpty,
-            lastAddressedHandle: try stringValue(row, "last_addressed_handle").nilIfEmpty
+            lastAddressedHandle: try stringValue(row, "last_addressed_handle").nilIfEmpty,
+            unreadCount: Int(try int64Value(row, "unread_count") ?? 0)
           ))
       }
       return chats

--- a/Sources/IMsgCore/MessageStore+MessageConstruction.swift
+++ b/Sources/IMsgCore/MessageStore+MessageConstruction.swift
@@ -62,7 +62,9 @@ extension MessageStore {
         isReactionAdd: reaction.isReactionAdd,
         reactedToGUID: reaction.reactedToGUID
       ),
-      poll: poll
+      poll: poll,
+      isRead: decoded.isRead,
+      dateRead: decoded.dateRead
     )
   }
 

--- a/Sources/IMsgCore/MessageStore+MessageRows.swift
+++ b/Sources/IMsgCore/MessageStore+MessageRows.swift
@@ -26,6 +26,8 @@ struct MessageRowColumns {
   let balloonBundleID: String
   let payloadData: String
   let messageSummaryInfo: String
+  let isRead: String?
+  let dateRead: String?
 
   static func message(chatID: String?) -> MessageRowColumns {
     MessageRowColumns(
@@ -49,7 +51,9 @@ struct MessageRowColumns {
       replyToGUID: "reply_to_guid",
       balloonBundleID: MessageRowColumns.balloonBundleID,
       payloadData: MessageRowColumns.payloadData,
-      messageSummaryInfo: MessageRowColumns.messageSummaryInfo
+      messageSummaryInfo: MessageRowColumns.messageSummaryInfo,
+      isRead: nil,
+      dateRead: nil
     )
   }
 }
@@ -73,6 +77,8 @@ struct DecodedMessageRow {
   let databaseReplyToGUID: String
   let balloonBundleID: String
   let poll: MessagePollEvent?
+  let isRead: Bool?
+  let dateRead: Date?
 }
 
 struct PollOptionTextCache {
@@ -112,6 +118,10 @@ struct MessageRowSelection {
     let summaryInfoColumn =
       schema.hasMessageSummaryInfoColumn
       ? "CASE WHEN \(pollCandidatePredicate) THEN m.message_summary_info ELSE NULL END" : "NULL"
+    let isReadColumn = schema.hasIsReadColumn ? "m.is_read AS is_read" : ""
+    let dateReadColumn = schema.hasDateReadColumn ? "m.date_read AS date_read" : ""
+    let readStateColumns = [isReadColumn, dateReadColumn].filter { !$0.isEmpty }.joined(separator: ", ")
+    let readStateSuffix = readStateColumns.isEmpty ? "" : ", \(readStateColumns)"
     let chatColumn = includeChatID ? ", cmj.chat_id AS \(columns.chatID!)" : ""
 
     let selectList = """
@@ -130,10 +140,34 @@ struct MessageRowSelection {
              \(replyToColumn) AS \(columns.replyToGUID),
              \(balloonColumn) AS \(columns.balloonBundleID),
              \(payloadDataColumn) AS \(columns.payloadData),
-             \(summaryInfoColumn) AS \(columns.messageSummaryInfo)
+             \(summaryInfoColumn) AS \(columns.messageSummaryInfo)\(readStateSuffix)
       """
     self.selectList = selectList
-    self.columns = columns
+    self.columns = MessageRowColumns(
+      rowID: columns.rowID,
+      chatID: columns.chatID,
+      handleID: columns.handleID,
+      sender: columns.sender,
+      text: columns.text,
+      date: columns.date,
+      isFromMe: columns.isFromMe,
+      service: columns.service,
+      isAudioMessage: columns.isAudioMessage,
+      destinationCallerID: columns.destinationCallerID,
+      guid: columns.guid,
+      associatedGUID: columns.associatedGUID,
+      associatedType: columns.associatedType,
+      attachments: columns.attachments,
+      body: columns.body,
+      threadOriginatorGUID: columns.threadOriginatorGUID,
+      threadOriginatorPart: columns.threadOriginatorPart,
+      replyToGUID: columns.replyToGUID,
+      balloonBundleID: columns.balloonBundleID,
+      payloadData: columns.payloadData,
+      messageSummaryInfo: columns.messageSummaryInfo,
+      isRead: schema.hasIsReadColumn ? "is_read" : nil,
+      dateRead: schema.hasDateReadColumn ? "date_read" : nil
+    )
   }
 
   private static func pollCandidatePredicate(schema: MessageStoreSchema) -> String {

--- a/Sources/IMsgCore/MessageStore+Messages.swift
+++ b/Sources/IMsgCore/MessageStore+Messages.swift
@@ -341,6 +341,16 @@ extension MessageStore {
       poll = nil
     }
 
+    var isRead: Bool?
+    var dateRead: Date?
+    if !isFromMe, let isReadColumn = columns.isRead {
+      isRead = (try intValue(row, isReadColumn) ?? 0) != 0
+      if isRead == true, let dateReadColumn = columns.dateRead {
+        let readRaw = try int64Value(row, dateReadColumn)
+        dateRead = readRaw.flatMap { $0 > 0 ? appleDate(from: $0) : nil }
+      }
+    }
+
     return DecodedMessageRow(
       rowID: rowID,
       chatID: resolvedChatID,
@@ -359,7 +369,9 @@ extension MessageStore {
       threadOriginatorPart: threadOriginatorPart,
       databaseReplyToGUID: databaseReplyToGUID,
       balloonBundleID: balloonBundleID,
-      poll: poll
+      poll: poll,
+      isRead: isRead,
+      dateRead: dateRead
     )
   }
 

--- a/Sources/IMsgCore/MessageStore.swift
+++ b/Sources/IMsgCore/MessageStore.swift
@@ -56,7 +56,9 @@ public final class MessageStore: @unchecked Sendable {
     hasChatMessageJoinMessageDateColumn: Bool? = nil,
     hasChatAccountIDColumn: Bool? = nil,
     hasChatAccountLoginColumn: Bool? = nil,
-    hasChatLastAddressedHandleColumn: Bool? = nil
+    hasChatLastAddressedHandleColumn: Bool? = nil,
+    hasIsReadColumn: Bool? = nil,
+    hasDateReadColumn: Bool? = nil
   ) throws {
     self.path = path
     self.queue = DispatchQueue(label: "imsg.db.test", qos: .userInitiated)
@@ -76,7 +78,9 @@ public final class MessageStore: @unchecked Sendable {
       hasChatMessageJoinMessageDateColumn: hasChatMessageJoinMessageDateColumn,
       hasChatAccountIDColumn: hasChatAccountIDColumn,
       hasChatAccountLoginColumn: hasChatAccountLoginColumn,
-      hasChatLastAddressedHandleColumn: hasChatLastAddressedHandleColumn
+      hasChatLastAddressedHandleColumn: hasChatLastAddressedHandleColumn,
+      hasIsReadColumn: hasIsReadColumn,
+      hasDateReadColumn: hasDateReadColumn
     )
   }
 

--- a/Sources/IMsgCore/MessageStoreSchema.swift
+++ b/Sources/IMsgCore/MessageStoreSchema.swift
@@ -16,6 +16,8 @@ struct MessageStoreSchema: Sendable {
   let hasChatAccountIDColumn: Bool
   let hasChatAccountLoginColumn: Bool
   let hasChatLastAddressedHandleColumn: Bool
+  let hasIsReadColumn: Bool
+  let hasDateReadColumn: Bool
 
   init(connection: Connection) {
     let messageColumns = MessageStore.tableColumns(connection: connection, table: "message")
@@ -41,6 +43,8 @@ struct MessageStoreSchema: Sendable {
     self.hasChatAccountIDColumn = chatColumns.contains("account_id")
     self.hasChatAccountLoginColumn = chatColumns.contains("account_login")
     self.hasChatLastAddressedHandleColumn = chatColumns.contains("last_addressed_handle")
+    self.hasIsReadColumn = messageColumns.contains("is_read")
+    self.hasDateReadColumn = messageColumns.contains("date_read")
   }
 
   init(
@@ -59,7 +63,9 @@ struct MessageStoreSchema: Sendable {
     hasChatMessageJoinMessageDateColumn: Bool? = nil,
     hasChatAccountIDColumn: Bool? = nil,
     hasChatAccountLoginColumn: Bool? = nil,
-    hasChatLastAddressedHandleColumn: Bool? = nil
+    hasChatLastAddressedHandleColumn: Bool? = nil,
+    hasIsReadColumn: Bool? = nil,
+    hasDateReadColumn: Bool? = nil
   ) {
     self.hasAttributedBody = hasAttributedBody ?? base.hasAttributedBody
     self.hasReactionColumns = hasReactionColumns ?? base.hasReactionColumns
@@ -81,5 +87,7 @@ struct MessageStoreSchema: Sendable {
     self.hasChatAccountLoginColumn = hasChatAccountLoginColumn ?? base.hasChatAccountLoginColumn
     self.hasChatLastAddressedHandleColumn =
       hasChatLastAddressedHandleColumn ?? base.hasChatLastAddressedHandleColumn
+    self.hasIsReadColumn = hasIsReadColumn ?? base.hasIsReadColumn
+    self.hasDateReadColumn = hasDateReadColumn ?? base.hasDateReadColumn
   }
 }

--- a/Sources/IMsgCore/Models.swift
+++ b/Sources/IMsgCore/Models.swift
@@ -193,6 +193,7 @@ public struct Chat: Sendable, Equatable {
   public let accountID: String?
   public let accountLogin: String?
   public let lastAddressedHandle: String?
+  public let unreadCount: Int
 
   public init(
     id: Int64,
@@ -202,7 +203,8 @@ public struct Chat: Sendable, Equatable {
     lastMessageAt: Date,
     accountID: String? = nil,
     accountLogin: String? = nil,
-    lastAddressedHandle: String? = nil
+    lastAddressedHandle: String? = nil,
+    unreadCount: Int = 0
   ) {
     self.id = id
     self.identifier = identifier
@@ -212,6 +214,7 @@ public struct Chat: Sendable, Equatable {
     self.accountID = accountID
     self.accountLogin = accountLogin
     self.lastAddressedHandle = lastAddressedHandle
+    self.unreadCount = unreadCount
   }
 }
 
@@ -336,6 +339,10 @@ public struct Message: Sendable, Equatable {
   public let isReactionAdd: Bool?
   /// The GUID of the message being reacted to (only set when isReaction is true)
   public let reactedToGUID: String?
+  /// Read state for inbound messages when `is_read` is present in chat.db.
+  public let isRead: Bool?
+  /// When the inbound message was marked read locally.
+  public let dateRead: Date?
 
   public init(
     rowID: Int64,
@@ -352,7 +359,9 @@ public struct Message: Sendable, Equatable {
     balloonBundleID: String? = nil,
     urlPreview: URLPreviewMetadata? = nil,
     reaction: ReactionMetadata = ReactionMetadata(),
-    poll: MessagePollEvent? = nil
+    poll: MessagePollEvent? = nil,
+    isRead: Bool? = nil,
+    dateRead: Date? = nil
   ) {
     self.rowID = rowID
     self.chatID = chatID
@@ -377,6 +386,8 @@ public struct Message: Sendable, Equatable {
     self.reactionType = reaction.reactionType
     self.isReactionAdd = reaction.isReactionAdd
     self.reactedToGUID = reaction.reactedToGUID
+    self.isRead = isRead
+    self.dateRead = dateRead
   }
 
   public init(
@@ -402,7 +413,9 @@ public struct Message: Sendable, Equatable {
     reactionType: ReactionType? = nil,
     isReactionAdd: Bool? = nil,
     reactedToGUID: String? = nil,
-    poll: MessagePollEvent? = nil
+    poll: MessagePollEvent? = nil,
+    isRead: Bool? = nil,
+    dateRead: Date? = nil
   ) {
     self.init(
       rowID: rowID,
@@ -431,7 +444,9 @@ public struct Message: Sendable, Equatable {
         isReactionAdd: isReactionAdd,
         reactedToGUID: reactedToGUID
       ),
-      poll: poll
+      poll: poll,
+      isRead: isRead,
+      dateRead: dateRead
     )
   }
 

--- a/Sources/imsg/Commands/ChatsCommand.swift
+++ b/Sources/imsg/Commands/ChatsCommand.swift
@@ -10,16 +10,19 @@ enum ChatsCommand {
     signature: CommandSignatures.withRuntimeFlags(
       CommandSignature(
         options: CommandSignatures.baseOptions() + [
-          .make(label: "limit", names: [.long("limit")], help: "Number of chats to list"),
+          .make(label: "limit", names: [.long("limit")], help: "Number of chats to list")
+        ],
+        flags: [
           .make(
             label: "unread-only", names: [.long("unread-only")],
-            help: "Return only chats with unread inbound messages"),
+            help: "Return only chats with unread inbound messages")
         ]
       )
     ),
     usageExamples: [
       "imsg chats --limit 5",
       "imsg chats --limit 5 --json",
+      "imsg chats --unread-only --json",
     ]
   ) { values, runtime in
     try await run(values: values, runtime: runtime)

--- a/Sources/imsg/Commands/ChatsCommand.swift
+++ b/Sources/imsg/Commands/ChatsCommand.swift
@@ -10,7 +10,10 @@ enum ChatsCommand {
     signature: CommandSignatures.withRuntimeFlags(
       CommandSignature(
         options: CommandSignatures.baseOptions() + [
-          .make(label: "limit", names: [.long("limit")], help: "Number of chats to list")
+          .make(label: "limit", names: [.long("limit")], help: "Number of chats to list"),
+          .make(
+            label: "unread-only", names: [.long("unread-only")],
+            help: "Return only chats with unread inbound messages"),
         ]
       )
     ),
@@ -31,8 +34,9 @@ enum ChatsCommand {
   ) async throws {
     let dbPath = values.option("db") ?? MessageStore.defaultPath
     let limit = values.optionInt("limit") ?? 20
+    let unreadOnly = values.flag("unread-only")
     let store = try MessageStore(path: dbPath)
-    let chats = try store.listChats(limit: limit)
+    let chats = try store.listChats(limit: limit, unreadOnly: unreadOnly)
     let contacts = await contactResolverFactory()
 
     if runtime.jsonOutput {

--- a/Sources/imsg/OutputModels.swift
+++ b/Sources/imsg/OutputModels.swift
@@ -15,6 +15,7 @@ struct ChatPayload: Codable {
   let accountID: String?
   let accountLogin: String?
   let lastAddressedHandle: String?
+  let unreadCount: Int
 
   init(
     chat: Chat, chatInfo: ChatInfo? = nil, participants: [String]? = nil, contactName: String? = nil
@@ -34,6 +35,7 @@ struct ChatPayload: Codable {
     self.accountID = chatInfo?.accountID ?? chat.accountID
     self.accountLogin = chatInfo?.accountLogin ?? chat.accountLogin
     self.lastAddressedHandle = chatInfo?.lastAddressedHandle ?? chat.lastAddressedHandle
+    self.unreadCount = chat.unreadCount
   }
 
   enum CodingKeys: String, CodingKey {
@@ -50,6 +52,7 @@ struct ChatPayload: Codable {
     case accountID = "account_id"
     case accountLogin = "account_login"
     case lastAddressedHandle = "last_addressed_handle"
+    case unreadCount = "unread_count"
   }
 }
 
@@ -108,6 +111,8 @@ struct MessagePayload: Codable {
   let reactionEmoji: String?
   let isReactionAdd: Bool?
   let reactedToGUID: String?
+  let isRead: Bool?
+  let dateRead: String?
 
   init(
     message: Message,
@@ -137,6 +142,16 @@ struct MessagePayload: Codable {
     self.balloonBundleID = message.balloonBundleID
     self.urlPreview = message.urlPreview.map { URLPreviewPayload(preview: $0) }
     self.poll = message.poll
+    if message.isFromMe {
+      self.isRead = nil
+      self.dateRead = nil
+    } else {
+      self.isRead = message.isRead
+      self.dateRead =
+        message.isRead == true
+        ? message.dateRead.map { CLIISO8601.format($0) }
+        : nil
+    }
 
     // Reaction event metadata
     if message.isReaction {
@@ -179,6 +194,8 @@ struct MessagePayload: Codable {
     case reactionEmoji = "reaction_emoji"
     case isReactionAdd = "is_reaction_add"
     case reactedToGUID = "reacted_to_guid"
+    case isRead = "is_read"
+    case dateRead = "date_read"
   }
 }
 

--- a/Sources/imsg/RPCPayloads.swift
+++ b/Sources/imsg/RPCPayloads.swift
@@ -9,7 +9,8 @@ func chatPayload(
   service: String,
   lastMessageAt: Date,
   participants: [String],
-  contactName: String? = nil
+  contactName: String? = nil,
+  unreadCount: Int = 0
 ) -> [String: Any] {
   var payload: [String: Any] = [
     "id": id,
@@ -20,6 +21,7 @@ func chatPayload(
     "last_message_at": CLIISO8601.format(lastMessageAt),
     "participants": participants,
     "is_group": isGroupHandle(identifier: identifier, guid: guid),
+    "unread_count": unreadCount,
   ]
   if let contactName {
     payload["contact_name"] = contactName

--- a/Sources/imsg/RPCServer+Handlers.swift
+++ b/Sources/imsg/RPCServer+Handlers.swift
@@ -18,7 +18,8 @@ private enum RPCSendTransport: String {
 extension RPCServer {
   func handleChatsList(id: Any?, params: [String: Any]) async throws {
     let limit = intParam(params["limit"]) ?? 20
-    let chats = try store.listChats(limit: max(limit, 1))
+    let unreadOnly = boolParam(params["unread_only"] ?? params["unreadOnly"]) ?? false
+    let chats = try store.listChats(limit: max(limit, 1), unreadOnly: unreadOnly)
     var payloads: [[String: Any]] = []
     payloads.reserveCapacity(chats.count)
 
@@ -41,7 +42,8 @@ extension RPCServer {
           service: service,
           lastMessageAt: chat.lastMessageAt,
           participants: participants,
-          contactName: contactName
+          contactName: contactName,
+          unreadCount: chat.unreadCount
         ))
     }
 

--- a/Tests/IMsgCoreTests/MessageDatabaseFixture.swift
+++ b/Tests/IMsgCoreTests/MessageDatabaseFixture.swift
@@ -18,6 +18,7 @@ enum MessageDatabaseFixture {
     var includeChatMessageDate = false
     var includeChatRouting = true
     var includeChatHandleJoin = true
+    var includeReadState = false
   }
 
   static func createSchema(_ db: Connection, options: SchemaOptions = SchemaOptions()) throws {
@@ -37,6 +38,10 @@ enum MessageDatabaseFixture {
     let payloadDataColumn = options.includePayloadData ? "payload_data BLOB," : ""
     let summaryInfoColumn = options.includeMessageSummaryInfo ? "message_summary_info BLOB," : ""
     let replyToColumn = options.includeReplyToGUID ? "reply_to_guid TEXT," : ""
+    let readStateColumns =
+      options.includeReadState
+      ? "is_read INTEGER, date_read INTEGER,"
+      : ""
 
     try db.execute(
       """
@@ -54,6 +59,7 @@ enum MessageDatabaseFixture {
         \(payloadDataColumn)
         \(summaryInfoColumn)
         \(replyToColumn)
+        \(readStateColumns)
         date INTEGER,
         is_from_me INTEGER,
         service TEXT

--- a/Tests/IMsgCoreTests/MessageStoreUnreadStateTests.swift
+++ b/Tests/IMsgCoreTests/MessageStoreUnreadStateTests.swift
@@ -1,0 +1,150 @@
+import Foundation
+import SQLite
+import Testing
+
+@testable import IMsgCore
+
+@Test
+func listChatsCountsUnreadInboundMessages() throws {
+  let db = try Connection(.inMemory)
+  try MessageDatabaseFixture.createSchema(
+    db,
+    options: MessageDatabaseFixture.SchemaOptions(includeReadState: true)
+  )
+
+  let now = Date()
+  try db.run(
+    """
+    INSERT INTO chat(ROWID, chat_identifier, guid, display_name, service_name)
+    VALUES
+      (1, '+111', 'iMessage;-;+111', 'Unread Chat', 'iMessage'),
+      (2, '+222', 'iMessage;-;+222', 'Read Chat', 'iMessage')
+    """
+  )
+  try db.run("INSERT INTO handle(ROWID, id) VALUES (1, '+111'), (2, '+222')")
+  try db.run("INSERT INTO chat_handle_join(chat_id, handle_id) VALUES (1, 1), (2, 2)")
+
+  let unreadDate = TestDatabase.appleEpoch(now.addingTimeInterval(-100))
+  let readDate = TestDatabase.appleEpoch(now.addingTimeInterval(-50))
+  try db.run(
+    """
+    INSERT INTO message(
+      ROWID, handle_id, text, date, is_from_me, service, is_read, date_read
+    )
+    VALUES
+      (1, 1, 'unread one', ?, 0, 'iMessage', 0, 0),
+      (2, 1, 'unread two', ?, 0, 'iMessage', 0, 0),
+      (3, 1, 'read inbound', ?, 0, 'iMessage', 1, ?),
+      (4, 1, 'outbound', ?, 1, 'iMessage', 0, 0),
+      (5, 2, 'all read', ?, 0, 'iMessage', 1, ?)
+    """,
+    unreadDate,
+    unreadDate,
+    readDate,
+    readDate,
+    readDate,
+    readDate,
+    readDate
+  )
+  try db.run(
+    """
+    INSERT INTO chat_message_join(chat_id, message_id)
+    VALUES (1, 1), (1, 2), (1, 3), (1, 4), (2, 5)
+    """
+  )
+
+  let store = try MessageStore(connection: db, path: ":memory:")
+  let chats = try store.listChats(limit: 10)
+  #expect(chats.count == 2)
+  let unreadChat = chats.first { $0.identifier == "+111" }
+  let readChat = chats.first { $0.identifier == "+222" }
+  #expect(unreadChat?.unreadCount == 2)
+  #expect(readChat?.unreadCount == 0)
+}
+
+@Test
+func listChatsUnreadOnlyFiltersChatsWithUnreadInboundMessages() throws {
+  let db = try Connection(.inMemory)
+  try MessageDatabaseFixture.createSchema(
+    db,
+    options: MessageDatabaseFixture.SchemaOptions(includeReadState: true)
+  )
+
+  let now = Date()
+  try db.run(
+    """
+    INSERT INTO chat(ROWID, chat_identifier, guid, display_name, service_name)
+    VALUES
+      (1, '+111', 'iMessage;-;+111', 'Unread Chat', 'iMessage'),
+      (2, '+222', 'iMessage;-;+222', 'Read Chat', 'iMessage')
+    """
+  )
+  try db.run("INSERT INTO handle(ROWID, id) VALUES (1, '+111'), (2, '+222')")
+  try db.run("INSERT INTO chat_handle_join(chat_id, handle_id) VALUES (1, 1), (2, 2)")
+  try db.run(
+    """
+    INSERT INTO message(ROWID, handle_id, text, date, is_from_me, service, is_read, date_read)
+    VALUES
+      (1, 1, 'unread', ?, 0, 'iMessage', 0, 0),
+      (2, 2, 'read', ?, 0, 'iMessage', 1, ?)
+    """,
+    TestDatabase.appleEpoch(now),
+    TestDatabase.appleEpoch(now),
+    TestDatabase.appleEpoch(now)
+  )
+  try db.run("INSERT INTO chat_message_join(chat_id, message_id) VALUES (1, 1), (2, 2)")
+
+  let store = try MessageStore(connection: db, path: ":memory:")
+  let chats = try store.listChats(limit: 10, unreadOnly: true)
+  #expect(chats.count == 1)
+  #expect(chats.first?.identifier == "+111")
+  #expect(chats.first?.unreadCount == 1)
+}
+
+@Test
+func messagesExposeInboundReadState() throws {
+  let db = try Connection(.inMemory)
+  try MessageDatabaseFixture.createSchema(
+    db,
+    options: MessageDatabaseFixture.SchemaOptions(includeReadState: true)
+  )
+
+  let now = Date()
+  let readAt = Date(timeIntervalSince1970: 1_700_000_000)
+  try db.run(
+    """
+    INSERT INTO chat(ROWID, chat_identifier, guid, display_name, service_name)
+    VALUES (1, '+123', 'iMessage;-;+123', 'Test Chat', 'iMessage')
+    """
+  )
+  try db.run("INSERT INTO handle(ROWID, id) VALUES (1, '+123'), (2, 'Me')")
+  try db.run("INSERT INTO chat_handle_join(chat_id, handle_id) VALUES (1, 1), (1, 2)")
+  try db.run(
+    """
+    INSERT INTO message(ROWID, handle_id, text, date, is_from_me, service, is_read, date_read)
+    VALUES
+      (1, 1, 'unread inbound', ?, 0, 'iMessage', 0, 0),
+      (2, 1, 'read inbound', ?, 0, 'iMessage', 1, ?),
+      (3, 2, 'outbound', ?, 1, 'iMessage', 0, 0)
+    """,
+    TestDatabase.appleEpoch(now),
+    TestDatabase.appleEpoch(now),
+    TestDatabase.appleEpoch(readAt),
+    TestDatabase.appleEpoch(now)
+  )
+  try db.run("INSERT INTO chat_message_join(chat_id, message_id) VALUES (1, 1), (1, 2), (1, 3)")
+
+  let store = try MessageStore(connection: db, path: ":memory:")
+  let messages = try store.messages(chatID: 1, limit: 10)
+  #expect(messages.count == 3)
+
+  let unread = messages.first { $0.rowID == 1 }
+  let read = messages.first { $0.rowID == 2 }
+  let outbound = messages.first { $0.rowID == 3 }
+  #expect(unread?.isRead == false)
+  #expect(unread?.dateRead == nil)
+  #expect(read?.isRead == true)
+  #expect(read?.dateRead == readAt)
+  #expect(outbound?.isRead == nil)
+  #expect(outbound?.dateRead == nil)
+}

--- a/Tests/imsgTests/ChatsCommandTests.swift
+++ b/Tests/imsgTests/ChatsCommandTests.swift
@@ -1,0 +1,29 @@
+import Foundation
+import Testing
+
+@testable import imsg
+
+@Test
+func chatsUnreadOnlyFlagFiltersToUnreadChats() async throws {
+  let dbPath = try CommandTestDatabase.makePathWithReadState()
+  let router = CommandRouter()
+
+  let (allOutput, _) = await StdoutCapture.capture {
+    await router.run(argv: ["imsg", "chats", "--db", dbPath, "--json"])
+  }
+  let allChats = allOutput.split(separator: "\n").map { line in
+    try! JSONSerialization.jsonObject(with: Data(line.utf8)) as! [String: Any]
+  }
+  #expect(allChats.count == 2)
+
+  let (unreadOutput, status) = await StdoutCapture.capture {
+    await router.run(argv: ["imsg", "chats", "--db", dbPath, "--unread-only", "--json"])
+  }
+  #expect(status == 0)
+  let unreadChats = unreadOutput.split(separator: "\n").map { line in
+    try! JSONSerialization.jsonObject(with: Data(line.utf8)) as! [String: Any]
+  }
+  #expect(unreadChats.count == 1)
+  #expect(unreadChats.first?["id"] as? Int == 1)
+  #expect(unreadChats.first?["unread_count"] as? Int == 1)
+}

--- a/Tests/imsgTests/CommandTestDatabase.swift
+++ b/Tests/imsgTests/CommandTestDatabase.swift
@@ -17,6 +17,14 @@ enum CommandTestDatabase {
     return path
   }
 
+  static func makePathWithReadState() throws -> String {
+    let path = try makeDatabasePath()
+    let db = try Connection(path)
+    try createSchema(db, includeChatHandleJoin: true, includeReadState: true)
+    try seedChatsWithReadState(db)
+    return path
+  }
+
   static func makePathDirectChat() throws -> String {
     let path = try makePath()
     let db = try Connection(path)
@@ -361,6 +369,38 @@ enum CommandTestDatabase {
       appleEpoch(readAt)
     )
     try db.run("INSERT INTO chat_message_join(chat_id, message_id) VALUES (1, 5), (1, 6)")
+  }
+
+  private static func seedChatsWithReadState(_ db: Connection) throws {
+    let now = Date()
+    try db.run(
+      """
+      INSERT INTO chat(
+        ROWID, chat_identifier, guid, display_name, service_name,
+        account_id, account_login, last_addressed_handle
+      )
+      VALUES
+        (1, 'iMessage;-;+123', 'iMessage;-;+123', '', 'iMessage',
+         'iMessage;-;me@icloud.com', 'me@icloud.com', 'me@icloud.com'),
+        (2, 'iMessage;-;+456', 'iMessage;-;+456', '', 'iMessage',
+         'iMessage;-;me@icloud.com', 'me@icloud.com', 'me@icloud.com')
+      """
+    )
+    try db.run("INSERT INTO handle(ROWID, id) VALUES (1, '+123'), (2, '+456')")
+    try db.run(
+      "INSERT INTO chat_handle_join(chat_id, handle_id) VALUES (1, 1), (2, 2)")
+    try db.run(
+      """
+      INSERT INTO message(ROWID, handle_id, text, date, is_from_me, service, is_read, date_read)
+      VALUES
+        (5, 1, 'unread', ?, 0, 'iMessage', 0, 0),
+        (6, 2, 'read', ?, 0, 'iMessage', 1, ?)
+      """,
+      appleEpoch(now),
+      appleEpoch(now),
+      appleEpoch(now)
+    )
+    try db.run("INSERT INTO chat_message_join(chat_id, message_id) VALUES (1, 5), (2, 6)")
   }
 
   private static func pollPayload(jsonObject: [String: Any]) throws -> Data {

--- a/Tests/imsgTests/CommandTestDatabase.swift
+++ b/Tests/imsgTests/CommandTestDatabase.swift
@@ -111,6 +111,13 @@ enum CommandTestDatabase {
     )
   }
 
+  static func makeStoreForRPCWithReadState() throws -> MessageStore {
+    let db = try Connection(.inMemory)
+    try createSchema(db, includeChatHandleJoin: true, includeReadState: true)
+    try seedRPCChatWithReadState(db)
+    return try MessageStore(connection: db, path: ":memory:")
+  }
+
   static func makeStoreForRPCWithReaction() throws -> MessageStore {
     let db = try Connection(.inMemory)
     try createSchema(db, includeChatHandleJoin: true, includeReactionColumns: true)
@@ -196,7 +203,8 @@ enum CommandTestDatabase {
     _ db: Connection,
     includeChatHandleJoin: Bool,
     includeReactionColumns: Bool = false,
-    includePollColumns: Bool = false
+    includePollColumns: Bool = false,
+    includeReadState: Bool = false
   ) throws {
     let reactionColumns =
       includeReactionColumns
@@ -214,6 +222,13 @@ enum CommandTestDatabase {
         "message_summary_info BLOB",
       ].joined(separator: ",\n") + ","
       : ""
+    let readStateColumns =
+      includeReadState
+      ? [
+        "is_read INTEGER",
+        "date_read INTEGER",
+      ].joined(separator: ",\n") + ","
+      : ""
     try db.execute(
       """
       CREATE TABLE message (
@@ -222,6 +237,7 @@ enum CommandTestDatabase {
         text TEXT,
         \(reactionColumns)
         \(pollColumns)
+        \(readStateColumns)
         date INTEGER,
         is_from_me INTEGER,
         service TEXT
@@ -314,6 +330,37 @@ enum CommandTestDatabase {
       appleEpoch(now)
     )
     try db.run("INSERT INTO chat_message_join(chat_id, message_id) VALUES (1, 5)")
+  }
+
+  private static func seedRPCChatWithReadState(_ db: Connection) throws {
+    let now = Date()
+    let readAt = Date(timeIntervalSince1970: 1_700_000_000)
+    try db.run(
+      """
+      INSERT INTO chat(
+        ROWID, chat_identifier, guid, display_name, service_name,
+        account_id, account_login, last_addressed_handle
+      )
+      VALUES (
+        1, 'iMessage;+;chat123', 'iMessage;+;chat123', 'Group Chat', 'iMessage',
+        'iMessage;+;me@icloud.com', 'me@icloud.com', 'me@icloud.com'
+      )
+      """
+    )
+    try db.run("INSERT INTO handle(ROWID, id) VALUES (1, '+123'), (2, 'me@icloud.com')")
+    try db.run("INSERT INTO chat_handle_join(chat_id, handle_id) VALUES (1, 1), (1, 2)")
+    try db.run(
+      """
+      INSERT INTO message(ROWID, handle_id, text, date, is_from_me, service, is_read, date_read)
+      VALUES
+        (5, 1, 'unread', ?, 0, 'iMessage', 0, 0),
+        (6, 1, 'read', ?, 0, 'iMessage', 1, ?)
+      """,
+      appleEpoch(now),
+      appleEpoch(now),
+      appleEpoch(readAt)
+    )
+    try db.run("INSERT INTO chat_message_join(chat_id, message_id) VALUES (1, 5), (1, 6)")
   }
 
   private static func pollPayload(jsonObject: [String: Any]) throws -> Data {

--- a/Tests/imsgTests/UnreadStatePayloadTests.swift
+++ b/Tests/imsgTests/UnreadStatePayloadTests.swift
@@ -1,5 +1,4 @@
 import Foundation
-import SQLite
 import Testing
 
 @testable import IMsgCore
@@ -86,41 +85,7 @@ func messagePayloadIncludesInboundReadState() throws {
 
 @Test
 func rpcChatsListSupportsUnreadOnlyAndUnreadCount() async throws {
-  let db = try Connection(.inMemory)
-  try MessageDatabaseFixture.createSchema(
-    db,
-    options: MessageDatabaseFixture.SchemaOptions(
-      includeChatRouting: true,
-      includeChatHandleJoin: true,
-      includeReadState: true
-    )
-  )
-
-  let now = Date()
-  try db.run(
-    """
-    INSERT INTO chat(
-      ROWID, chat_identifier, guid, display_name, service_name,
-      account_id, account_login, last_addressed_handle
-    )
-    VALUES (
-      1, 'iMessage;+;chat123', 'iMessage;+;chat123', 'Group Chat', 'iMessage',
-      'iMessage;+;me@icloud.com', 'me@icloud.com', 'me@icloud.com'
-    )
-    """
-  )
-  try db.run("INSERT INTO handle(ROWID, id) VALUES (1, '+123'), (2, 'me@icloud.com')")
-  try db.run("INSERT INTO chat_handle_join(chat_id, handle_id) VALUES (1, 1), (1, 2)")
-  try db.run(
-    """
-    INSERT INTO message(ROWID, handle_id, text, date, is_from_me, service, is_read, date_read)
-    VALUES (5, 1, 'hello', ?, 0, 'iMessage', 0, 0)
-    """,
-    CommandTestDatabase.appleEpoch(now)
-  )
-  try db.run("INSERT INTO chat_message_join(chat_id, message_id) VALUES (1, 5)")
-
-  let store = try MessageStore(connection: db, path: ":memory:")
+  let store = try CommandTestDatabase.makeStoreForRPCWithReadState()
   let output = TestRPCOutput()
   let server = RPCServer(store: store, verbose: false, output: output)
 
@@ -136,46 +101,7 @@ func rpcChatsListSupportsUnreadOnlyAndUnreadCount() async throws {
 
 @Test
 func rpcMessagesHistoryIncludesInboundReadState() async throws {
-  let db = try Connection(.inMemory)
-  try MessageDatabaseFixture.createSchema(
-    db,
-    options: MessageDatabaseFixture.SchemaOptions(
-      includeChatRouting: true,
-      includeChatHandleJoin: true,
-      includeReadState: true
-    )
-  )
-
-  let now = Date()
-  let readAt = Date(timeIntervalSince1970: 1_700_000_000)
-  try db.run(
-    """
-    INSERT INTO chat(
-      ROWID, chat_identifier, guid, display_name, service_name,
-      account_id, account_login, last_addressed_handle
-    )
-    VALUES (
-      1, 'iMessage;+;chat123', 'iMessage;+;chat123', 'Group Chat', 'iMessage',
-      'iMessage;+;me@icloud.com', 'me@icloud.com', 'me@icloud.com'
-    )
-    """
-  )
-  try db.run("INSERT INTO handle(ROWID, id) VALUES (1, '+123'), (2, 'me@icloud.com')")
-  try db.run("INSERT INTO chat_handle_join(chat_id, handle_id) VALUES (1, 1), (1, 2)")
-  try db.run(
-    """
-    INSERT INTO message(ROWID, handle_id, text, date, is_from_me, service, is_read, date_read)
-    VALUES
-      (5, 1, 'unread', ?, 0, 'iMessage', 0, 0),
-      (6, 1, 'read', ?, 0, 'iMessage', 1, ?)
-    """,
-    CommandTestDatabase.appleEpoch(now),
-    CommandTestDatabase.appleEpoch(now),
-    CommandTestDatabase.appleEpoch(readAt)
-  )
-  try db.run("INSERT INTO chat_message_join(chat_id, message_id) VALUES (1, 5), (1, 6)")
-
-  let store = try MessageStore(connection: db, path: ":memory:")
+  let store = try CommandTestDatabase.makeStoreForRPCWithReadState()
   let output = TestRPCOutput()
   let server = RPCServer(store: store, verbose: false, output: output)
 

--- a/Tests/imsgTests/UnreadStatePayloadTests.swift
+++ b/Tests/imsgTests/UnreadStatePayloadTests.swift
@@ -1,0 +1,195 @@
+import Foundation
+import SQLite
+import Testing
+
+@testable import IMsgCore
+@testable import imsg
+
+@Test
+func chatPayloadIncludesUnreadCount() throws {
+  let chat = Chat(
+    id: 1,
+    identifier: "+123",
+    name: "Test",
+    service: "iMessage",
+    lastMessageAt: Date(timeIntervalSince1970: 0),
+    unreadCount: 3
+  )
+  let payload = ChatPayload(chat: chat)
+  let data = try JSONEncoder().encode(payload)
+  let object = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+  #expect(object?["unread_count"] as? Int == 3)
+}
+
+@Test
+func messagePayloadIncludesInboundReadState() throws {
+  let readAt = Date(timeIntervalSince1970: 1_700_000_000)
+  let unreadMessage = Message(
+    rowID: 1,
+    chatID: 1,
+    sender: "+123",
+    text: "unread",
+    date: Date(timeIntervalSince1970: 1),
+    isFromMe: false,
+    service: "iMessage",
+    handleID: 1,
+    attachmentsCount: 0,
+    isRead: false
+  )
+  let readMessage = Message(
+    rowID: 2,
+    chatID: 1,
+    sender: "+123",
+    text: "read",
+    date: Date(timeIntervalSince1970: 2),
+    isFromMe: false,
+    service: "iMessage",
+    handleID: 1,
+    attachmentsCount: 0,
+    isRead: true,
+    dateRead: readAt
+  )
+  let outboundMessage = Message(
+    rowID: 3,
+    chatID: 1,
+    sender: "me@icloud.com",
+    text: "sent",
+    date: Date(timeIntervalSince1970: 3),
+    isFromMe: true,
+    service: "iMessage",
+    handleID: 2,
+    attachmentsCount: 0,
+    isRead: false
+  )
+
+  let unreadPayload = MessagePayload(message: unreadMessage, attachments: [])
+  let readPayload = MessagePayload(message: readMessage, attachments: [])
+  let outboundPayload = MessagePayload(message: outboundMessage, attachments: [])
+
+  let unreadObject = try JSONSerialization.jsonObject(
+    with: try JSONEncoder().encode(unreadPayload)
+  ) as? [String: Any]
+  let readObject = try JSONSerialization.jsonObject(
+    with: try JSONEncoder().encode(readPayload)
+  ) as? [String: Any]
+  let outboundObject = try JSONSerialization.jsonObject(
+    with: try JSONEncoder().encode(outboundPayload)
+  ) as? [String: Any]
+
+  #expect(unreadObject?["is_read"] as? Bool == false)
+  #expect(unreadObject?["date_read"] == nil)
+  #expect(readObject?["is_read"] as? Bool == true)
+  #expect(readObject?["date_read"] as? String != nil)
+  #expect(outboundObject?["is_read"] == nil)
+  #expect(outboundObject?["date_read"] == nil)
+}
+
+@Test
+func rpcChatsListSupportsUnreadOnlyAndUnreadCount() async throws {
+  let db = try Connection(.inMemory)
+  try MessageDatabaseFixture.createSchema(
+    db,
+    options: MessageDatabaseFixture.SchemaOptions(
+      includeChatRouting: true,
+      includeChatHandleJoin: true,
+      includeReadState: true
+    )
+  )
+
+  let now = Date()
+  try db.run(
+    """
+    INSERT INTO chat(
+      ROWID, chat_identifier, guid, display_name, service_name,
+      account_id, account_login, last_addressed_handle
+    )
+    VALUES (
+      1, 'iMessage;+;chat123', 'iMessage;+;chat123', 'Group Chat', 'iMessage',
+      'iMessage;+;me@icloud.com', 'me@icloud.com', 'me@icloud.com'
+    )
+    """
+  )
+  try db.run("INSERT INTO handle(ROWID, id) VALUES (1, '+123'), (2, 'me@icloud.com')")
+  try db.run("INSERT INTO chat_handle_join(chat_id, handle_id) VALUES (1, 1), (1, 2)")
+  try db.run(
+    """
+    INSERT INTO message(ROWID, handle_id, text, date, is_from_me, service, is_read, date_read)
+    VALUES (5, 1, 'hello', ?, 0, 'iMessage', 0, 0)
+    """,
+    CommandTestDatabase.appleEpoch(now)
+  )
+  try db.run("INSERT INTO chat_message_join(chat_id, message_id) VALUES (1, 5)")
+
+  let store = try MessageStore(connection: db, path: ":memory:")
+  let output = TestRPCOutput()
+  let server = RPCServer(store: store, verbose: false, output: output)
+
+  let line =
+    #"{"jsonrpc":"2.0","id":"1","method":"chats.list","params":{"limit":10,"unread_only":true}}"#
+  await server.handleLineForTesting(line)
+
+  let result = output.responses[0]["result"] as? [String: Any]
+  let chats = result?["chats"] as? [[String: Any]] ?? []
+  #expect(chats.count == 1)
+  #expect(chats[0]["unread_count"] as? Int == 1)
+}
+
+@Test
+func rpcMessagesHistoryIncludesInboundReadState() async throws {
+  let db = try Connection(.inMemory)
+  try MessageDatabaseFixture.createSchema(
+    db,
+    options: MessageDatabaseFixture.SchemaOptions(
+      includeChatRouting: true,
+      includeChatHandleJoin: true,
+      includeReadState: true
+    )
+  )
+
+  let now = Date()
+  let readAt = Date(timeIntervalSince1970: 1_700_000_000)
+  try db.run(
+    """
+    INSERT INTO chat(
+      ROWID, chat_identifier, guid, display_name, service_name,
+      account_id, account_login, last_addressed_handle
+    )
+    VALUES (
+      1, 'iMessage;+;chat123', 'iMessage;+;chat123', 'Group Chat', 'iMessage',
+      'iMessage;+;me@icloud.com', 'me@icloud.com', 'me@icloud.com'
+    )
+    """
+  )
+  try db.run("INSERT INTO handle(ROWID, id) VALUES (1, '+123'), (2, 'me@icloud.com')")
+  try db.run("INSERT INTO chat_handle_join(chat_id, handle_id) VALUES (1, 1), (1, 2)")
+  try db.run(
+    """
+    INSERT INTO message(ROWID, handle_id, text, date, is_from_me, service, is_read, date_read)
+    VALUES
+      (5, 1, 'unread', ?, 0, 'iMessage', 0, 0),
+      (6, 1, 'read', ?, 0, 'iMessage', 1, ?)
+    """,
+    CommandTestDatabase.appleEpoch(now),
+    CommandTestDatabase.appleEpoch(now),
+    CommandTestDatabase.appleEpoch(readAt)
+  )
+  try db.run("INSERT INTO chat_message_join(chat_id, message_id) VALUES (1, 5), (1, 6)")
+
+  let store = try MessageStore(connection: db, path: ":memory:")
+  let output = TestRPCOutput()
+  let server = RPCServer(store: store, verbose: false, output: output)
+
+  let line =
+    #"{"jsonrpc":"2.0","id":2,"method":"messages.history","params":{"chat_id":1,"limit":5}}"#
+  await server.handleLineForTesting(line)
+
+  let result = output.responses.first?["result"] as? [String: Any]
+  let messages = result?["messages"] as? [[String: Any]] ?? []
+  #expect(messages.count == 2)
+  let unread = messages.first { ($0["text"] as? String) == "unread" }
+  let read = messages.first { ($0["text"] as? String) == "read" }
+  #expect(unread?["is_read"] as? Bool == false)
+  #expect(unread?["date_read"] == nil)
+  #expect(read?["is_read"] as? Bool == true)
+  #expect(read?["date_read"] as? String != nil)
+}

--- a/docs/chats.md
+++ b/docs/chats.md
@@ -46,6 +46,7 @@ Every chat object — from `chats`, `group`, or any nested chat metadata in `his
 | `account_id` | string | Routing diagnostic. Read-only. |
 | `account_login` | string | Routing diagnostic. Read-only. |
 | `last_addressed_handle` | string | Routing diagnostic. Read-only. |
+| `unread_count` | int | Count of unread inbound messages in the chat. |
 
 ## Routing identifiers — which one to use
 
@@ -70,7 +71,13 @@ To distinguish your own messages from others':
 
 ## Filtering tips
 
-`imsg chats` does not take filter flags — it's designed to be cheap. Pipe through `jq` or `grep` for ad-hoc filtering:
+`imsg chats` takes one filter flag, `--unread-only`, which returns only chats with unread inbound messages:
+
+```bash
+imsg chats --unread-only --json
+```
+
+For anything else, pipe through `jq` or `grep` for ad-hoc filtering:
 
 ```bash
 imsg chats --json | jq -s 'map(select(.is_group == true))'

--- a/docs/json.md
+++ b/docs/json.md
@@ -32,6 +32,7 @@ Returned by `imsg chats`, `imsg group`, and embedded in nested chat references i
 | `account_id` | string | Routing diagnostic. Read-only. |
 | `account_login` | string | Routing diagnostic. Read-only. |
 | `last_addressed_handle` | string | Routing diagnostic. Read-only. |
+| `unread_count` | int | Count of unread inbound messages in the chat. |
 
 ## Message
 
@@ -59,6 +60,8 @@ Returned by `imsg history`, `imsg watch`, and the JSON-RPC `messages.history` an
 | `attachments` | array | Present when `--attachments` is set. See below. |
 | `thread_originator_guid` | string | For inline-reply threads. |
 | `poll` | object | Present for native Apple Messages Polls creation and vote rows. See below. |
+| `is_read` | bool | Inbound only — omitted when `is_from_me` is true. |
+| `date_read` | ISO8601 | Inbound only — present when `is_read` is true. |
 
 ### URL preview coalescing
 

--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -29,6 +29,7 @@ The pattern intentionally mirrors language servers and the way `imsg`'s parent g
 Params:
 
 - `limit` (int, default 20)
+- `unread_only` (bool, default `false`) — when true, return only chats with `unread_count > 0`
 
 Result:
 


### PR DESCRIPTION
## Summary

Expose read/unread state that already lives in `chat.db` so callers don't have
to re-derive it:

- `chats.list` (RPC) and `imsg chats --json` now include `unread_count` per
  chat — a count of inbound messages where `is_read = 0`.
- `messages.history` (RPC) and `imsg history --json` now include `is_read`
  and `date_read` on inbound messages (omitted for outbound/`is_from_me`
  messages, where the columns aren't meaningful).
- Added `unread_only` (RPC param) / `--unread-only` (CLI flag) to filter
  `chats.list` / `imsg chats` down to chats with `unread_count > 0`.
- All of the above degrade gracefully on older `chat.db` schemas that lack
  `is_read` / `date_read` columns (`unread_count` reports `0`, `is_read` /
  `date_read` are omitted) — detected via the existing `MessageStoreSchema`
  column-probing.

This is read-only: no writes to `chat.db`, no new permissions, no change to
existing output shape for callers that don't look at the new fields.

## Docs

- `docs/rpc.md`: documented `unread_only` param on `chats.list`.

## Test plan

- [x] `make test` — full suite green (372 tests), including new coverage:
  - `Tests/IMsgCoreTests/MessageStoreUnreadStateTests.swift`
  - `Tests/imsgTests/UnreadStatePayloadTests.swift`
- [x] `make build` — release binary builds and runs
- [x] Manually verified against a real `~/Library/Messages/chat.db`:
  `imsg chats --json` and `imsg chats --unread-only --json` both return the
  expected `unread_count` values.
