### PR TITLE
build: refresh Swift package dependencies

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,9 +9,9 @@ let package = Package(
     .executable(name: "imsg", targets: ["imsg"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/steipete/Commander.git", from: "0.2.2"),
+    .package(url: "https://github.com/steipete/Commander.git", from: "0.2.3"),
     .package(url: "https://github.com/stephencelis/SQLite.swift.git", from: "0.16.0"),
-    .package(url: "https://github.com/marmelroy/PhoneNumberKit.git", from: "4.3.0"),
+    .package(url: "https://github.com/PhoneNumberKit/PhoneNumberKit.git", from: "5.0.4"),
   ],
   targets: {
     var targets: [Target] = [

--- a/Tests/imsgTests/ReleasePackagingTests.swift
+++ b/Tests/imsgTests/ReleasePackagingTests.swift
@@ -66,6 +66,16 @@ func linuxReleaseStaticallyLinksSwiftRuntime() throws {
 }
 
 @Test
+func dependencyPatchTargetsPhoneNumberKitV5BundleResource() throws {
+  let script = try readRepositoryFile("scripts/patch-deps.sh")
+
+  #expect(script.contains("PhoneNumberKit/Sources/PhoneNumberKit/Bundle+Resources.swift"))
+  #expect(!script.contains("PhoneNumberKit/PhoneNumberKit/Bundle+Resources.swift"))
+  #expect(script.contains("PhoneNumberKit bundle resource patch target is missing"))
+  #expect(script.contains("Bundle.main.bundleURL.resolvingSymlinksInPath()"))
+}
+
+@Test
 func bridgeHelperBuildsUseRelocatableInstallName() throws {
   let developmentBuild = try readRepositoryFile("Makefile")
   let universalBuild = try readRepositoryFile("scripts/build-universal.sh")

--- a/scripts/patch-deps.sh
+++ b/scripts/patch-deps.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 SQLITE_PACKAGE=".build/checkouts/SQLite.swift/Package.swift"
-PHONE_NUMBER_BUNDLE=".build/checkouts/PhoneNumberKit/PhoneNumberKit/Bundle+Resources.swift"
+PHONE_NUMBER_BUNDLE=".build/checkouts/PhoneNumberKit/Sources/PhoneNumberKit/Bundle+Resources.swift"
 
 # Try python3, then python, then fail
 if command -v python3 >/dev/null 2>&1; then
@@ -32,13 +32,18 @@ path.write_text(text.replace(needle, replacement))
 PY
 fi
 
-if [[ -f "$PHONE_NUMBER_BUNDLE" ]]; then
-  chmod u+w "$PHONE_NUMBER_BUNDLE" || true
-  $PYTHON_BIN - <<'PY'
+if [[ ! -f "$PHONE_NUMBER_BUNDLE" ]]; then
+  echo "Error: PhoneNumberKit bundle resource patch target is missing: $PHONE_NUMBER_BUNDLE" >&2
+  exit 1
+fi
+
+chmod u+w "$PHONE_NUMBER_BUNDLE" || true
+PHONE_NUMBER_BUNDLE="$PHONE_NUMBER_BUNDLE" $PYTHON_BIN - <<'PY'
+import os
 import sys
 from pathlib import Path
 
-path = Path(".build/checkouts/PhoneNumberKit/PhoneNumberKit/Bundle+Resources.swift")
+path = Path(os.environ["PHONE_NUMBER_BUNDLE"])
 text = path.read_text()
 
 updated = False
@@ -61,4 +66,3 @@ elif "resolvingSymlinksInPath()" not in text:
 if updated:
     path.write_text(text)
 PY
-fi


### PR DESCRIPTION
## Summary

- update Commander from 0.2.2 to 0.2.3
- update PhoneNumberKit from 4.3.0 to 5.0.4 and its canonical repository
- update the release patch target for PhoneNumberKit 5 and fail loudly if upstream layout drifts
- add regression coverage for release dependency patching

## Verification

- `make test` — 424 tests passed
- `make lint` — passed; 9 existing warnings, 0 serious violations
- `make build` — universal CLI (`arm64`, `x86_64`) and helper (`arm64e`, `arm64`, `x86_64`) built
- Codex autoreview — clean, no accepted/actionable findings
- verified latest releases: Commander 0.2.3, SQLite.swift 0.16.0, PhoneNumberKit 5.0.4
