### PR TITLE
feat: expose message read state

### DIFF
--- a/.agents/skills/imsg/SKILL.md
+++ b/.agents/skills/imsg/SKILL.md
@@ -29,6 +29,7 @@ Resolve a person visible in the Messages.app UI from `chats`, not `search`. The 
 
 ```bash
 imsg chats --limit 200 --json | jq -s '.[] | select((.contact_name // .display_name // .name // .identifier // "" | ascii_downcase) | contains("beatrix"))'
+imsg chats --unread-only --json | jq -s
 ```
 
 Then inspect and read the chat by rowid:
@@ -43,6 +44,7 @@ imsg history --chat-id ID --start 2025-01-01T00:00:00Z --end 2025-02-01T00:00:00
 - `--start` is inclusive, `--end` exclusive; both take ISO8601. Use absolute timestamps for date-scoped questions.
 - `--attachments` adds attachment metadata; `--convert-attachments` converts CAF→M4A / GIF→PNG for model consumption.
 - `imsg search --query "pizza tonight" --json` searches message bodies only (`--match contains` default, `exact` available).
+- Chat-list JSON includes `unread_count`. Inbound message payloads include `is_read` and, when read, `date_read`; outbound payloads omit both.
 - SIP-free lookups: `imsg whois --address "+15551234567" --type phone --local`, `imsg nickname --address "+15551234567" --local --json`, `imsg account --local --json`. Note `nickname --local` returns *your* AddressBook label for the handle; the iMessage-shared nickname needs default-mode `nickname` via the bridge.
 - Direct `sqlite3` queries are a last resort; the `handle` table lacks the resolved names `imsg chats` provides.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.12.4 - Unreleased
 
+### Read Commands
+- feat: expose per-chat unread counts and inbound message read timestamps across JSON, JSON-RPC, search, history, and watch, with an unread-only chat filter (#160, thanks @chiedo).
+
 ### Native Polls
 - fix: match native poll vote envelopes, participant handles, and summary metadata so votes render participant markers and correct notifications (#162, thanks @omarshahine).
 

--- a/Sources/IMsgCore/Message+URLPreview.swift
+++ b/Sources/IMsgCore/Message+URLPreview.swift
@@ -43,7 +43,9 @@ extension Message {
         isReactionAdd: isReactionAdd,
         reactedToGUID: reactedToGUID
       ),
-      poll: poll
+      poll: poll,
+      isRead: isRead,
+      dateRead: dateRead
     )
   }
 }

