### PR TITLE
fix: harden SPI attachment and reply mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 ### Packaging
 - fix: isolate universal builds per architecture and consume SwiftPM's reported product paths so stale slices cannot silently ship older CLI code.
 
+### Advanced IMCore
+- fix: canonicalize securely staged attachment paths when Messages attachments are relocated through a symlink, and find nested threaded-reply items for edit, unsend, delete, and notify operations.
+
 ### Native Polls
 - fix: match native poll vote envelopes, participant handles, and summary metadata so votes render participant markers and correct notifications (#162, thanks @omarshahine).
 

--- a/Sources/IMsgCore/AttachmentSource.swift
+++ b/Sources/IMsgCore/AttachmentSource.swift
@@ -1,0 +1,93 @@
+import Foundation
+
+#if canImport(Darwin)
+  import Darwin
+#elseif canImport(Glibc)
+  import Glibc
+#endif
+
+enum AttachmentSource {
+  static func openFile(at path: String) throws -> FileHandle {
+    let components = (path as NSString).pathComponents
+    guard components.first == "/", components.count > 1, let filename = components.last else {
+      throw IMsgError.appleScriptFailure("Invalid attachment path")
+    }
+
+    var directoryFD = open("/", O_RDONLY | O_DIRECTORY | O_CLOEXEC)
+    guard directoryFD >= 0 else {
+      throw openError(path: path)
+    }
+    defer { close(directoryFD) }
+
+    for component in components.dropFirst().dropLast() where component != "/" {
+      let nextFD = openat(
+        directoryFD,
+        component,
+        O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC
+      )
+      guard nextFD >= 0 else {
+        throw openError(path: path)
+      }
+      close(directoryFD)
+      directoryFD = nextFD
+    }
+
+    let sourceFD = openat(
+      directoryFD,
+      filename,
+      O_RDONLY | O_NONBLOCK | O_NOFOLLOW | O_CLOEXEC
+    )
+    guard sourceFD >= 0 else {
+      throw openError(path: path)
+    }
+
+    var info = stat()
+    guard fstat(sourceFD, &info) == 0, (info.st_mode & S_IFMT) == S_IFREG else {
+      close(sourceFD)
+      throw IMsgError.appleScriptFailure("Attachment must be a regular file")
+    }
+    return FileHandle(fileDescriptor: sourceFD, closeOnDealloc: true)
+  }
+
+  static func copy(_ source: FileHandle, to destination: URL) throws {
+    let destinationFD = destination.path.withCString { path in
+      open(path, O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC, S_IRUSR | S_IWUSR)
+    }
+    guard destinationFD >= 0 else {
+      throw IMsgError.appleScriptFailure("Could not create staged attachment")
+    }
+    let destinationHandle = FileHandle(fileDescriptor: destinationFD, closeOnDealloc: true)
+    defer { try? destinationHandle.close() }
+
+    #if canImport(Darwin)
+      guard
+        fcopyfile(
+          source.fileDescriptor,
+          destinationFD,
+          nil,
+          copyfile_flags_t(COPYFILE_ALL)
+        ) == 0
+      else {
+        throw openError(path: destination.path)
+      }
+    #else
+      while let chunk = try source.read(upToCount: 1024 * 1024), !chunk.isEmpty {
+        try destinationHandle.write(contentsOf: chunk)
+      }
+      var info = stat()
+      if fstat(source.fileDescriptor, &info) == 0 {
+        _ = fchmod(destinationFD, info.st_mode & 0o777)
+      }
+    #endif
+  }
+
+  private static func openError(path: String) -> IMsgError {
+    let code = errno
+    if code == ENOENT {
+      return .appleScriptFailure("Attachment not found at \(path)")
+    }
+    return .appleScriptFailure(
+      "Could not securely open attachment at \(path): \(String(cString: strerror(code)))"
+    )
+  }
+}

--- a/Sources/IMsgCore/MessageSender.swift
+++ b/Sources/IMsgCore/MessageSender.swift
@@ -120,15 +120,15 @@ public struct MessageSender {
   }
 
   private static func stageAttachment(at path: String, destinationRoot: URL) throws -> String {
-    let expandedPath = (path as NSString).expandingTildeInPath
-    let sourceURL = URL(fileURLWithPath: expandedPath)
+    let sourcePath = SecurePath.absoluteLexicalPath(path)
+    let sourceURL = URL(fileURLWithPath: sourcePath)
     let fileManager = FileManager.default
-    guard fileManager.fileExists(atPath: sourceURL.path) else {
-      throw IMsgError.appleScriptFailure("Attachment not found at \(sourceURL.path)")
-    }
+    let sourceHandle = try AttachmentSource.openFile(at: sourcePath)
+    defer { try? sourceHandle.close() }
 
     try fileManager.createDirectory(at: destinationRoot, withIntermediateDirectories: true)
-    let attachmentDir = destinationRoot.appendingPathComponent(
+    let canonicalRoot = destinationRoot.resolvingSymlinksInPath()
+    let attachmentDir = canonicalRoot.appendingPathComponent(
       UUID().uuidString,
       isDirectory: true
     )
@@ -137,7 +137,12 @@ public struct MessageSender {
       sourceURL.lastPathComponent,
       isDirectory: false
     )
-    try fileManager.copyItem(at: sourceURL, to: destination)
+    do {
+      try AttachmentSource.copy(sourceHandle, to: destination)
+    } catch {
+      try? fileManager.removeItem(at: destination)
+      throw error
+    }
     return destination.path
   }
 

--- a/Sources/IMsgCore/SecurePath.swift
+++ b/Sources/IMsgCore/SecurePath.swift
@@ -35,17 +35,25 @@ public enum SecurePath {
     return path
   }
 
-  /// Returns true if any component of `path` (after tilde expansion and CWD
-  /// resolution for relative paths) is a symbolic link. Final component
-  /// included.
-  public static func hasSymlinkComponent(_ path: String) -> Bool {
+  private static func absoluteExpandedPath(_ path: String) -> String {
     var lexicalPath = (path as NSString).expandingTildeInPath
     if !lexicalPath.hasPrefix("/") {
       lexicalPath =
         (FileManager.default.currentDirectoryPath as NSString)
         .appendingPathComponent(lexicalPath)
     }
-    lexicalPath = normalizingTrustedSystemAliasPrefix(lexicalPath)
+    return lexicalPath
+  }
+
+  static func absoluteLexicalPath(_ path: String) -> String {
+    normalizingTrustedSystemAliasPrefix(absoluteExpandedPath(path))
+  }
+
+  /// Returns true if any component of `path` (after tilde expansion and CWD
+  /// resolution for relative paths) is a symbolic link. Final component
+  /// included.
+  public static func hasSymlinkComponent(_ path: String) -> Bool {
+    let lexicalPath = absoluteLexicalPath(path)
 
     let components = (lexicalPath as NSString).pathComponents
     guard !components.isEmpty else { return false }

--- a/Sources/IMsgHelper/IMsgInjected.m
+++ b/Sources/IMsgHelper/IMsgInjected.m
@@ -1446,6 +1446,82 @@ static NSString *deriveThreadIdentifier(NSString *parentGuid,
 /// the load to keep the reply / reaction code paths independent (each
 /// fires its own load), which is what BlueBubblesHelper does too — and
 /// avoids gnarly out-parameter plumbing through deriveThreadIdentifier.
+static id safelyReadObjectSelector(id object, SEL selector) {
+    if (!object || !selector || ![object respondsToSelector:selector]) return nil;
+    @try {
+        return ((id (*)(id, SEL))objc_msgSend)(object, selector);
+    } @catch (__unused NSException *exception) {
+        // Some Tahoe IMCore proxy objects claim private selectors through
+        // forwarding, then raise unrecognized-selector when invoked.
+        return nil;
+    }
+}
+
+static id safelyReadObjectSelectorWithObject(id object, SEL selector, id argument) {
+    if (!object || !selector || ![object respondsToSelector:selector]) return nil;
+    @try {
+        return ((id (*)(id, SEL, id))objc_msgSend)(object, selector, argument);
+    } @catch (__unused NSException *exception) {
+        return nil;
+    }
+}
+
+static id safelyReadObjectSelectorWithTwoObjects(id object, SEL selector,
+                                                 id first, id second) {
+    if (!object || !selector || ![object respondsToSelector:selector]) return nil;
+    @try {
+        return ((id (*)(id, SEL, id, id))objc_msgSend)(
+            object, selector, first, second);
+    } @catch (__unused NSException *exception) {
+        return nil;
+    }
+}
+
+static id normalizeFoundMessageItemWithChatContext(id object, id chatContext) {
+    if (!object) return nil;
+
+    Class partClass = NSClassFromString(@"IMMessagePartChatItem");
+    if (partClass && [object isKindOfClass:partClass]) return object;
+
+    // History loading can yield an IMMessage, its backing IMMessageItem, or
+    // a chat item directly depending on OS version and whether it is a
+    // threaded reply. Normalize all three to the chat item mutations expect.
+    id messageItem = object;
+    SEL itemSel = @selector(_imMessageItem);
+    if ([messageItem respondsToSelector:itemSel]) {
+        messageItem = safelyReadObjectSelector(messageItem, itemSel);
+        if (!messageItem) return nil;
+    }
+    SEL chatItemsSel = @selector(_newChatItems);
+    BOOL hasChatItemsSelector = [messageItem respondsToSelector:chatItemsSel];
+    id items = nil;
+    if (hasChatItemsSelector) {
+        items = safelyReadObjectSelector(messageItem, chatItemsSel);
+    }
+    BOOL needsContext = !items
+        || ([items isKindOfClass:[NSArray class]] && ((NSArray *)items).count == 0);
+    if (needsContext && chatContext) {
+        SEL contextSel = NSSelectorFromString(@"_newChatItemsWithChatContext:");
+        items = safelyReadObjectSelectorWithObject(messageItem, contextSel, chatContext);
+        BOOL contextItemsMissing = !items
+            || ([items isKindOfClass:[NSArray class]] && ((NSArray *)items).count == 0);
+        if (contextItemsMissing) {
+            SEL partsSel = NSSelectorFromString(
+                @"_newMessagePartsForMessageItem:chatContext:");
+            items = safelyReadObjectSelectorWithTwoObjects(
+                partClass, partsSel, messageItem, chatContext);
+        }
+    }
+    if ([items isKindOfClass:[NSArray class]]) {
+        return ((NSArray *)items).firstObject;
+    }
+    return items ?: (hasChatItemsSelector ? nil : messageItem);
+}
+
+static id normalizeFoundMessageItem(id object) {
+    return normalizeFoundMessageItemWithChatContext(object, nil);
+}
+
 static id loadParentFirstChatItem(NSString *parentGuid, id *outParentMessage) {
     if (outParentMessage) *outParentMessage = nil;
     if (parentGuid.length == 0) return nil;
@@ -1477,14 +1553,7 @@ static id loadParentFirstChatItem(NSString *parentGuid, id *outParentMessage) {
     }
     if (!parent) return nil;
     if (outParentMessage) *outParentMessage = parent;
-
-    if (![parent respondsToSelector:@selector(_imMessageItem)]) return nil;
-    id parentItem = [parent performSelector:@selector(_imMessageItem)];
-    SEL chatItemsSel = NSSelectorFromString(@"_newChatItems");
-    if (!parentItem || ![parentItem respondsToSelector:chatItemsSel]) return nil;
-    id items = [parentItem performSelector:chatItemsSel];
-    return [items isKindOfClass:[NSArray class]]
-        ? ((NSArray *)items).firstObject : items;
+    return normalizeFoundMessageItem(parent);
 }
 
 /// Dispatch a built IMMessage into the chat after installing the same
@@ -2404,6 +2473,56 @@ static id buildIMMessage(NSAttributedString *body,
 /// `chat.chatItems` window. Falls back to the older
 /// `loadedChatItemsForChat:beforeDate:limit:loadIfNeeded:` + sync poll
 /// for OSes that don't expose the block-based load.
+static id findMessageItemInObject(id object,
+                                  NSString *messageGuid,
+                                  NSMutableSet<NSValue *> *visited,
+                                  NSUInteger depth) {
+    if (!object || !messageGuid.length || depth > 8) return nil;
+
+    NSValue *identity = [NSValue valueWithNonretainedObject:object];
+    if ([visited containsObject:identity]) return nil;
+    [visited addObject:identity];
+
+    SEL guidSel = @selector(guid);
+    if ([object respondsToSelector:guidSel]) {
+        id guid = safelyReadObjectSelector(object, guidSel);
+        if ([guid isKindOfClass:[NSString class]]
+            && [guid isEqualToString:messageGuid]) {
+            id normalized = normalizeFoundMessageItem(object);
+            if (normalized) return normalized;
+        }
+    }
+
+    // Threaded replies can sit below a top-level transcript item. Walk both
+    // public-ish wrappers and private backing objects, with a small depth cap
+    // and identity set so cyclic IMCore graphs cannot recurse forever.
+    NSArray<NSString *> *objectSelectors = @[
+        @"message", @"messageItem", @"_item", @"_imMessageItem"
+    ];
+    for (NSString *name in objectSelectors) {
+        SEL sel = NSSelectorFromString(name);
+        if (![object respondsToSelector:sel]) continue;
+        id child = safelyReadObjectSelector(object, sel);
+        id match = findMessageItemInObject(child, messageGuid, visited, depth + 1);
+        if (match) return match;
+    }
+
+    NSArray<NSString *> *collectionSelectors = @[
+        @"_newChatItems", @"chatItems", @"aggregateAttachmentParts"
+    ];
+    for (NSString *name in collectionSelectors) {
+        SEL sel = NSSelectorFromString(name);
+        if (![object respondsToSelector:sel]) continue;
+        id children = safelyReadObjectSelector(object, sel);
+        if (![children isKindOfClass:[NSArray class]]) continue;
+        for (id child in (NSArray *)children) {
+            id match = findMessageItemInObject(child, messageGuid, visited, depth + 1);
+            if (match) return match;
+        }
+    }
+    return nil;
+}
+
 static id findMessageItem(IMChat *chat, NSString *messageGuid) {
     if (!chat || !messageGuid.length) {
         return nil;
@@ -2413,7 +2532,15 @@ static id findMessageItem(IMChat *chat, NSString *messageGuid) {
     // (returns an IMMessage). Callers want the chat item, so navigate
     // IMMessage → IMMessageItem → first IMMessagePartChatItem via the
     // same accessor walk loadParentFirstChatItem performs.
-    id loadedChatItem = loadParentFirstChatItem(messageGuid, NULL);
+    id loadedMessage = nil;
+    id loadedChatItem = loadParentFirstChatItem(messageGuid, &loadedMessage);
+    if (!loadedChatItem && loadedMessage) {
+        Class contextClass = NSClassFromString(@"IMMutableChatContext");
+        SEL contextSel = NSSelectorFromString(@"chatContextForPinnedChat:");
+        id chatContext = safelyReadObjectSelectorWithObject(contextClass, contextSel, chat);
+        loadedChatItem = normalizeFoundMessageItemWithChatContext(
+            loadedMessage, chatContext);
+    }
     if (loadedChatItem) return loadedChatItem;
 
     Class hcClass = NSClassFromString(@"IMChatHistoryController");
@@ -2441,25 +2568,73 @@ static id findMessageItem(IMChat *chat, NSString *messageGuid) {
         if ([chat respondsToSelector:@selector(chatItems)]) {
             items = [chat performSelector:@selector(chatItems)];
         }
+        NSMutableSet<NSValue *> *visited = [NSMutableSet set];
         for (id item in items) {
-            id message = nil;
-            if ([item respondsToSelector:@selector(message)]) {
-                message = [item performSelector:@selector(message)];
-            }
-            NSString *guid = nil;
-            if (message && [message respondsToSelector:@selector(guid)]) {
-                guid = [message performSelector:@selector(guid)];
-            } else if ([item respondsToSelector:@selector(guid)]) {
-                guid = [item performSelector:@selector(guid)];
-            }
-            if ([guid isEqualToString:messageGuid]) {
-                return item;
-            }
+            id match = findMessageItemInObject(item, messageGuid, visited, 0);
+            if (match) return match;
         }
         [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode
                                  beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];
     }
     return nil;
+}
+
+static id findMessagePartInObject(id object, NSInteger partIndex) {
+    if (!object) return nil;
+    if ([object isKindOfClass:[NSArray class]]) {
+        for (id child in (NSArray *)object) {
+            id match = findMessagePartInObject(child, partIndex);
+            if (match) return match;
+        }
+        return nil;
+    }
+
+    id aggregate = safelyReadObjectSelector(
+        object, @selector(aggregateAttachmentParts));
+    id aggregateMatch = findMessagePartInObject(aggregate, partIndex);
+    if (aggregateMatch) return aggregateMatch;
+
+    if ([object respondsToSelector:@selector(index)]) {
+        @try {
+            if ([(IMMessagePartChatItem *)object index] == partIndex) return object;
+        } @catch (__unused NSException *exception) {
+        }
+        return nil;
+    }
+    return partIndex == 0 ? object : nil;
+}
+
+static id findMessagePart(IMChat *chat, NSString *messageGuid, NSInteger partIndex) {
+    id item = findMessageItem(chat, messageGuid);
+    if (!item) return nil;
+
+    id messageItem = safelyReadObjectSelector(item, @selector(messageItem));
+    if (!messageItem) messageItem = item;
+
+    Class contextClass = NSClassFromString(@"IMMutableChatContext");
+    SEL contextSel = NSSelectorFromString(@"chatContextForPinnedChat:");
+    id chatContext = safelyReadObjectSelectorWithObject(
+        contextClass, contextSel, chat);
+
+    id parts = safelyReadObjectSelector(messageItem, @selector(_newChatItems));
+    BOOL partsMissing = !parts
+        || ([parts isKindOfClass:[NSArray class]] && ((NSArray *)parts).count == 0);
+    if (partsMissing && chatContext) {
+        SEL contextItemsSel = NSSelectorFromString(@"_newChatItemsWithChatContext:");
+        parts = safelyReadObjectSelectorWithObject(
+            messageItem, contextItemsSel, chatContext);
+        partsMissing = !parts
+            || ([parts isKindOfClass:[NSArray class]] && ((NSArray *)parts).count == 0);
+        if (partsMissing) {
+            Class partClass = NSClassFromString(@"IMMessagePartChatItem");
+            SEL partsSel = NSSelectorFromString(
+                @"_newMessagePartsForMessageItem:chatContext:");
+            parts = safelyReadObjectSelectorWithTwoObjects(
+                partClass, partsSel, messageItem, chatContext);
+        }
+    }
+
+    return findMessagePartInObject(parts ?: item, partIndex);
 }
 
 /// Best-effort messageGuid extractor for transactional sends. Returns the
@@ -3697,54 +3872,13 @@ static NSDictionary *handleUnsendMessage(NSInteger requestId, NSDictionary *para
         return errorResponse(requestId, @"retractMessagePart: not available on this macOS");
     }
 
-    id messageItem = findMessageItem(chat, messageGuid);
-    if (!messageItem) {
+    id target = findMessagePart(chat, messageGuid, partIndex);
+    if (!target) {
         return errorResponse(requestId,
-            [NSString stringWithFormat:@"Message not found: %@", messageGuid]);
+            [NSString stringWithFormat:@"Message part not found: %ld", (long)partIndex]);
     }
 
     @try {
-        id newChatItems = nil;
-        SEL ncSel = @selector(_newChatItems);
-        if ([messageItem respondsToSelector:ncSel]) {
-            // Route through objc_msgSend to avoid ARC's "performSelector
-            // names a selector which retains the object" warning on the
-            // underscore-prefixed selector.
-            newChatItems = ((id (*)(id, SEL))objc_msgSend)(messageItem, ncSel);
-        }
-        id target = nil;
-        if ([newChatItems isKindOfClass:[NSArray class]]) {
-            NSArray *arr = newChatItems;
-            if (arr.count == 0) target = messageItem;
-            else if (arr.count == 1) target = arr.firstObject;
-            else {
-                for (id sub in arr) {
-                    // Aggregate attachment unwrap
-                    if ([sub respondsToSelector:@selector(aggregateAttachmentParts)]) {
-                        NSArray *agg = [sub performSelector:@selector(aggregateAttachmentParts)];
-                        for (id p in agg) {
-                            if ([p respondsToSelector:@selector(index)]
-                                && [(IMMessagePartChatItem *)p index] == partIndex) {
-                                target = p; break;
-                            }
-                        }
-                        if (target) break;
-                    }
-                    if ([sub respondsToSelector:@selector(index)]
-                        && [(IMMessagePartChatItem *)sub index] == partIndex) {
-                        target = sub; break;
-                    }
-                }
-            }
-        } else if (newChatItems != nil) {
-            target = newChatItems;
-        } else {
-            target = messageItem;
-        }
-        if (!target) {
-            return errorResponse(requestId,
-                [NSString stringWithFormat:@"Message part not found: %ld", (long)partIndex]);
-        }
         [chat performSelector:@selector(retractMessagePart:) withObject:target];
     } @catch (NSException *ex) {
         return errorResponse(requestId, ex.reason ?: @"unsend-message failed");

--- a/Tests/IMsgCoreTests/MessageSenderAttachmentSecurityTests.swift
+++ b/Tests/IMsgCoreTests/MessageSenderAttachmentSecurityTests.swift
@@ -1,0 +1,109 @@
+import Foundation
+import Testing
+
+@testable import IMsgCore
+
+#if canImport(Darwin)
+  import Darwin
+#elseif canImport(Glibc)
+  import Glibc
+#endif
+
+@Test
+func messageSenderCanonicalizesStagingBelowSymlinkedAttachmentsRoot() throws {
+  let fileManager = FileManager.default
+  let root = fileManager.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+  let realRoot = root.appendingPathComponent("real", isDirectory: true)
+  let linkedRoot = root.appendingPathComponent("linked", isDirectory: true)
+  let source = root.appendingPathComponent("source.txt")
+  try fileManager.createDirectory(at: realRoot, withIntermediateDirectories: true)
+  try fileManager.createSymbolicLink(at: linkedRoot, withDestinationURL: realRoot)
+  try Data("payload".utf8).write(to: source)
+  try fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: source.path)
+  defer { try? fileManager.removeItem(at: root) }
+
+  var captured: [String] = []
+  let sender = MessageSender(
+    runner: { _, args in captured = args },
+    attachmentsSubdirectoryProvider: { linkedRoot }
+  )
+  try sender.send(
+    MessageSendOptions(
+      recipient: "+16502530000",
+      attachmentPath: source.path,
+      service: .imessage
+    ))
+
+  let stagedPath = captured[3]
+  #expect(stagedPath.hasPrefix(realRoot.path))
+  #expect(!stagedPath.hasPrefix(linkedRoot.path))
+  #expect(SecurePath.hasSymlinkComponent(stagedPath) == false)
+  #expect(try Data(contentsOf: URL(fileURLWithPath: stagedPath)) == Data("payload".utf8))
+  let stagedAttributes = try fileManager.attributesOfItem(atPath: stagedPath)
+  #expect((stagedAttributes[.posixPermissions] as? NSNumber)?.intValue == 0o600)
+}
+
+@Test
+func messageSenderRejectsCallerControlledAttachmentSymlinkBeforeStaging() throws {
+  let fileManager = FileManager.default
+  let root = fileManager.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+  let realRoot = root.appendingPathComponent("real", isDirectory: true)
+  let linkedRoot = root.appendingPathComponent("linked", isDirectory: true)
+  let finalLink = root.appendingPathComponent("linked.txt")
+  let dotDotTraversal = linkedRoot.path + "/../source.txt"
+  let source = realRoot.appendingPathComponent("source.txt")
+  try fileManager.createDirectory(at: realRoot, withIntermediateDirectories: true)
+  try Data("private payload".utf8).write(to: source)
+  try fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: source.path)
+  try fileManager.createSymbolicLink(at: linkedRoot, withDestinationURL: realRoot)
+  try fileManager.createSymbolicLink(at: finalLink, withDestinationURL: source)
+  defer { try? fileManager.removeItem(at: root) }
+
+  var didRun = false
+  let sender = MessageSender(
+    runner: { _, _ in didRun = true },
+    attachmentsSubdirectoryProvider: { realRoot }
+  )
+
+  for attackPath in [
+    linkedRoot.appendingPathComponent("source.txt").path,
+    finalLink.path,
+    dotDotTraversal,
+  ] {
+    #expect(throws: IMsgError.self) {
+      try sender.send(
+        MessageSendOptions(
+          recipient: "+16502530000",
+          attachmentPath: attackPath,
+          service: .imessage
+        ))
+    }
+  }
+  #expect(didRun == false)
+}
+
+@Test
+func messageSenderRejectsFIFOWithoutBlocking() throws {
+  let fileManager = FileManager.default
+  let root = fileManager.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+  let fifo = root.appendingPathComponent("attachment.fifo")
+  try fileManager.createDirectory(at: root, withIntermediateDirectories: true)
+  #expect(mkfifo(fifo.path, S_IRUSR | S_IWUSR) == 0)
+  defer { try? fileManager.removeItem(at: root) }
+
+  var didRun = false
+  let sender = MessageSender(
+    runner: { _, _ in didRun = true },
+    attachmentsSubdirectoryProvider: { root.appendingPathComponent("staged") }
+  )
+
+  #expect(throws: IMsgError.self) {
+    try sender.send(
+      MessageSendOptions(
+        recipient: "+16502530000",
+        attachmentPath: fifo.path,
+        service: .imessage
+      ))
+  }
+  #expect(didRun == false)
+}

--- a/Tests/IMsgCoreTests/UtilityTests.swift
+++ b/Tests/IMsgCoreTests/UtilityTests.swift
@@ -165,7 +165,21 @@ func securePathDetectsParentSymlink() throws {
 }
 
 @Test
+func securePathDoesNotNormalizeAwaySymlinkedDotDotComponent() throws {
+  let fileManager = FileManager.default
+  let root = fileManager.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+  let realDirectory = root.appendingPathComponent("real", isDirectory: true)
+  let link = root.appendingPathComponent("link", isDirectory: true)
+  try fileManager.createDirectory(at: realDirectory, withIntermediateDirectories: true)
+  try fileManager.createSymbolicLink(at: link, withDestinationURL: realDirectory)
+  defer { try? fileManager.removeItem(at: root) }
+
+  #expect(SecurePath.hasSymlinkComponent(link.appendingPathComponent("../queue").path))
+}
+
+@Test
 func securePathAllowsTrustedSystemAliasPrefixes() throws {
+  #expect(SecurePath.absoluteLexicalPath("/var/example") == "/private/var/example")
   let privateTmp = URL(fileURLWithPath: "/private/tmp", isDirectory: true)
   let dirName = "imsg-secure-path-\(UUID().uuidString)"
   let realDir = privateTmp.appendingPathComponent(dirName)

--- a/Tests/imsgTests/BridgeCommandRegistrationTests.swift
+++ b/Tests/imsgTests/BridgeCommandRegistrationTests.swift
@@ -85,6 +85,54 @@ func bridgeAttachmentStagingUsesChatGuid() throws {
 }
 
 @Test
+func injectedHelperFindsNestedThreadReplyItems() throws {
+  let testFile = URL(fileURLWithPath: #filePath)
+  let repoRoot =
+    testFile
+    .deletingLastPathComponent()
+    .deletingLastPathComponent()
+    .deletingLastPathComponent()
+  let helper = repoRoot.appendingPathComponent("Sources/IMsgHelper/IMsgInjected.m")
+  let source = stripObjectiveCComments(try String(contentsOf: helper, encoding: .utf8))
+  let recursiveBody = try #require(
+    functionBody(named: "findMessageItemInObject", in: source)
+  )
+  let normalizationBody = try #require(
+    functionBody(named: "normalizeFoundMessageItemWithChatContext", in: source)
+  )
+  let safeSelectorBody = try #require(
+    functionBody(named: "safelyReadObjectSelector", in: source)
+  )
+  let lookupBody = try #require(
+    functionBody(named: "findMessageItem(IMChat", in: source)
+  )
+  let loadBody = try #require(
+    functionBody(named: "loadParentFirstChatItem", in: source)
+  )
+
+  #expect(recursiveBody.contains("depth > 8"))
+  #expect(recursiveBody.contains("valueWithNonretainedObject"))
+  #expect(recursiveBody.contains("normalizeFoundMessageItem(object)"))
+  #expect(recursiveBody.contains(#"@"_newChatItems""#))
+  #expect(recursiveBody.contains(#"@"_item""#))
+  #expect(recursiveBody.contains(#"@"messageItem""#))
+  #expect(normalizationBody.contains("@selector(_imMessageItem)"))
+  #expect(normalizationBody.contains("@selector(_newChatItems)"))
+  #expect(normalizationBody.contains("isKindOfClass:partClass"))
+  #expect(source.contains("_newChatItemsWithChatContext:"))
+  #expect(source.contains("_newMessagePartsForMessageItem:chatContext:"))
+  #expect(source.contains("findMessagePartInObject"))
+  #expect(source.contains("findMessagePart(chat, messageGuid, partIndex)"))
+  #expect(source.contains("if ([(IMMessagePartChatItem *)object index] == partIndex)"))
+  #expect(lookupBody.contains("chatContextForPinnedChat:"))
+  #expect(lookupBody.contains("normalizeFoundMessageItemWithChatContext"))
+  #expect(safeSelectorBody.contains("@catch"))
+  #expect(recursiveBody.contains("safelyReadObjectSelector"))
+  #expect(loadBody.contains("normalizeFoundMessageItem(parent)"))
+  #expect(lookupBody.contains("findMessageItemInObject"))
+}
+
+@Test
 func bridgeReplySendsKeepAssociatedMessageFallback() throws {
   let testFile = URL(fileURLWithPath: #filePath)
   let repoRoot =


### PR DESCRIPTION
## Summary

- securely stage attachments when the Messages attachment root is symlinked, using descriptor-relative no-follow traversal and metadata-preserving copies
- resolve Tahoe threaded reply backing items through chat context so SPI mutations target the requested message part
- add regression coverage for symlink, dot-component, FIFO, permission, and nested reply-item cases

## Verification

- `make test` — 423 tests passed
- `make lint` — no serious violations
- `make build` — universal CLI and bridge helper built
- autoreview — clean
- live SIP-disabled macOS VM — attachment send and threaded unsend queued successfully
