### PR TITLE
fix: isolate universal build products

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - feat: expose per-chat unread counts and inbound message read timestamps across JSON, JSON-RPC, search, history, and watch, with an unread-only chat filter (#160, #170, thanks @chiedo).
 - feat: add snapshot-consistent logical message statistics through `imsg stats` and `messages.stats`, with strict chat scoping, timezone-aware date buckets, and deduplicated optional media totals (#161, thanks @omarshahine).
 
+### Packaging
+- fix: isolate universal builds per architecture and consume SwiftPM's reported product paths so stale slices cannot silently ship older CLI code.
+
 ### Native Polls
 - fix: match native poll vote envelopes, participant handles, and summary metadata so votes render participant markers and correct notifications (#162, thanks @omarshahine).
 

--- a/Tests/imsgTests/ReleasePackagingTests.swift
+++ b/Tests/imsgTests/ReleasePackagingTests.swift
@@ -21,6 +21,10 @@ func universalBuildScriptShipsArm64eHelperSlice() throws {
   // load an arm64-only dylib, which silently kills the bridge.
   #expect(script.contains(#"HELPER_ARCHES_VALUE=${HELPER_ARCHES:-"arm64e arm64 x86_64"}"#))
   #expect(script.contains("lipo -create"))
+  #expect(script.contains("--scratch-path"))
+  #expect(script.contains("--show-bin-path"))
+  #expect(script.contains(#"for bundle in "${PRODUCT_DIRS[0]}"/*.bundle"#))
+  #expect(!script.contains(#".build/${ARCH}-apple-macosx"#))
   #expect(script.contains("imsg-bridge-helper.dylib"))
   // release.yml ships via this script only, so it must guard every helper slice.
   #expect(
@@ -41,6 +45,10 @@ func signAndNotarizeScriptDefaultsHelperToArm64e() throws {
   // arm64e. Assert the loop and its lipo check as one contiguous block so this
   // can't pass by matching the separate clang-args HELPER_ARCH_LIST loop.
   #expect(script.contains(#"HELPER_ARCHES_VALUE=${HELPER_ARCHES:-"arm64e arm64 x86_64"}"#))
+  #expect(script.contains("--scratch-path"))
+  #expect(script.contains("--show-bin-path"))
+  #expect(script.contains(#"for bundle in "${PRODUCT_DIRS[0]}"/*.bundle"#))
+  #expect(!script.contains(#".build/${ARCH}-apple-macosx"#))
   #expect(
     script.contains(
       """

--- a/scripts/build-universal.sh
+++ b/scripts/build-universal.sh
@@ -15,15 +15,18 @@ HELPER_ARCHES_VALUE=${HELPER_ARCHES:-"arm64e arm64 x86_64"}
 HELPER_ARCH_LIST=( ${HELPER_ARCHES_VALUE} )
 BUILD_MODE=${BUILD_MODE:-release}
 CODESIGN_IDENTITY=${CODESIGN_IDENTITY:-"-"}
+SWIFT_SCRATCH_ROOT=${SWIFT_SCRATCH_ROOT:-"${ROOT}/.build/universal"}
 
-for ARCH in "${ARCH_LIST[@]}"; do
-  swift build -c "$BUILD_MODE" --product "$APP_NAME" --arch "$ARCH"
-done
-
-FIRST_ARCH="${ARCH_LIST[0]}"
 BINARIES=()
+PRODUCT_DIRS=()
 for ARCH in "${ARCH_LIST[@]}"; do
-  BINARIES+=("${ROOT}/.build/${ARCH}-apple-macosx/${BUILD_MODE}/${APP_NAME}")
+  SCRATCH_PATH="${SWIFT_SCRATCH_ROOT}/${ARCH}"
+  swift build -c "$BUILD_MODE" --product "$APP_NAME" --arch "$ARCH" \
+    --scratch-path "$SCRATCH_PATH"
+  PRODUCT_DIR=$(swift build -c "$BUILD_MODE" --arch "$ARCH" \
+    --scratch-path "$SCRATCH_PATH" --show-bin-path)
+  BINARIES+=("${PRODUCT_DIR}/${APP_NAME}")
+  PRODUCT_DIRS+=("$PRODUCT_DIR")
 done
 
 DIST_DIR="$(mktemp -d "/tmp/${APP_NAME}-universal.XXXXXX")"
@@ -70,7 +73,7 @@ else
     "${DIST_DIR}/${HELPER_NAME}"
 fi
 
-for bundle in "${ROOT}/.build/${FIRST_ARCH}-apple-macosx/${BUILD_MODE}"/*.bundle; do
+for bundle in "${PRODUCT_DIRS[0]}"/*.bundle; do
   if [[ -e "$bundle" ]]; then
     cp -R "$bundle" "$DIST_DIR/"
   fi

--- a/scripts/sign-and-notarize.sh
+++ b/scripts/sign-and-notarize.sh
@@ -17,6 +17,7 @@ ARCH_LIST=( ${ARCHES_VALUE} )
 # if any slice (incl. arm64e) is missing.
 HELPER_ARCHES_VALUE=${HELPER_ARCHES:-"arm64e arm64 x86_64"}
 HELPER_ARCH_LIST=( ${HELPER_ARCHES_VALUE} )
+SWIFT_SCRATCH_ROOT=${SWIFT_SCRATCH_ROOT:-"${ROOT}/.build/universal"}
 DIST_DIR="$(mktemp -d "/tmp/${APP_NAME}-dist.XXXXXX")"
 API_KEY_FILE="$(mktemp "/tmp/${APP_NAME}-notary.XXXXXX.p8")"
 
@@ -33,13 +34,16 @@ fi
 
 echo "$APP_STORE_CONNECT_API_KEY_P8" | sed 's/\\n/\n/g' > "$API_KEY_FILE"
 
-for ARCH in "${ARCH_LIST[@]}"; do
-  swift build -c release --product imsg --arch "$ARCH"
-done
-
 BINARIES=()
+PRODUCT_DIRS=()
 for ARCH in "${ARCH_LIST[@]}"; do
-  BINARIES+=("$ROOT/.build/${ARCH}-apple-macosx/release/imsg")
+  SCRATCH_PATH="${SWIFT_SCRATCH_ROOT}/${ARCH}"
+  swift build -c release --product "$APP_NAME" --arch "$ARCH" \
+    --scratch-path "$SCRATCH_PATH"
+  PRODUCT_DIR=$(swift build -c release --arch "$ARCH" \
+    --scratch-path "$SCRATCH_PATH" --show-bin-path)
+  BINARIES+=("${PRODUCT_DIR}/${APP_NAME}")
+  PRODUCT_DIRS+=("$PRODUCT_DIR")
 done
 
 lipo -create "${BINARIES[@]}" -output "$DIST_DIR/imsg"
@@ -72,8 +76,7 @@ codesign --force --timestamp --options runtime --sign "$CODESIGN_IDENTITY" \
   --identifier com.steipete.imsg.bridge-helper \
   "$DIST_DIR/$HELPER_NAME"
 
-FIRST_ARCH="${ARCH_LIST[0]}"
-for bundle in "$ROOT/.build/${FIRST_ARCH}-apple-macosx/release"/*.bundle; do
+for bundle in "${PRODUCT_DIRS[0]}"/*.bundle; do
   if [[ -e "$bundle" ]]; then
     cp -R "$bundle" "$DIST_DIR/"
   fi


### PR DESCRIPTION
## Summary

- isolate each universal-build architecture in its own SwiftPM scratch directory
- use SwiftPM's reported product path for executable slices and resource bundles
- apply the same invariant to release signing/notarization

## Why

The existing scripts read fixed `.build/<arch>-apple-macosx/...` paths. Those paths can retain older products when another SwiftPM build layout is active, allowing a successful universal build to package stale CLI slices.

## Proof

- `bash -n scripts/build-universal.sh scripts/sign-and-notarize.sh`
- `swift test --filter ReleasePackaging`
- fresh-scratch `make build`
- universal CLI: `x86_64 arm64`
- universal helper: `x86_64 arm64 arm64e`
- AutoReview clean