--- a/Sources/IMsgCore/MessageStore+Chats.swift
+++ b/Sources/IMsgCore/MessageStore+Chats.swift
@@ -19,8 +19,9 @@ private struct ListChatsQuery {
   let sql: String
   let bindings: [Binding?]
 
-  init(limit: Int, schema: MessageStoreSchema) {
+  init(limit: Int, offset: Int = 0, unreadOnly: Bool, schema: MessageStoreSchema) {
     let routing = ChatRoutingSelection(schema: schema)
+    let unreadSelection = UnreadChatSelection(enabled: unreadOnly)
     if schema.hasChatMessageJoinMessageDateColumn {
       self.sql = """
         SELECT c.ROWID AS chat_rowid, IFNULL(c.display_name, c.chat_identifier) AS name,
@@ -31,9 +32,10 @@ private struct ListChatsQuery {
                \(routing.lastAddressedHandleColumn) AS last_addressed_handle
         FROM chat c
         JOIN chat_message_join cmj ON c.ROWID = cmj.chat_id
+        \(unreadSelection.joinClause)
         GROUP BY c.ROWID
-        ORDER BY last_date DESC
-        LIMIT ?
+        ORDER BY last_date DESC, c.ROWID DESC
+        LIMIT ? OFFSET ?
         """
     } else {
       self.sql = """
@@ -46,13 +48,75 @@ private struct ListChatsQuery {
         FROM chat c
         JOIN chat_message_join cmj ON c.ROWID = cmj.chat_id
         JOIN message m ON m.ROWID = cmj.message_id
+        \(unreadSelection.joinClause)
         GROUP BY c.ROWID
-        ORDER BY last_date DESC
-        LIMIT ?
+        ORDER BY last_date DESC, c.ROWID DESC
+        LIMIT ? OFFSET ?
         """
     }
-    self.bindings = [limit]
+    self.bindings = [limit, offset]
   }
+}
+
+private struct UnreadChatSelection {
+  let joinClause: String
+
+  init(enabled: Bool) {
+    guard enabled else {
+      self.joinClause = ""
+      return
+    }
+    self.joinClause = """
+      JOIN (
+        SELECT DISTINCT cmj_unread.chat_id
+        FROM chat_message_join cmj_unread
+        JOIN message m_unread ON m_unread.ROWID = cmj_unread.message_id
+        WHERE m_unread.is_from_me = 0 AND m_unread.is_read = 0
+      ) unread ON unread.chat_id = c.ROWID
+      """
+  }
+}
+
+private struct UnreadMessagesQuery {
+  let sql: String
+  let bindings: [Binding?]
+  let selection: MessageRowSelection
+
+  init(store: MessageStore, chatIDs: [Int64]) {
+    let selection = MessageRowSelection(store: store, includeChatID: true)
+    self.selection = selection
+    let placeholders = Array(repeating: "?", count: chatIDs.count).joined(separator: ", ")
+    self.sql = """
+      SELECT \(selection.selectList)
+      FROM message m
+      JOIN chat_message_join cmj ON m.ROWID = cmj.message_id
+      LEFT JOIN handle h ON m.handle_id = h.ROWID
+      WHERE cmj.chat_id IN (\(placeholders))
+        AND m.is_from_me = 0
+        AND m.is_read = 0
+      ORDER BY cmj.chat_id, m.ROWID
+      """
+    self.bindings = chatIDs.map { $0 as Binding? }
+  }
+}
+
+private struct ChatRow {
+  let id: Int64
+  let identifier: String
+  let name: String
+  let service: String
+  let lastMessageAt: Date
+  let accountID: String?
+  let accountLogin: String?
+  let lastAddressedHandle: String?
+}
+
+private struct UnreadStateUnavailableError: LocalizedError, CustomStringConvertible {
+  private let message =
+    "Unread filtering is unavailable because this Messages database has no message.is_read column"
+
+  var errorDescription: String? { message }
+  var description: String { message }
 }
 
 private struct ChatInfoQuery {
@@ -91,26 +155,137 @@ private struct ParticipantsQuery {
 }
 
 extension MessageStore {
-  public func listChats(limit: Int) throws -> [Chat] {
-    let query = ListChatsQuery(limit: limit, schema: schema)
-    return try withConnection { db in
-      var chats: [Chat] = []
-      let rows = try db.prepareRowIterator(query.sql, bindings: query.bindings)
-      while let row = try rows.failableNext() {
-        chats.append(
-          Chat(
-            id: try int64Value(row, "chat_rowid") ?? 0,
-            identifier: try stringValue(row, "chat_identifier"),
-            name: try stringValue(row, "name"),
-            service: try stringValue(row, "service_name"),
-            lastMessageAt: try appleDate(from: int64Value(row, "last_date")),
-            accountID: try stringValue(row, "account_id").nilIfEmpty,
-            accountLogin: try stringValue(row, "account_login").nilIfEmpty,
-            lastAddressedHandle: try stringValue(row, "last_addressed_handle").nilIfEmpty
-          ))
-      }
-      return chats
+  public var supportsUnreadState: Bool { schema.hasIsReadColumn }
+
+  public func listChats(limit: Int, unreadOnly: Bool = false) throws -> [Chat] {
+    guard limit > 0 else { return [] }
+    if unreadOnly && !supportsUnreadState {
+      throw UnreadStateUnavailableError()
     }
+    return try withConnection { db in
+      if !unreadOnly {
+        let query = ListChatsQuery(limit: limit, unreadOnly: false, schema: schema)
+        let rows = try chatRows(for: query, db: db)
+        let counts = try unreadCounts(for: rows.map(\.id), db: db)
+        return rows.map { chat(from: $0, unreadCount: counts[$0.id]) }
+      }
+
+      // The SQL predicate narrows the candidate set cheaply, then logical-message counting
+      // rejects false positives such as unread URL-preview rows attached to read text rows.
+      let batchLimit = max(limit, 50)
+      var offset = 0
+      var result: [Chat] = []
+      while result.count < limit {
+        let query = ListChatsQuery(
+          limit: batchLimit,
+          offset: offset,
+          unreadOnly: true,
+          schema: schema
+        )
+        let rows = try chatRows(for: query, db: db)
+        guard !rows.isEmpty else { break }
+        let counts = try unreadCounts(for: rows.map(\.id), db: db)
+        for row in rows {
+          guard let count = counts[row.id], count > 0 else { continue }
+          result.append(chat(from: row, unreadCount: count))
+          if result.count == limit { break }
+        }
+        guard rows.count == batchLimit else { break }
+        offset += rows.count
+      }
+      return result
+    }
+  }
+
+  private func chatRows(for query: ListChatsQuery, db: Connection) throws -> [ChatRow] {
+    var result: [ChatRow] = []
+    let rows = try db.prepareRowIterator(query.sql, bindings: query.bindings)
+    while let row = try rows.failableNext() {
+      result.append(
+        ChatRow(
+          id: try int64Value(row, "chat_rowid") ?? 0,
+          identifier: try stringValue(row, "chat_identifier"),
+          name: try stringValue(row, "name"),
+          service: try stringValue(row, "service_name"),
+          lastMessageAt: try appleDate(from: int64Value(row, "last_date")),
+          accountID: try stringValue(row, "account_id").nilIfEmpty,
+          accountLogin: try stringValue(row, "account_login").nilIfEmpty,
+          lastAddressedHandle: try stringValue(row, "last_addressed_handle").nilIfEmpty
+        ))
+    }
+    return result
+  }
+
+  private func chat(from row: ChatRow, unreadCount: Int?) -> Chat {
+    Chat(
+      id: row.id,
+      identifier: row.identifier,
+      name: row.name,
+      service: row.service,
+      lastMessageAt: row.lastMessageAt,
+      accountID: row.accountID,
+      accountLogin: row.accountLogin,
+      lastAddressedHandle: row.lastAddressedHandle,
+      unreadCount: supportsUnreadState ? unreadCount ?? 0 : nil
+    )
+  }
+
+  private func unreadCounts(for chatIDs: [Int64], db: Connection) throws -> [Int64: Int] {
+    guard supportsUnreadState else { return [:] }
+    var result: [Int64: Int] = [:]
+    // Stay below SQLite builds with the traditional 999-variable limit.
+    var offset = 0
+    while offset < chatIDs.count {
+      let end = min(offset + 500, chatIDs.count)
+      let chunk = Array(chatIDs[offset..<end])
+      let query = UnreadMessagesQuery(store: self, chatIDs: chunk)
+      let rows = try db.prepareRowIterator(query.sql, bindings: query.bindings)
+      var unreadMessageIDsByChat: [Int64: Set<Int64>] = [:]
+      while let row = try rows.failableNext() {
+        let decoded = try decodeMessageRow(
+          row,
+          columns: query.selection.columns,
+          fallbackChatID: nil
+        )
+        let reaction = decodeReaction(
+          associatedType: decoded.associatedType,
+          associatedGUID: decoded.associatedGUID,
+          text: decoded.text
+        )
+        let message = Message(
+          rowID: decoded.rowID,
+          chatID: decoded.chatID,
+          sender: decoded.sender,
+          text: decoded.text,
+          date: decoded.date,
+          isFromMe: decoded.isFromMe,
+          service: decoded.service,
+          handleID: decoded.handleID,
+          attachmentsCount: decoded.attachments,
+          guid: decoded.guid,
+          balloonBundleID: decoded.balloonBundleID.nilIfEmpty,
+          reaction: Message.ReactionMetadata(
+            isReaction: reaction.isReaction,
+            reactionType: reaction.reactionType,
+            isReactionAdd: reaction.isReactionAdd,
+            reactedToGUID: reaction.reactedToGUID
+          )
+        )
+        var logicalRowID = message.rowID
+        if isURLPreviewBalloon(message),
+          let textMessage = try precedingTextMessageForURLPreview(message, db: db)
+        {
+          guard textMessage.isRead == false else { continue }
+          logicalRowID = textMessage.rowID
+        }
+        unreadMessageIDsByChat[decoded.chatID, default: []].insert(logicalRowID)
+      }
+      for (chatID, rowIDs) in unreadMessageIDsByChat {
+        result[chatID] = rowIDs.count
+      }
+      offset = end
+    }
+    return result
   }
 
   public func chatInfo(chatID: Int64) throws -> ChatInfo? {

--- a/Sources/IMsgCore/MessageStore+MessageConstruction.swift
+++ b/Sources/IMsgCore/MessageStore+MessageConstruction.swift
@@ -62,7 +62,9 @@ extension MessageStore {
         isReactionAdd: reaction.isReactionAdd,
         reactedToGUID: reaction.reactedToGUID
       ),
-      poll: poll
+      poll: poll,
+      isRead: decoded.isRead,
+      dateRead: decoded.dateRead
     )
   }
 

--- a/Sources/IMsgCore/MessageStore+MessageRows.swift
+++ b/Sources/IMsgCore/MessageStore+MessageRows.swift
@@ -26,6 +26,8 @@ struct MessageRowColumns {
   let balloonBundleID: String
   let payloadData: String
   let messageSummaryInfo: String
+  let isRead: String
+  let dateRead: String
 
   static func message(chatID: String?) -> MessageRowColumns {
     MessageRowColumns(
@@ -49,7 +51,9 @@ struct MessageRowColumns {
       replyToGUID: "reply_to_guid",
       balloonBundleID: MessageRowColumns.balloonBundleID,
       payloadData: MessageRowColumns.payloadData,
-      messageSummaryInfo: MessageRowColumns.messageSummaryInfo
+      messageSummaryInfo: MessageRowColumns.messageSummaryInfo,
+      isRead: "is_read",
+      dateRead: "date_read"
     )
   }
 }
@@ -73,6 +77,8 @@ struct DecodedMessageRow {
   let databaseReplyToGUID: String
   let balloonBundleID: String
   let poll: MessagePollEvent?
+  let isRead: Bool?
+  let dateRead: Date?
 }
 
 struct PollOptionTextCache {
@@ -112,6 +118,8 @@ struct MessageRowSelection {
     let summaryInfoColumn =
       schema.hasMessageSummaryInfoColumn
       ? "CASE WHEN \(pollCandidatePredicate) THEN m.message_summary_info ELSE NULL END" : "NULL"
+    let isReadColumn = schema.hasIsReadColumn ? "m.is_read" : "NULL"
+    let dateReadColumn = schema.hasDateReadColumn ? "m.date_read" : "NULL"
     let chatColumn = includeChatID ? ", cmj.chat_id AS \(columns.chatID!)" : ""
 
     let selectList = """
@@ -130,7 +138,9 @@ struct MessageRowSelection {
              \(replyToColumn) AS \(columns.replyToGUID),
              \(balloonColumn) AS \(columns.balloonBundleID),
              \(payloadDataColumn) AS \(columns.payloadData),
-             \(summaryInfoColumn) AS \(columns.messageSummaryInfo)
+             \(summaryInfoColumn) AS \(columns.messageSummaryInfo),
+             \(isReadColumn) AS \(columns.isRead),
+             \(dateReadColumn) AS \(columns.dateRead)
       """
     self.selectList = selectList
     self.columns = columns

--- a/Sources/IMsgCore/MessageStore+Messages.swift
+++ b/Sources/IMsgCore/MessageStore+Messages.swift
@@ -341,6 +341,16 @@ extension MessageStore {
       poll = nil
     }
 
+    var isRead: Bool?
+    var dateRead: Date?
+    if !isFromMe, let readRaw = try intValue(row, columns.isRead) {
+      isRead = readRaw != 0
+      if isRead == true {
+        let readRaw = try int64Value(row, columns.dateRead)
+        dateRead = readRaw.flatMap { $0 > 0 ? appleDate(from: $0) : nil }
+      }
+    }
+
     return DecodedMessageRow(
       rowID: rowID,
       chatID: resolvedChatID,
@@ -359,7 +369,9 @@ extension MessageStore {
       threadOriginatorPart: threadOriginatorPart,
       databaseReplyToGUID: databaseReplyToGUID,
       balloonBundleID: balloonBundleID,
-      poll: poll
+      poll: poll,
+      isRead: isRead,
+      dateRead: dateRead
     )
   }
 

--- a/Sources/IMsgCore/MessageStore.swift
+++ b/Sources/IMsgCore/MessageStore.swift
@@ -56,7 +56,9 @@ public final class MessageStore: @unchecked Sendable {
     hasChatMessageJoinMessageDateColumn: Bool? = nil,
     hasChatAccountIDColumn: Bool? = nil,
     hasChatAccountLoginColumn: Bool? = nil,
-    hasChatLastAddressedHandleColumn: Bool? = nil
+    hasChatLastAddressedHandleColumn: Bool? = nil,
+    hasIsReadColumn: Bool? = nil,
+    hasDateReadColumn: Bool? = nil
   ) throws {
     self.path = path
     self.queue = DispatchQueue(label: "imsg.db.test", qos: .userInitiated)
@@ -76,7 +78,9 @@ public final class MessageStore: @unchecked Sendable {
       hasChatMessageJoinMessageDateColumn: hasChatMessageJoinMessageDateColumn,
       hasChatAccountIDColumn: hasChatAccountIDColumn,
       hasChatAccountLoginColumn: hasChatAccountLoginColumn,
-      hasChatLastAddressedHandleColumn: hasChatLastAddressedHandleColumn
+      hasChatLastAddressedHandleColumn: hasChatLastAddressedHandleColumn,
+      hasIsReadColumn: hasIsReadColumn,
+      hasDateReadColumn: hasDateReadColumn
     )
   }
 

--- a/Sources/IMsgCore/MessageStoreSchema.swift
+++ b/Sources/IMsgCore/MessageStoreSchema.swift
@@ -16,6 +16,8 @@ struct MessageStoreSchema: Sendable {
   let hasChatAccountIDColumn: Bool
   let hasChatAccountLoginColumn: Bool
   let hasChatLastAddressedHandleColumn: Bool
+  let hasIsReadColumn: Bool
+  let hasDateReadColumn: Bool
 
   init(connection: Connection) {
     let messageColumns = MessageStore.tableColumns(connection: connection, table: "message")
@@ -41,6 +43,8 @@ struct MessageStoreSchema: Sendable {
     self.hasChatAccountIDColumn = chatColumns.contains("account_id")
     self.hasChatAccountLoginColumn = chatColumns.contains("account_login")
     self.hasChatLastAddressedHandleColumn = chatColumns.contains("last_addressed_handle")
+    self.hasIsReadColumn = messageColumns.contains("is_read")
+    self.hasDateReadColumn = messageColumns.contains("date_read")
   }
 
   init(
@@ -59,7 +63,9 @@ struct MessageStoreSchema: Sendable {
     hasChatMessageJoinMessageDateColumn: Bool? = nil,
     hasChatAccountIDColumn: Bool? = nil,
     hasChatAccountLoginColumn: Bool? = nil,
-    hasChatLastAddressedHandleColumn: Bool? = nil
+    hasChatLastAddressedHandleColumn: Bool? = nil,
+    hasIsReadColumn: Bool? = nil,
+    hasDateReadColumn: Bool? = nil
   ) {
     self.hasAttributedBody = hasAttributedBody ?? base.hasAttributedBody
     self.hasReactionColumns = hasReactionColumns ?? base.hasReactionColumns
@@ -81,5 +87,7 @@ struct MessageStoreSchema: Sendable {
     self.hasChatAccountLoginColumn = hasChatAccountLoginColumn ?? base.hasChatAccountLoginColumn
     self.hasChatLastAddressedHandleColumn =
       hasChatLastAddressedHandleColumn ?? base.hasChatLastAddressedHandleColumn
+    self.hasIsReadColumn = hasIsReadColumn ?? base.hasIsReadColumn
+    self.hasDateReadColumn = hasDateReadColumn ?? base.hasDateReadColumn
   }
 }

--- a/Sources/IMsgCore/Models.swift
+++ b/Sources/IMsgCore/Models.swift
@@ -193,6 +193,8 @@ public struct Chat: Sendable, Equatable {
   public let accountID: String?
   public let accountLogin: String?
   public let lastAddressedHandle: String?
+  /// Inbound unread row count, or nil when the database has no read state.
+  public let unreadCount: Int?
 
   public init(
     id: Int64,
@@ -202,7 +204,8 @@ public struct Chat: Sendable, Equatable {
     lastMessageAt: Date,
     accountID: String? = nil,
     accountLogin: String? = nil,
-    lastAddressedHandle: String? = nil
+    lastAddressedHandle: String? = nil,
+    unreadCount: Int? = nil
   ) {
     self.id = id
     self.identifier = identifier
@@ -212,6 +215,7 @@ public struct Chat: Sendable, Equatable {
     self.accountID = accountID
     self.accountLogin = accountLogin
     self.lastAddressedHandle = lastAddressedHandle
+    self.unreadCount = unreadCount
   }
 }
 
@@ -336,6 +340,10 @@ public struct Message: Sendable, Equatable {
   public let isReactionAdd: Bool?
   /// The GUID of the message being reacted to (only set when isReaction is true)
   public let reactedToGUID: String?
+  /// Local read state for inbound messages, when available.
+  public let isRead: Bool?
+  /// Local read timestamp for inbound messages, when available.
+  public let dateRead: Date?
 
   public init(
     rowID: Int64,
@@ -352,7 +360,9 @@ public struct Message: Sendable, Equatable {
     balloonBundleID: String? = nil,
     urlPreview: URLPreviewMetadata? = nil,
     reaction: ReactionMetadata = ReactionMetadata(),
-    poll: MessagePollEvent? = nil
+    poll: MessagePollEvent? = nil,
+    isRead: Bool? = nil,
+    dateRead: Date? = nil
   ) {
     self.rowID = rowID
     self.chatID = chatID
@@ -377,6 +387,8 @@ public struct Message: Sendable, Equatable {
     self.reactionType = reaction.reactionType
     self.isReactionAdd = reaction.isReactionAdd
     self.reactedToGUID = reaction.reactedToGUID
+    self.isRead = isRead
+    self.dateRead = dateRead
   }
 
   public init(
@@ -402,7 +414,9 @@ public struct Message: Sendable, Equatable {
     reactionType: ReactionType? = nil,
     isReactionAdd: Bool? = nil,
     reactedToGUID: String? = nil,
-    poll: MessagePollEvent? = nil
+    poll: MessagePollEvent? = nil,
+    isRead: Bool? = nil,
+    dateRead: Date? = nil
   ) {
     self.init(
       rowID: rowID,
@@ -431,10 +445,11 @@ public struct Message: Sendable, Equatable {
         isReactionAdd: isReactionAdd,
         reactedToGUID: reactedToGUID
       ),
-      poll: poll
+      poll: poll,
+      isRead: isRead,
+      dateRead: dateRead
     )
   }
-
 }
 
 public struct AttachmentMeta: Sendable, Equatable {

--- a/Sources/imsg/Commands/ChatsCommand.swift
+++ b/Sources/imsg/Commands/ChatsCommand.swift
@@ -11,12 +11,18 @@ enum ChatsCommand {
       CommandSignature(
         options: CommandSignatures.baseOptions() + [
           .make(label: "limit", names: [.long("limit")], help: "Number of chats to list")
+        ],
+        flags: [
+          .make(
+            label: "unread-only", names: [.long("unread-only")],
+            help: "Return only chats with unread inbound messages")
         ]
       )
     ),
     usageExamples: [
       "imsg chats --limit 5",
       "imsg chats --limit 5 --json",
+      "imsg chats --unread-only --json",
     ]
   ) { values, runtime in
     try await run(values: values, runtime: runtime)
@@ -31,8 +37,9 @@ enum ChatsCommand {
   ) async throws {
     let dbPath = values.option("db") ?? MessageStore.defaultPath
     let limit = values.optionInt("limit") ?? 20
+    let unreadOnly = values.flag("unread-only")
     let store = try MessageStore(path: dbPath)
-    let chats = try store.listChats(limit: limit)
+    let chats = try store.listChats(limit: limit, unreadOnly: unreadOnly)
     let contacts = await contactResolverFactory()
 
     if runtime.jsonOutput {

--- a/Sources/imsg/OutputModels.swift
+++ b/Sources/imsg/OutputModels.swift
@@ -15,6 +15,7 @@ struct ChatPayload: Codable {
   let accountID: String?
   let accountLogin: String?
   let lastAddressedHandle: String?
+  let unreadCount: Int?
 
   init(
     chat: Chat, chatInfo: ChatInfo? = nil, participants: [String]? = nil, contactName: String? = nil
@@ -34,6 +35,7 @@ struct ChatPayload: Codable {
     self.accountID = chatInfo?.accountID ?? chat.accountID
     self.accountLogin = chatInfo?.accountLogin ?? chat.accountLogin
     self.lastAddressedHandle = chatInfo?.lastAddressedHandle ?? chat.lastAddressedHandle
+    self.unreadCount = chat.unreadCount
   }
 
   enum CodingKeys: String, CodingKey {
@@ -50,6 +52,7 @@ struct ChatPayload: Codable {
     case accountID = "account_id"
     case accountLogin = "account_login"
     case lastAddressedHandle = "last_addressed_handle"
+    case unreadCount = "unread_count"
   }
 }
 
@@ -108,6 +111,8 @@ struct MessagePayload: Codable {
   let reactionEmoji: String?
   let isReactionAdd: Bool?
   let reactedToGUID: String?
+  let isRead: Bool?
+  let dateRead: String?
 
   init(
     message: Message,
@@ -137,6 +142,16 @@ struct MessagePayload: Codable {
     self.balloonBundleID = message.balloonBundleID
     self.urlPreview = message.urlPreview.map { URLPreviewPayload(preview: $0) }
     self.poll = message.poll
+    if message.isFromMe {
+      self.isRead = nil
+      self.dateRead = nil
+    } else {
+      self.isRead = message.isRead
+      self.dateRead =
+        message.isRead == true
+        ? message.dateRead.map { CLIISO8601.format($0) }
+        : nil
+    }
 
     // Reaction event metadata
     if message.isReaction {
@@ -179,6 +194,8 @@ struct MessagePayload: Codable {
     case reactionEmoji = "reaction_emoji"
     case isReactionAdd = "is_reaction_add"
     case reactedToGUID = "reacted_to_guid"
+    case isRead = "is_read"
+    case dateRead = "date_read"
   }
 }
 

--- a/Sources/imsg/RPCPayloads.swift
+++ b/Sources/imsg/RPCPayloads.swift
@@ -9,7 +9,8 @@ func chatPayload(
   service: String,
   lastMessageAt: Date,
   participants: [String],
-  contactName: String? = nil
+  contactName: String? = nil,
+  unreadCount: Int? = nil
 ) -> [String: Any] {
   var payload: [String: Any] = [
     "id": id,
@@ -21,6 +22,9 @@ func chatPayload(
     "participants": participants,
     "is_group": isGroupHandle(identifier: identifier, guid: guid),
   ]
+  if let unreadCount {
+    payload["unread_count"] = unreadCount
+  }
   if let contactName {
     payload["contact_name"] = contactName
   }

--- a/Sources/imsg/RPCServer+Handlers.swift
+++ b/Sources/imsg/RPCServer+Handlers.swift
@@ -18,7 +18,12 @@ private enum RPCSendTransport: String {
 extension RPCServer {
   func handleChatsList(id: Any?, params: [String: Any]) async throws {
     let limit = intParam(params["limit"]) ?? 20
-    let chats = try store.listChats(limit: max(limit, 1))
+    let unreadOnly = boolParam(params["unread_only"] ?? params["unreadOnly"]) ?? false
+    guard !unreadOnly || store.supportsUnreadState else {
+      throw RPCError.invalidParams(
+        "unread_only is unavailable because this Messages database has no read-state column")
+    }
+    let chats = try store.listChats(limit: max(limit, 1), unreadOnly: unreadOnly)
     var payloads: [[String: Any]] = []
     payloads.reserveCapacity(chats.count)
 
@@ -41,7 +46,8 @@ extension RPCServer {
           service: service,
           lastMessageAt: chat.lastMessageAt,
           participants: participants,
-          contactName: contactName
+          contactName: contactName,
+          unreadCount: chat.unreadCount
         ))
     }
 

--- a/Tests/IMsgCoreTests/MessageDatabaseFixture.swift
+++ b/Tests/IMsgCoreTests/MessageDatabaseFixture.swift
@@ -18,6 +18,7 @@ enum MessageDatabaseFixture {
     var includeChatMessageDate = false
     var includeChatRouting = true
     var includeChatHandleJoin = true
+    var includeReadState = false
   }
 
   static func createSchema(_ db: Connection, options: SchemaOptions = SchemaOptions()) throws {
@@ -37,6 +38,10 @@ enum MessageDatabaseFixture {
     let payloadDataColumn = options.includePayloadData ? "payload_data BLOB," : ""
     let summaryInfoColumn = options.includeMessageSummaryInfo ? "message_summary_info BLOB," : ""
     let replyToColumn = options.includeReplyToGUID ? "reply_to_guid TEXT," : ""
+    let readStateColumns =
+      options.includeReadState
+      ? "is_read INTEGER, date_read INTEGER,"
+      : ""
 
     try db.execute(
       """
@@ -54,6 +59,7 @@ enum MessageDatabaseFixture {
         \(payloadDataColumn)
         \(summaryInfoColumn)
         \(replyToColumn)
+        \(readStateColumns)
         date INTEGER,
         is_from_me INTEGER,
         service TEXT

--- a/Tests/IMsgCoreTests/MessageStoreURLPreviewTests.swift
+++ b/Tests/IMsgCoreTests/MessageStoreURLPreviewTests.swift
@@ -16,6 +16,7 @@ func makeURLPreviewTestDB() throws -> Connection {
       associated_message_guid TEXT,
       associated_message_type INTEGER,
       balloon_bundle_id TEXT,
+      is_read INTEGER, date_read INTEGER,
       date INTEGER,
       is_from_me INTEGER,
       service TEXT
@@ -40,15 +41,17 @@ func insertURLPreviewTestMessage(
   associatedMessageType: Int? = nil,
   balloonBundleID: String? = nil,
   date: Date,
-  isFromMe: Bool = false
+  isFromMe: Bool = false,
+  isRead: Bool = false,
+  dateRead: Date? = nil
 ) throws {
   try db.run(
     """
     INSERT INTO message(
       ROWID, handle_id, text, guid, associated_message_guid, associated_message_type,
-      balloon_bundle_id, date, is_from_me, service
+      balloon_bundle_id, is_read, date_read, date, is_from_me, service
     )
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'iMessage')
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'iMessage')
     """,
     rowID,
     handleID,
@@ -57,6 +60,8 @@ func insertURLPreviewTestMessage(
     associatedMessageGUID,
     associatedMessageType,
     balloonBundleID,
+    isRead ? 1 : 0,
+    dateRead.map(TestDatabase.appleEpoch) ?? 0,
     TestDatabase.appleEpoch(date),
     isFromMe ? 1 : 0
   )
@@ -105,13 +110,16 @@ func messagesAfterSkipsPreviewOnlyBatchForPublicCursorlessAPI() throws {
 func messagesByChatCoalescesURLPreviewSplitSend() throws {
   let db = try makeURLPreviewTestDB()
   let now = Date()
+  let readAt = Date(timeIntervalSince1970: 1_700_000_000)
   try db.run("INSERT INTO handle(ROWID, id) VALUES (1, '+123')")
   try insertURLPreviewTestMessage(
     db,
     rowID: 1,
     text: "Dump https://example.com",
     guid: "text-guid",
-    date: now
+    date: now,
+    isRead: true,
+    dateRead: readAt
   )
   try insertURLPreviewTestMessage(
     db,
@@ -132,6 +140,8 @@ func messagesByChatCoalescesURLPreviewSplitSend() throws {
   #expect(messages.first?.urlPreview?.rowID == 2)
   #expect(messages.first?.urlPreview?.guid == "preview-guid")
   #expect(messages.first?.urlPreview?.balloonBundleID == MessageStore.urlPreviewBalloonBundleID)
+  #expect(messages.first?.isRead == true)
+  #expect(messages.first?.dateRead == readAt)
 }
 
 @Test

--- a/Tests/IMsgCoreTests/MessageStoreUnreadStateTests.swift
+++ b/Tests/IMsgCoreTests/MessageStoreUnreadStateTests.swift
@@ -1,0 +1,405 @@
+import Foundation
+import SQLite
+import Testing
+
+@testable import IMsgCore
+
+@Test
+func listChatsCountsUnreadInboundMessages() throws {
+  let db = try Connection(.inMemory)
+  try MessageDatabaseFixture.createSchema(
+    db,
+    options: MessageDatabaseFixture.SchemaOptions(includeReadState: true)
+  )
+
+  let now = Date()
+  try db.run(
+    """
+    INSERT INTO chat(ROWID, chat_identifier, guid, display_name, service_name)
+    VALUES
+      (1, '+111', 'iMessage;-;+111', 'Unread Chat', 'iMessage'),
+      (2, '+222', 'iMessage;-;+222', 'Read Chat', 'iMessage')
+    """
+  )
+  try db.run("INSERT INTO handle(ROWID, id) VALUES (1, '+111'), (2, '+222')")
+  try db.run("INSERT INTO chat_handle_join(chat_id, handle_id) VALUES (1, 1), (2, 2)")
+
+  let unreadDate = TestDatabase.appleEpoch(now.addingTimeInterval(-100))
+  let readDate = TestDatabase.appleEpoch(now.addingTimeInterval(-50))
+  try db.run(
+    """
+    INSERT INTO message(
+      ROWID, handle_id, text, date, is_from_me, service, is_read, date_read
+    )
+    VALUES
+      (1, 1, 'unread one', ?, 0, 'iMessage', 0, 0),
+      (2, 1, 'unread two', ?, 0, 'iMessage', 0, 0),
+      (3, 1, 'read inbound', ?, 0, 'iMessage', 1, ?),
+      (4, 1, 'outbound', ?, 1, 'iMessage', 0, 0),
+      (5, 2, 'all read', ?, 0, 'iMessage', 1, ?)
+    """,
+    unreadDate,
+    unreadDate,
+    readDate,
+    readDate,
+    readDate,
+    readDate,
+    readDate
+  )
+  try db.run(
+    """
+    INSERT INTO chat_message_join(chat_id, message_id)
+    VALUES (1, 1), (1, 2), (1, 3), (1, 4), (2, 5)
+    """
+  )
+
+  let store = try MessageStore(connection: db, path: ":memory:")
+  let chats = try store.listChats(limit: 10)
+  #expect(chats.count == 2)
+  let unreadChat = chats.first { $0.identifier == "+111" }
+  let readChat = chats.first { $0.identifier == "+222" }
+  #expect(unreadChat?.unreadCount == 2)
+  #expect(readChat?.unreadCount == 0)
+}
+
+@Test
+func listChatsCountsSplitURLPreviewAsOneUnreadMessage() throws {
+  let db = try Connection(.inMemory)
+  try MessageDatabaseFixture.createSchema(
+    db,
+    options: MessageDatabaseFixture.SchemaOptions(
+      includeReactionColumns: true,
+      includeBalloonBundleID: true,
+      includeReadState: true
+    )
+  )
+  let now = Date()
+  try db.run(
+    """
+    INSERT INTO chat(ROWID, chat_identifier, guid, display_name, service_name)
+    VALUES (1, '+111', 'iMessage;-;+111', 'Links', 'iMessage')
+    """
+  )
+  try db.run("INSERT INTO handle(ROWID, id) VALUES (1, '+111')")
+  try db.run(
+    """
+    INSERT INTO message(
+      ROWID, handle_id, text, guid, associated_message_guid, associated_message_type,
+      balloon_bundle_id, date, is_from_me, service, is_read, date_read
+    )
+    VALUES
+      (1, 1, 'See https://example.com', 'text-guid', NULL, NULL, NULL, ?, 0, 'iMessage', 0, 0),
+      (2, 1, 'https://example.com', 'preview-guid', NULL, NULL, ?, ?, 0, 'iMessage', 0, 0)
+    """,
+    TestDatabase.appleEpoch(now),
+    MessageStore.urlPreviewBalloonBundleID,
+    TestDatabase.appleEpoch(now.addingTimeInterval(1))
+  )
+  try db.run("INSERT INTO chat_message_join(chat_id, message_id) VALUES (1, 1), (1, 2)")
+
+  let store = try MessageStore(connection: db, path: ":memory:")
+  #expect(try store.listChats(limit: 1).first?.unreadCount == 1)
+  #expect(try store.listChats(limit: 1, unreadOnly: true).first?.unreadCount == 1)
+}
+
+@Test
+func listChatsUsesTextRowReadStateForSplitURLPreview() throws {
+  let db = try Connection(.inMemory)
+  try MessageDatabaseFixture.createSchema(
+    db,
+    options: MessageDatabaseFixture.SchemaOptions(
+      includeReactionColumns: true,
+      includeBalloonBundleID: true,
+      includeReadState: true
+    )
+  )
+  let now = Date()
+  try db.run(
+    """
+    INSERT INTO chat(ROWID, chat_identifier, guid, display_name, service_name)
+    VALUES (1, '+111', 'iMessage;-;+111', 'Links', 'iMessage')
+    """
+  )
+  try db.run("INSERT INTO handle(ROWID, id) VALUES (1, '+111')")
+  try db.run(
+    """
+    INSERT INTO message(
+      ROWID, handle_id, text, guid, associated_message_guid, associated_message_type,
+      balloon_bundle_id, date, is_from_me, service, is_read, date_read
+    )
+    VALUES
+      (1, 1, 'See https://example.com', 'text-guid', NULL, NULL, NULL, ?, 0, 'iMessage', 1, ?),
+      (2, 1, 'https://example.com', 'preview-guid', NULL, NULL, ?, ?, 0, 'iMessage', 0, 0)
+    """,
+    TestDatabase.appleEpoch(now),
+    TestDatabase.appleEpoch(now),
+    MessageStore.urlPreviewBalloonBundleID,
+    TestDatabase.appleEpoch(now.addingTimeInterval(1))
+  )
+  try db.run("INSERT INTO chat_message_join(chat_id, message_id) VALUES (1, 1), (1, 2)")
+
+  let store = try MessageStore(connection: db, path: ":memory:")
+  #expect(try store.listChats(limit: 1).first?.unreadCount == 0)
+  #expect(try store.listChats(limit: 1, unreadOnly: true).isEmpty)
+}
+
+@Test
+func listChatsDoesNotCoalesceURLPreviewAcrossInterveningMessage() throws {
+  let db = try Connection(.inMemory)
+  try MessageDatabaseFixture.createSchema(
+    db,
+    options: MessageDatabaseFixture.SchemaOptions(
+      includeReactionColumns: true,
+      includeBalloonBundleID: true,
+      includeReadState: true
+    )
+  )
+  let now = Date()
+  try db.run(
+    """
+    INSERT INTO chat(ROWID, chat_identifier, guid, display_name, service_name)
+    VALUES (1, '+111', 'iMessage;-;+111', 'Links', 'iMessage')
+    """
+  )
+  try db.run("INSERT INTO handle(ROWID, id) VALUES (1, '+111')")
+  try db.run(
+    """
+    INSERT INTO message(
+      ROWID, handle_id, text, guid, associated_message_guid, associated_message_type,
+      balloon_bundle_id, date, is_from_me, service, is_read, date_read
+    )
+    VALUES
+      (1, 1, 'See https://example.com', 'text-guid', NULL, NULL, NULL, ?, 0, 'iMessage', 0, 0),
+      (2, 1, 'intervening', 'middle-guid', NULL, NULL, NULL, ?, 0, 'iMessage', 1, ?),
+      (3, 1, 'https://example.com', 'preview-guid', NULL, NULL, ?, ?, 0, 'iMessage', 0, 0)
+    """,
+    TestDatabase.appleEpoch(now),
+    TestDatabase.appleEpoch(now.addingTimeInterval(1)),
+    TestDatabase.appleEpoch(now.addingTimeInterval(1)),
+    MessageStore.urlPreviewBalloonBundleID,
+    TestDatabase.appleEpoch(now.addingTimeInterval(2))
+  )
+  try db.run(
+    "INSERT INTO chat_message_join(chat_id, message_id) VALUES (1, 1), (1, 2), (1, 3)"
+  )
+
+  let store = try MessageStore(connection: db, path: ":memory:")
+  #expect(try store.listChats(limit: 1).first?.unreadCount == 2)
+}
+
+@Test
+func listChatsUnreadOnlyContinuesPastFalseURLPreviewCandidate() throws {
+  let db = try Connection(.inMemory)
+  try MessageDatabaseFixture.createSchema(
+    db,
+    options: MessageDatabaseFixture.SchemaOptions(
+      includeReactionColumns: true,
+      includeBalloonBundleID: true,
+      includeReadState: true
+    )
+  )
+  let now = Date()
+  try db.run(
+    """
+    INSERT INTO chat(ROWID, chat_identifier, guid, display_name, service_name)
+    VALUES
+      (1, '+111', 'iMessage;-;+111', 'Older Unread', 'iMessage'),
+      (2, '+222', 'iMessage;-;+222', 'Newer Read Link', 'iMessage')
+    """
+  )
+  try db.run("INSERT INTO handle(ROWID, id) VALUES (1, '+111'), (2, '+222')")
+  try db.run(
+    """
+    INSERT INTO message(
+      ROWID, handle_id, text, guid, balloon_bundle_id, date, is_from_me, service,
+      is_read, date_read
+    )
+    VALUES
+      (1, 1, 'actually unread', 'unread-guid', NULL, ?, 0, 'iMessage', 0, 0),
+      (2, 2, 'See https://example.com', 'text-guid', NULL, ?, 0, 'iMessage', 1, ?),
+      (3, 2, 'https://example.com', 'preview-guid', ?, ?, 0, 'iMessage', 0, 0)
+    """,
+    TestDatabase.appleEpoch(now.addingTimeInterval(-60)),
+    TestDatabase.appleEpoch(now),
+    TestDatabase.appleEpoch(now),
+    MessageStore.urlPreviewBalloonBundleID,
+    TestDatabase.appleEpoch(now.addingTimeInterval(1))
+  )
+  try db.run(
+    "INSERT INTO chat_message_join(chat_id, message_id) VALUES (1, 1), (2, 2), (2, 3)"
+  )
+
+  let store = try MessageStore(connection: db, path: ":memory:")
+  let chats = try store.listChats(limit: 1, unreadOnly: true)
+  #expect(chats.map(\.id) == [1])
+  #expect(chats.first?.unreadCount == 1)
+}
+
+@Test
+func listChatsUnreadOnlyFiltersChatsWithUnreadInboundMessages() throws {
+  let db = try Connection(.inMemory)
+  try MessageDatabaseFixture.createSchema(
+    db,
+    options: MessageDatabaseFixture.SchemaOptions(includeReadState: true)
+  )
+
+  let now = Date()
+  try db.run(
+    """
+    INSERT INTO chat(ROWID, chat_identifier, guid, display_name, service_name)
+    VALUES
+      (1, '+111', 'iMessage;-;+111', 'Unread Chat', 'iMessage'),
+      (2, '+222', 'iMessage;-;+222', 'Read Chat', 'iMessage')
+    """
+  )
+  try db.run("INSERT INTO handle(ROWID, id) VALUES (1, '+111'), (2, '+222')")
+  try db.run("INSERT INTO chat_handle_join(chat_id, handle_id) VALUES (1, 1), (2, 2)")
+  try db.run(
+    """
+    INSERT INTO message(ROWID, handle_id, text, date, is_from_me, service, is_read, date_read)
+    VALUES
+      (1, 1, 'unread', ?, 0, 'iMessage', 0, 0),
+      (2, 2, 'read', ?, 0, 'iMessage', 1, ?)
+    """,
+    TestDatabase.appleEpoch(now),
+    TestDatabase.appleEpoch(now),
+    TestDatabase.appleEpoch(now)
+  )
+  try db.run("INSERT INTO chat_message_join(chat_id, message_id) VALUES (1, 1), (2, 2)")
+
+  let store = try MessageStore(connection: db, path: ":memory:")
+  let chats = try store.listChats(limit: 10, unreadOnly: true)
+  #expect(chats.count == 1)
+  #expect(chats.first?.identifier == "+111")
+  #expect(chats.first?.unreadCount == 1)
+}
+
+@Test
+func listChatsUnreadOnlyFiltersBeforeApplyingLimit() throws {
+  let db = try Connection(.inMemory)
+  try MessageDatabaseFixture.createSchema(
+    db,
+    options: MessageDatabaseFixture.SchemaOptions(includeReadState: true)
+  )
+
+  let now = Date()
+  try db.run(
+    """
+    INSERT INTO chat(ROWID, chat_identifier, guid, display_name, service_name)
+    VALUES
+      (1, '+111', 'iMessage;-;+111', 'Older Unread', 'iMessage'),
+      (2, '+222', 'iMessage;-;+222', 'Newer Read', 'iMessage')
+    """
+  )
+  try db.run("INSERT INTO handle(ROWID, id) VALUES (1, '+111'), (2, '+222')")
+  try db.run(
+    """
+    INSERT INTO message(ROWID, handle_id, text, date, is_from_me, service, is_read, date_read)
+    VALUES
+      (1, 1, 'unread', ?, 0, 'iMessage', 0, 0),
+      (2, 2, 'read', ?, 0, 'iMessage', 1, ?)
+    """,
+    TestDatabase.appleEpoch(now.addingTimeInterval(-60)),
+    TestDatabase.appleEpoch(now),
+    TestDatabase.appleEpoch(now)
+  )
+  try db.run("INSERT INTO chat_message_join(chat_id, message_id) VALUES (1, 1), (2, 2)")
+
+  let store = try MessageStore(connection: db, path: ":memory:")
+  let chats = try store.listChats(limit: 1, unreadOnly: true)
+  #expect(chats.map(\.id) == [1])
+}
+
+@Test
+func listChatsOmitsUnreadStateWhenSchemaDoesNotSupportIt() throws {
+  let db = try Connection(.inMemory)
+  try MessageDatabaseFixture.createSchema(db)
+  try db.run(
+    """
+    INSERT INTO chat(ROWID, chat_identifier, guid, display_name, service_name)
+    VALUES (1, '+111', 'iMessage;-;+111', 'Legacy Chat', 'iMessage')
+    """
+  )
+  try db.run(
+    """
+    INSERT INTO message(ROWID, handle_id, text, date, is_from_me, service)
+    VALUES (1, NULL, 'hello', 1, 0, 'iMessage')
+    """
+  )
+  try db.run("INSERT INTO chat_message_join(chat_id, message_id) VALUES (1, 1)")
+
+  let store = try MessageStore(connection: db, path: ":memory:")
+  #expect(store.supportsUnreadState == false)
+  #expect(try store.listChats(limit: 1).first?.unreadCount == nil)
+  #expect(throws: (any Error).self) {
+    try store.listChats(limit: 1, unreadOnly: true)
+  }
+}
+
+@Test
+func messagesExposeInboundReadState() throws {
+  let db = try Connection(.inMemory)
+  try MessageDatabaseFixture.createSchema(
+    db,
+    options: MessageDatabaseFixture.SchemaOptions(includeReadState: true)
+  )
+
+  let now = Date()
+  let readAt = Date(timeIntervalSince1970: 1_700_000_000)
+  try db.run(
+    """
+    INSERT INTO chat(ROWID, chat_identifier, guid, display_name, service_name)
+    VALUES (1, '+123', 'iMessage;-;+123', 'Test Chat', 'iMessage')
+    """
+  )
+  try db.run("INSERT INTO handle(ROWID, id) VALUES (1, '+123'), (2, 'Me')")
+  try db.run("INSERT INTO chat_handle_join(chat_id, handle_id) VALUES (1, 1), (1, 2)")
+  try db.run(
+    """
+    INSERT INTO message(ROWID, handle_id, text, date, is_from_me, service, is_read, date_read)
+    VALUES
+      (1, 1, 'unread inbound', ?, 0, 'iMessage', 0, 0),
+      (2, 1, 'read inbound', ?, 0, 'iMessage', 1, ?),
+      (3, 2, 'outbound', ?, 1, 'iMessage', 0, 0)
+    """,
+    TestDatabase.appleEpoch(now),
+    TestDatabase.appleEpoch(now),
+    TestDatabase.appleEpoch(readAt),
+    TestDatabase.appleEpoch(now)
+  )
+  try db.run("INSERT INTO chat_message_join(chat_id, message_id) VALUES (1, 1), (1, 2), (1, 3)")
+
+  let store = try MessageStore(connection: db, path: ":memory:")
+  let messages = try store.messages(chatID: 1, limit: 10)
+  #expect(messages.count == 3)
+
+  let unread = messages.first { $0.rowID == 1 }
+  let read = messages.first { $0.rowID == 2 }
+  let outbound = messages.first { $0.rowID == 3 }
+  #expect(unread?.isRead == false)
+  #expect(unread?.dateRead == nil)
+  #expect(read?.isRead == true)
+  #expect(read?.dateRead == readAt)
+  #expect(outbound?.isRead == nil)
+  #expect(outbound?.dateRead == nil)
+}
+
+@Test
+func messagesExposeReadFlagWhenDateReadColumnIsUnavailable() throws {
+  let db = try Connection(.inMemory)
+  try MessageDatabaseFixture.createSchema(db)
+  try db.execute("ALTER TABLE message ADD COLUMN is_read INTEGER;")
+  try db.run("INSERT INTO handle(ROWID, id) VALUES (1, '+123')")
+  try db.run(
+    """
+    INSERT INTO message(ROWID, handle_id, text, date, is_from_me, service, is_read)
+    VALUES (1, 1, 'read inbound', 1, 0, 'iMessage', 1)
+    """
+  )
+  try db.run("INSERT INTO chat_message_join(chat_id, message_id) VALUES (1, 1)")
+
+  let store = try MessageStore(connection: db, path: ":memory:")
+  let message = try #require(store.messages(chatID: 1, limit: 1).first)
+  #expect(message.isRead == true)
+  #expect(message.dateRead == nil)
+}

--- a/Tests/imsgTests/ChatsCommandTests.swift
+++ b/Tests/imsgTests/ChatsCommandTests.swift
@@ -1,0 +1,42 @@
+import Foundation
+import Testing
+
+@testable import imsg
+
+@Test
+func chatsUnreadOnlyFlagFiltersToUnreadChats() async throws {
+  let dbPath = try UnreadStateCommandTestDatabase.makePath()
+  let router = CommandRouter()
+
+  let (allOutput, _) = await StdoutCapture.capture {
+    await router.run(argv: ["imsg", "chats", "--db", dbPath, "--json"])
+  }
+  let allChats = allOutput.split(separator: "\n").map { line in
+    try! JSONSerialization.jsonObject(with: Data(line.utf8)) as! [String: Any]
+  }
+  #expect(allChats.count == 2)
+
+  let (unreadOutput, status) = await StdoutCapture.capture {
+    await router.run(argv: ["imsg", "chats", "--db", dbPath, "--unread-only", "--json"])
+  }
+  #expect(status == 0)
+  let unreadChats = unreadOutput.split(separator: "\n").map { line in
+    try! JSONSerialization.jsonObject(with: Data(line.utf8)) as! [String: Any]
+  }
+  #expect(unreadChats.count == 1)
+  #expect(unreadChats.first?["id"] as? Int == 1)
+  #expect(unreadChats.first?["unread_count"] as? Int == 1)
+}
+
+@Test
+func chatsUnreadOnlyRejectsDatabaseWithoutReadState() async throws {
+  let dbPath = try CommandTestDatabase.makePath()
+  let router = CommandRouter()
+
+  let (output, status) = await StdoutCapture.capture {
+    await router.run(argv: ["imsg", "chats", "--db", dbPath, "--unread-only", "--json"])
+  }
+
+  #expect(status == 1)
+  #expect(output.contains("Unread filtering is unavailable"))
+}

--- a/Tests/imsgTests/UnreadStateCommandTestDatabase.swift
+++ b/Tests/imsgTests/UnreadStateCommandTestDatabase.swift
@@ -1,0 +1,125 @@
+import Foundation
+import SQLite
+
+@testable import IMsgCore
+
+enum UnreadStateCommandTestDatabase {
+  static func makePath() throws -> String {
+    let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    let path = directory.appendingPathComponent("chat.db").path
+    let db = try Connection(path)
+    try createSchema(db)
+    try seedChats(db)
+    return path
+  }
+
+  static func makeStoreForRPC() throws -> MessageStore {
+    let db = try Connection(.inMemory)
+    try createSchema(db)
+    try seedRPCChat(db)
+    return try MessageStore(connection: db, path: ":memory:")
+  }
+
+  private static func createSchema(_ db: Connection) throws {
+    try db.execute(
+      """
+      CREATE TABLE message (
+        ROWID INTEGER PRIMARY KEY,
+        handle_id INTEGER,
+        text TEXT,
+        is_read INTEGER,
+        date_read INTEGER,
+        date INTEGER,
+        is_from_me INTEGER,
+        service TEXT
+      );
+      CREATE TABLE chat (
+        ROWID INTEGER PRIMARY KEY,
+        chat_identifier TEXT,
+        guid TEXT,
+        display_name TEXT,
+        service_name TEXT,
+        account_id TEXT,
+        account_login TEXT,
+        last_addressed_handle TEXT
+      );
+      CREATE TABLE handle (ROWID INTEGER PRIMARY KEY, id TEXT);
+      CREATE TABLE chat_handle_join (chat_id INTEGER, handle_id INTEGER);
+      CREATE TABLE chat_message_join (chat_id INTEGER, message_id INTEGER);
+      CREATE TABLE message_attachment_join (message_id INTEGER, attachment_id INTEGER);
+      CREATE TABLE attachment (
+        ROWID INTEGER PRIMARY KEY,
+        filename TEXT,
+        transfer_name TEXT,
+        uti TEXT,
+        mime_type TEXT,
+        total_bytes INTEGER,
+        is_sticker INTEGER
+      );
+      """
+    )
+  }
+
+  private static func seedRPCChat(_ db: Connection) throws {
+    let now = Date()
+    let readAt = Date(timeIntervalSince1970: 1_700_000_000)
+    try db.run(
+      """
+      INSERT INTO chat(
+        ROWID, chat_identifier, guid, display_name, service_name,
+        account_id, account_login, last_addressed_handle
+      )
+      VALUES (
+        1, 'iMessage;+;chat123', 'iMessage;+;chat123', 'Group Chat', 'iMessage',
+        'iMessage;+;me@icloud.com', 'me@icloud.com', 'me@icloud.com'
+      )
+      """
+    )
+    try db.run("INSERT INTO handle(ROWID, id) VALUES (1, '+123'), (2, 'me@icloud.com')")
+    try db.run("INSERT INTO chat_handle_join(chat_id, handle_id) VALUES (1, 1), (1, 2)")
+    try db.run(
+      """
+      INSERT INTO message(ROWID, handle_id, text, date, is_from_me, service, is_read, date_read)
+      VALUES
+        (5, 1, 'unread', ?, 0, 'iMessage', 0, 0),
+        (6, 1, 'read', ?, 0, 'iMessage', 1, ?)
+      """,
+      CommandTestDatabase.appleEpoch(now),
+      CommandTestDatabase.appleEpoch(now),
+      CommandTestDatabase.appleEpoch(readAt)
+    )
+    try db.run("INSERT INTO chat_message_join(chat_id, message_id) VALUES (1, 5), (1, 6)")
+  }
+
+  private static func seedChats(_ db: Connection) throws {
+    let now = Date()
+    try db.run(
+      """
+      INSERT INTO chat(
+        ROWID, chat_identifier, guid, display_name, service_name,
+        account_id, account_login, last_addressed_handle
+      )
+      VALUES
+        (1, 'iMessage;-;+123', 'iMessage;-;+123', '', 'iMessage',
+         'iMessage;-;me@icloud.com', 'me@icloud.com', 'me@icloud.com'),
+        (2, 'iMessage;-;+456', 'iMessage;-;+456', '', 'iMessage',
+         'iMessage;-;me@icloud.com', 'me@icloud.com', 'me@icloud.com')
+      """
+    )
+    try db.run("INSERT INTO handle(ROWID, id) VALUES (1, '+123'), (2, '+456')")
+    try db.run("INSERT INTO chat_handle_join(chat_id, handle_id) VALUES (1, 1), (2, 2)")
+    try db.run(
+      """
+      INSERT INTO message(ROWID, handle_id, text, date, is_from_me, service, is_read, date_read)
+      VALUES
+        (5, 1, 'unread', ?, 0, 'iMessage', 0, 0),
+        (6, 2, 'read', ?, 0, 'iMessage', 1, ?)
+      """,
+      CommandTestDatabase.appleEpoch(now),
+      CommandTestDatabase.appleEpoch(now),
+      CommandTestDatabase.appleEpoch(now)
+    )
+    try db.run("INSERT INTO chat_message_join(chat_id, message_id) VALUES (1, 5), (2, 6)")
+  }
+}

--- a/Tests/imsgTests/UnreadStatePayloadTests.swift
+++ b/Tests/imsgTests/UnreadStatePayloadTests.swift
@@ -1,0 +1,164 @@
+import Foundation
+import Testing
+
+@testable import IMsgCore
+@testable import imsg
+
+@Test
+func chatPayloadIncludesUnreadCount() throws {
+  let chat = Chat(
+    id: 1,
+    identifier: "+123",
+    name: "Test",
+    service: "iMessage",
+    lastMessageAt: Date(timeIntervalSince1970: 0),
+    unreadCount: 3
+  )
+  let payload = ChatPayload(chat: chat)
+  let data = try JSONEncoder().encode(payload)
+  let object = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+  #expect(object?["unread_count"] as? Int == 3)
+}
+
+@Test
+func chatPayloadOmitsUnsupportedUnreadCount() throws {
+  let chat = Chat(
+    id: 1,
+    identifier: "+123",
+    name: "Test",
+    service: "iMessage",
+    lastMessageAt: Date(timeIntervalSince1970: 0)
+  )
+  let object =
+    try JSONSerialization.jsonObject(
+      with: JSONEncoder().encode(ChatPayload(chat: chat))
+    ) as? [String: Any]
+  #expect(object?["unread_count"] == nil)
+}
+
+@Test
+func messagePayloadIncludesInboundReadState() throws {
+  let readAt = Date(timeIntervalSince1970: 1_700_000_000)
+  let unreadMessage = Message(
+    rowID: 1,
+    chatID: 1,
+    sender: "+123",
+    text: "unread",
+    date: Date(timeIntervalSince1970: 1),
+    isFromMe: false,
+    service: "iMessage",
+    handleID: 1,
+    attachmentsCount: 0,
+    isRead: false
+  )
+  let readMessage = Message(
+    rowID: 2,
+    chatID: 1,
+    sender: "+123",
+    text: "read",
+    date: Date(timeIntervalSince1970: 2),
+    isFromMe: false,
+    service: "iMessage",
+    handleID: 1,
+    attachmentsCount: 0,
+    isRead: true,
+    dateRead: readAt
+  )
+  let outboundMessage = Message(
+    rowID: 3,
+    chatID: 1,
+    sender: "me@icloud.com",
+    text: "sent",
+    date: Date(timeIntervalSince1970: 3),
+    isFromMe: true,
+    service: "iMessage",
+    handleID: 2,
+    attachmentsCount: 0,
+    isRead: false
+  )
+
+  let unreadPayload = MessagePayload(message: unreadMessage, attachments: [])
+  let readPayload = MessagePayload(message: readMessage, attachments: [])
+  let outboundPayload = MessagePayload(message: outboundMessage, attachments: [])
+
+  let unreadObject =
+    try JSONSerialization.jsonObject(
+      with: try JSONEncoder().encode(unreadPayload)
+    ) as? [String: Any]
+  let readObject =
+    try JSONSerialization.jsonObject(
+      with: try JSONEncoder().encode(readPayload)
+    ) as? [String: Any]
+  let outboundObject =
+    try JSONSerialization.jsonObject(
+      with: try JSONEncoder().encode(outboundPayload)
+    ) as? [String: Any]
+
+  #expect(unreadObject?["is_read"] as? Bool == false)
+  #expect(unreadObject?["date_read"] == nil)
+  #expect(readObject?["is_read"] as? Bool == true)
+  #expect(readObject?["date_read"] as? String != nil)
+  #expect(outboundObject?["is_read"] == nil)
+  #expect(outboundObject?["date_read"] == nil)
+}
+
+@Test
+func rpcChatsListSupportsUnreadOnlyAndUnreadCount() async throws {
+  let store = try UnreadStateCommandTestDatabase.makeStoreForRPC()
+  let output = TestRPCOutput()
+  let server = RPCServer(store: store, verbose: false, output: output)
+
+  let line =
+    #"{"jsonrpc":"2.0","id":"1","method":"chats.list","params":{"limit":10,"unread_only":true}}"#
+  await server.handleLineForTesting(line)
+
+  let result = output.responses[0]["result"] as? [String: Any]
+  let chats = result?["chats"] as? [[String: Any]] ?? []
+  #expect(chats.count == 1)
+  #expect(chats[0]["unread_count"] as? Int == 1)
+
+  let camelLine =
+    #"{"jsonrpc":"2.0","id":"2","method":"chats.list","params":{"limit":10,"unreadOnly":true}}"#
+  await server.handleLineForTesting(camelLine)
+  #expect(output.responses.count == 2)
+  let camelResult = output.responses.last?["result"] as? [String: Any]
+  let camelChats = camelResult?["chats"] as? [[String: Any]] ?? []
+  #expect(camelChats.count == 1)
+  #expect(camelChats[0]["unread_count"] as? Int == 1)
+}
+
+@Test
+func rpcChatsListRejectsUnreadFilterWhenSchemaLacksReadState() async throws {
+  let store = try CommandTestDatabase.makeStoreForRPC()
+  let output = TestRPCOutput()
+  let server = RPCServer(store: store, verbose: false, output: output)
+
+  let line =
+    #"{"jsonrpc":"2.0","id":"1","method":"chats.list","params":{"unread_only":true}}"#
+  await server.handleLineForTesting(line)
+
+  #expect(output.errors.count == 1)
+  let error = output.errors.first?["error"] as? [String: Any]
+  #expect(error?["code"] as? Int == -32602)
+}
+
+@Test
+func rpcMessagesHistoryIncludesInboundReadState() async throws {
+  let store = try UnreadStateCommandTestDatabase.makeStoreForRPC()
+  let output = TestRPCOutput()
+  let server = RPCServer(store: store, verbose: false, output: output)
+
+  let line =
+    #"{"jsonrpc":"2.0","id":2,"method":"messages.history","params":{"chat_id":1,"limit":5}}"#
+  await server.handleLineForTesting(line)
+
+  let result = output.responses.first?["result"] as? [String: Any]
+  let messages = result?["messages"] as? [[String: Any]] ?? []
+  #expect(messages.count == 2)
+  let unread = messages.first { ($0["text"] as? String) == "unread" }
+  let read = messages.first { ($0["text"] as? String) == "read" }
+  #expect(unread?["is_read"] as? Bool == false)
+  #expect(unread?["date_read"] == nil)
+  #expect(read?["is_read"] as? Bool == true)
+  #expect(read?["date_read"] as? String != nil)
+}

--- a/docs/chats.md
+++ b/docs/chats.md
@@ -27,9 +27,9 @@ Use this before scripting a send. It returns identifier, GUID, service, particip
 
 `imsg group` works for direct chats too, despite the name. Treat it as "chat detail," not "groups only."
 
-## Chat object
+## Chat list object
 
-Every chat object — from `chats`, `group`, or any nested chat metadata in `history`/`watch` — includes:
+Objects returned by `imsg chats --json` and JSON-RPC `chats.list` include:
 
 | Field | Type | Notes |
 |-------|------|-------|
@@ -46,6 +46,7 @@ Every chat object — from `chats`, `group`, or any nested chat metadata in `his
 | `account_id` | string | Routing diagnostic. Read-only. |
 | `account_login` | string | Routing diagnostic. Read-only. |
 | `last_addressed_handle` | string | Routing diagnostic. Read-only. |
+| `unread_count` | int | Count of unread inbound messages in the chat. Omitted on older database schemas without read state. |
 
 ## Routing identifiers — which one to use
 
@@ -70,7 +71,15 @@ To distinguish your own messages from others':
 
 ## Filtering tips
 
-`imsg chats` does not take filter flags — it's designed to be cheap. Pipe through `jq` or `grep` for ad-hoc filtering:
+`imsg chats` takes one filter flag, `--unread-only`, which returns only chats with unread inbound messages:
+
+```bash
+imsg chats --unread-only --json
+```
+
+On an older Messages database without a read-state column, `--unread-only` fails clearly instead of reporting an empty inbox.
+
+For anything else, pipe through `jq` or `grep` for ad-hoc filtering:
 
 ```bash
 imsg chats --json | jq -s 'map(select(.is_group == true))'

--- a/docs/json.md
+++ b/docs/json.md
@@ -13,9 +13,9 @@ imsg watch --chat-id 42 --json
 
 Human progress, prompts, and warnings are written to **stderr**, not stdout. Stdout is reserved for parseable JSON so pipelines stay clean.
 
-## Chat
+## Chat list item
 
-Returned by `imsg chats`, `imsg group`, and embedded in nested chat references in messages.
+Returned by `imsg chats --json` and JSON-RPC `chats.list`.
 
 | Field | Type | Notes |
 |-------|------|-------|
@@ -32,10 +32,11 @@ Returned by `imsg chats`, `imsg group`, and embedded in nested chat references i
 | `account_id` | string | Routing diagnostic. Read-only. |
 | `account_login` | string | Routing diagnostic. Read-only. |
 | `last_addressed_handle` | string | Routing diagnostic. Read-only. |
+| `unread_count` | int | Count of unread inbound messages in the chat. Omitted on older database schemas without read state. |
 
 ## Message
 
-Returned by `imsg history`, `imsg watch`, and the JSON-RPC `messages.history` and `watch.subscribe` notifications.
+Returned by `imsg history`, `imsg search`, `imsg watch`, and the JSON-RPC `messages.history` and `watch.subscribe` notifications.
 
 | Field | Type | Notes |
 |-------|------|-------|
@@ -59,6 +60,10 @@ Returned by `imsg history`, `imsg watch`, and the JSON-RPC `messages.history` an
 | `attachments` | array | Present when `--attachments` is set. See below. |
 | `thread_originator_guid` | string | For inline-reply threads. |
 | `poll` | object | Present for native Apple Messages Polls creation and vote rows. See below. |
+| `is_read` | bool | Inbound only — omitted when `is_from_me` is true. |
+| `date_read` | ISO8601 | Inbound only — present when `is_read` is true. |
+
+Read state is a database snapshot. A watch notification includes the state present when that message row is emitted; reading it later does not generate a second message notification.
 
 ### URL preview coalescing
 

--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -29,6 +29,7 @@ The pattern intentionally mirrors language servers and the way `imsg`'s parent g
 Params:
 
 - `limit` (int, default 20)
+- `unread_only` (bool, default `false`) — when true, return only chats with `unread_count > 0`; unavailable database schemas return an invalid-params error rather than an empty list
 
 Result:
 
@@ -230,7 +231,7 @@ Response:
 
 ### Chat
 
-See [JSON output → Chat](json.md#chat). Every field documented there appears in the RPC `chats.list` response.
+See [JSON output → Chat list item](json.md#chat-list-item). Every field documented there appears in the RPC `chats.list` response.
 
 ### Message
 


### PR DESCRIPTION
## Summary

- expose optional inbound `is_read` / `date_read` fields in history and RPC payloads
- expose schema-aware per-chat `unread_count` plus CLI/RPC unread-only filtering
- count logical messages correctly across split URL previews and preserve outbound/legacy omission semantics
- document the additive API and CLI behavior

This is a maintainer rewrite of #160 because that fork does not allow maintainer edits. Thanks @chiedo for proposing and iterating on the feature; the landed commit retains contributor credit.

## Improvements over the proposal

- probes `is_read` and `date_read` independently instead of assuming one schema shape
- omits unsupported/read-irrelevant fields rather than fabricating zero values
- filters before the caller's logical limit while paginating past false URL-preview candidates
- resolves split previews against their actual predecessor and uses the originating text row's read state
- preserves read state during URL-preview coalescing
- covers CLI parsing, snake/camel RPC inputs, schema fallback, payload omission, pagination, and rich-link edge cases

## Proof

- `DEVELOPER_DIR=/Applications/Xcode-26.6.app/Contents/Developer make test` — 392 tests passed
- `DEVELOPER_DIR=/Applications/Xcode-26.6.app/Contents/Developer make lint` — 0 serious violations; 9 pre-existing warnings
- `DEVELOPER_DIR=/Applications/Xcode-26.6.app/Contents/Developer make build` — universal CLI (`arm64`, `x86_64`) and helper (`arm64e`, `arm64`, `x86_64`)
- AutoReview — clean after fixing one accepted URL-preview read-state finding
- exact candidate SHA-256: `2b158ecb12cac94e142c671af3d039fe4dc1b03f271f0a17ea898418f64a8990`
- exact candidate live-tested against a macOS 26 Messages database through both CLI and RPC: numeric counts, positive-only unread filtering, inbound read timestamps, and outbound omission all verified
