### PR TITLE
fix: coalesce consecutive URL previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - feat: add snapshot-consistent logical message statistics through `imsg stats` and `messages.stats`, with strict chat scoping, timezone-aware date buckets, and deduplicated optional media totals (#161, thanks @omarshahine).
 - feat: inspect future Send Later rows read-only through `imsg scheduled list` and `messages.scheduled`, without requiring the private IMCore bridge (#163, thanks @omarshahine).
 - feat: inspect local chat-background metadata, cache presence, and newest set/clear event through `imsg chat-background status`, without mutating the chat or requiring the private bridge (#167, thanks @omarshahine).
+- fix: coalesce consecutive link-preview rows from one text send so history and unread chat counts expose one logical message.
 
 ### Packaging
 - fix: isolate universal builds per architecture and consume SwiftPM's reported product paths so stale slices cannot silently ship older CLI code.

--- a/Sources/IMsgCore/MessageStore+MessageConstruction.swift
+++ b/Sources/IMsgCore/MessageStore+MessageConstruction.swift
@@ -84,23 +84,33 @@ extension MessageStore {
         AND cmj.chat_id = ?
         \(reactionFilter)
       ORDER BY m.ROWID DESC
-      LIMIT 1
       """
     let rows = try db.prepareRowIterator(sql, bindings: [preview.rowID, preview.chatID])
-    guard let row = try rows.failableNext() else { return nil }
-    let decoded = try decodeMessageRow(
-      row,
-      columns: selection.columns,
-      fallbackChatID: preview.chatID
-    )
+    var previews = [preview]
     var parentCache: ReplyParentCache = [:]
     var pollOptionCache = PollOptionTextCache()
-    let previous = try message(
-      from: decoded,
-      db,
-      parentCache: &parentCache,
-      pollOptionCache: &pollOptionCache
-    )
-    return canCoalesceURLPreview(textMessage: previous, previewMessage: preview) ? previous : nil
+    while let row = try rows.failableNext() {
+      let decoded = try decodeMessageRow(
+        row,
+        columns: selection.columns,
+        fallbackChatID: preview.chatID
+      )
+      let previous = try message(
+        from: decoded,
+        db,
+        parentCache: &parentCache,
+        pollOptionCache: &pollOptionCache
+      )
+      if isURLPreviewBalloon(previous) {
+        previews.append(previous)
+        continue
+      }
+      // One text send can produce a contiguous row per URL. Validate the entire
+      // run so an unrelated message still remains a hard coalescing boundary.
+      return previews.allSatisfy {
+        canCoalesceURLPreview(textMessage: previous, previewMessage: $0)
+      } ? previous : nil
+    }
+    return nil
   }
 }

--- a/Tests/IMsgCoreTests/MessageStoreConsecutiveURLPreviewTests.swift
+++ b/Tests/IMsgCoreTests/MessageStoreConsecutiveURLPreviewTests.swift
@@ -1,0 +1,40 @@
+import Foundation
+import Testing
+
+@testable import IMsgCore
+
+@Test
+func messagesByChatCoalescesConsecutiveURLPreviews() throws {
+  let db = try makeURLPreviewTestDB()
+  let now = Date()
+  try db.run("INSERT INTO handle(ROWID, id) VALUES (1, '+123')")
+  try insertURLPreviewTestMessage(
+    db,
+    rowID: 1,
+    text: "See https://one.example and https://two.example",
+    guid: "text-guid",
+    date: now
+  )
+  try insertURLPreviewTestMessage(
+    db,
+    rowID: 2,
+    text: "https://one.example",
+    guid: "first-preview-guid",
+    balloonBundleID: MessageStore.urlPreviewBalloonBundleID,
+    date: now.addingTimeInterval(1)
+  )
+  try insertURLPreviewTestMessage(
+    db,
+    rowID: 3,
+    text: "https://two.example",
+    guid: "second-preview-guid",
+    balloonBundleID: MessageStore.urlPreviewBalloonBundleID,
+    date: now.addingTimeInterval(2)
+  )
+
+  let store = try MessageStore(connection: db, path: ":memory:")
+  let messages = try store.messages(chatID: 1, limit: 10)
+
+  #expect(messages.map(\.rowID) == [1])
+  #expect(messages.first?.urlPreview?.rowID == 3)
+}

--- a/Tests/IMsgCoreTests/MessageStoreUnreadStateTests.swift
+++ b/Tests/IMsgCoreTests/MessageStoreUnreadStateTests.swift
@@ -63,7 +63,7 @@ func listChatsCountsUnreadInboundMessages() throws {
 }
 
 @Test
-func listChatsCountsSplitURLPreviewAsOneUnreadMessage() throws {
+func listChatsCountsConsecutiveSplitURLPreviewsAsOneUnreadMessage() throws {
   let db = try Connection(.inMemory)
   try MessageDatabaseFixture.createSchema(
     db,
@@ -88,14 +88,19 @@ func listChatsCountsSplitURLPreviewAsOneUnreadMessage() throws {
       balloon_bundle_id, date, is_from_me, service, is_read, date_read
     )
     VALUES
-      (1, 1, 'See https://example.com', 'text-guid', NULL, NULL, NULL, ?, 0, 'iMessage', 0, 0),
-      (2, 1, 'https://example.com', 'preview-guid', NULL, NULL, ?, ?, 0, 'iMessage', 0, 0)
+      (1, 1, 'See https://one.example and https://two.example', 'text-guid', NULL, NULL, NULL, ?, 0, 'iMessage', 0, 0),
+      (2, 1, 'https://one.example', 'first-preview-guid', NULL, NULL, ?, ?, 0, 'iMessage', 0, 0),
+      (3, 1, 'https://two.example', 'second-preview-guid', NULL, NULL, ?, ?, 0, 'iMessage', 0, 0)
     """,
     TestDatabase.appleEpoch(now),
     MessageStore.urlPreviewBalloonBundleID,
-    TestDatabase.appleEpoch(now.addingTimeInterval(1))
+    TestDatabase.appleEpoch(now.addingTimeInterval(1)),
+    MessageStore.urlPreviewBalloonBundleID,
+    TestDatabase.appleEpoch(now.addingTimeInterval(2))
   )
-  try db.run("INSERT INTO chat_message_join(chat_id, message_id) VALUES (1, 1), (1, 2)")
+  try db.run(
+    "INSERT INTO chat_message_join(chat_id, message_id) VALUES (1, 1), (1, 2), (1, 3)"
+  )
 
   let store = try MessageStore(connection: db, path: ":memory:")
   #expect(try store.listChats(limit: 1).first?.unreadCount == 1)


### PR DESCRIPTION
## Summary

- walk backward across a contiguous run of URL-preview rows to find the originating text message
- require every preview in the run to satisfy the existing sender, chat, URL, and five-second compatibility checks
- keep unrelated messages as hard coalescing boundaries
- count one text send with multiple link previews as one logical history row and one unread message

## Regression proof

Before the fix, a text row followed by two preview rows produced history row IDs `[3, 1]` and unread count `2`. The new history and unread fixtures both fail on `main` and pass on this head.

- focused URL-preview tests: 23 passed
- focused unread-state tests: 16 passed across core and CLI/RPC coverage
- `make lint` (repo-baseline warnings only)
- `make test`: 207 passed
- AutoReview: clean, no accepted/actionable findings
