### PR TITLE
fix(media): bound ffmpeg conversion wait with a timeout

### DIFF
--- a/Sources/IMsgCore/AttachmentResolver.swift
+++ b/Sources/IMsgCore/AttachmentResolver.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 
 #if canImport(CryptoKit)
@@ -118,7 +119,15 @@ enum AttachmentResolver {
     }
   }
 
-  static func runConversionProcess(executableURL: URL, arguments: [String]) throws -> Int32 {
+  /// Default bound for external converters (ffmpeg). Hung converters must not
+  /// block attachment metadata resolution indefinitely.
+  static let conversionProcessTimeout: TimeInterval = 60
+
+  static func runConversionProcess(
+    executableURL: URL,
+    arguments: [String],
+    timeout: TimeInterval = conversionProcessTimeout
+  ) throws -> Int32 {
     let process = Process()
     process.executableURL = executableURL
     process.arguments = arguments
@@ -126,7 +135,25 @@ enum AttachmentResolver {
     process.standardError = FileHandle(forWritingAtPath: "/dev/null")
 
     try process.run()
-    process.waitUntilExit()
+
+    let deadline = Date().addingTimeInterval(max(0.05, timeout))
+    while process.isRunning {
+      if Date() >= deadline {
+        process.terminate()
+        // Allow a brief grace period for SIGTERM cleanup, then force-kill.
+        let killDeadline = Date().addingTimeInterval(0.5)
+        while process.isRunning, Date() < killDeadline {
+          Thread.sleep(forTimeInterval: 0.02)
+        }
+        if process.isRunning {
+          process.interrupt()
+          kill(process.processIdentifier, SIGKILL)
+        }
+        process.waitUntilExit()
+        return 128 + SIGTERM
+      }
+      Thread.sleep(forTimeInterval: 0.05)
+    }
     return process.terminationStatus
   }
 

--- a/Sources/IMsgCore/AttachmentResolver.swift
+++ b/Sources/IMsgCore/AttachmentResolver.swift
@@ -136,25 +136,40 @@ enum AttachmentResolver {
 
     try process.run()
 
-    let deadline = Date().addingTimeInterval(max(0.05, timeout))
+    // Monotonic deadline so wall-clock jumps cannot stretch the bound.
+    let clock = ContinuousClock()
+    let bound = Duration.seconds(max(0.05, timeout))
+    let deadline = clock.now + bound
     while process.isRunning {
-      if Date() >= deadline {
-        process.terminate()
-        // Allow a brief grace period for SIGTERM cleanup, then force-kill.
-        let killDeadline = Date().addingTimeInterval(0.5)
-        while process.isRunning, Date() < killDeadline {
-          Thread.sleep(forTimeInterval: 0.02)
-        }
-        if process.isRunning {
-          process.interrupt()
-          kill(process.processIdentifier, SIGKILL)
-        }
+      if clock.now >= deadline {
+        terminateConversionProcess(process)
         process.waitUntilExit()
         return 128 + SIGTERM
       }
       Thread.sleep(forTimeInterval: 0.05)
     }
     return process.terminationStatus
+  }
+
+  /// SIGTERM the process, then SIGKILL process and process-group after grace.
+  private static func terminateConversionProcess(_ process: Process) {
+    let pid = process.processIdentifier
+    guard pid > 0 else { return }
+    process.terminate()
+    // Negative pid targets the process group when the child is the group leader
+    // (common for simple exec'd converters; best-effort for multi-process trees).
+    kill(-pid, SIGTERM)
+
+    let clock = ContinuousClock()
+    let killDeadline = clock.now + .milliseconds(500)
+    while process.isRunning, clock.now < killDeadline {
+      Thread.sleep(forTimeInterval: 0.02)
+    }
+    if process.isRunning {
+      process.interrupt()
+      kill(pid, SIGKILL)
+      kill(-pid, SIGKILL)
+    }
   }
 
   private static func conversionPlan(

--- a/Sources/IMsgCore/AttachmentResolver.swift
+++ b/Sources/IMsgCore/AttachmentResolver.swift
@@ -155,10 +155,11 @@ enum AttachmentResolver {
   private static func terminateConversionProcess(_ process: Process) {
     let pid = process.processIdentifier
     guard pid > 0 else { return }
+    let ownsProcessGroup = getpgid(pid) == pid
     process.terminate()
-    // Negative pid targets the process group when the child is the group leader
-    // (common for simple exec'd converters; best-effort for multi-process trees).
-    kill(-pid, SIGTERM)
+    if ownsProcessGroup {
+      kill(-pid, SIGTERM)
+    }
 
     let clock = ContinuousClock()
     let killDeadline = clock.now + .milliseconds(500)
@@ -166,8 +167,11 @@ enum AttachmentResolver {
       Thread.sleep(forTimeInterval: 0.02)
     }
     if process.isRunning {
-      process.interrupt()
       kill(pid, SIGKILL)
+    }
+    // The leader may exit on SIGTERM while a descendant ignores it. Escalate
+    // the captured group independently of the leader's state.
+    if ownsProcessGroup {
       kill(-pid, SIGKILL)
     }
   }

--- a/Tests/IMsgCoreTests/AttachmentResolverProcessTests.swift
+++ b/Tests/IMsgCoreTests/AttachmentResolverProcessTests.swift
@@ -32,3 +32,52 @@ func attachmentResolverConversionTimesOutOnHungConverter() throws {
   #expect(elapsed < .seconds(5))
   #expect(elapsed >= .milliseconds(300))
 }
+
+@Test
+func attachmentResolverConversionKillsDescendantsAfterLeaderExits() throws {
+  let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+  try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+  defer { try? FileManager.default.removeItem(at: dir) }
+
+  let pidFile = dir.appendingPathComponent("pids")
+  let hung = dir.appendingPathComponent("ffmpeg")
+  try """
+  #!/bin/sh
+  trap 'exit 0' TERM
+  sh -c 'trap "" TERM; exec sleep 30' &
+  child=$!
+  printf '%s %s\n' "$$" "$child" > "\(pidFile.path)"
+  wait "$child"
+  """.write(to: hung, atomically: true, encoding: .utf8)
+  try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: hung.path)
+
+  let exitStatus = try AttachmentResolver.runConversionProcess(
+    executableURL: hung,
+    arguments: [],
+    timeout: 0.5
+  )
+  let processIDs = try String(contentsOf: pidFile, encoding: .utf8)
+    .split(separator: " ")
+    .compactMap { pid_t($0.trimmingCharacters(in: .whitespacesAndNewlines)) }
+
+  #expect(exitStatus == 128 + SIGTERM)
+  #expect(processIDs.count == 2)
+  for processID in processIDs {
+    #expect(waitForProcessExit(processID))
+  }
+}
+
+private func waitForProcessExit(_ processID: pid_t) -> Bool {
+  let clock = ContinuousClock()
+  let deadline = clock.now + .seconds(2)
+  while clock.now < deadline {
+    errno = 0
+    let result = kill(processID, 0)
+    let probeError = errno
+    if result == -1, probeError == ESRCH {
+      return true
+    }
+    Thread.sleep(forTimeInterval: 0.02)
+  }
+  return false
+}

--- a/Tests/IMsgCoreTests/AttachmentResolverProcessTests.swift
+++ b/Tests/IMsgCoreTests/AttachmentResolverProcessTests.swift
@@ -1,0 +1,34 @@
+import Darwin
+import Foundation
+import Testing
+
+@testable import IMsgCore
+
+@Test
+func attachmentResolverConversionTimesOutOnHungConverter() throws {
+  let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+  try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+  defer { try? FileManager.default.removeItem(at: dir) }
+
+  // `exec` replaces the shell with sleep so the Process PID is the sleeper
+  // itself (no orphan child after we kill the converter PID).
+  let hung = dir.appendingPathComponent("ffmpeg")
+  try """
+  #!/bin/sh
+  exec sleep 30
+  """.write(to: hung, atomically: true, encoding: .utf8)
+  try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: hung.path)
+
+  let clock = ContinuousClock()
+  let start = clock.now
+  let exitStatus = try AttachmentResolver.runConversionProcess(
+    executableURL: hung,
+    arguments: ["-i", "in", "out"],
+    timeout: 0.4
+  )
+  let elapsed = start.duration(to: clock.now)
+
+  #expect(exitStatus == 128 + SIGTERM)
+  #expect(elapsed < .seconds(5))
+  #expect(elapsed >= .milliseconds(300))
+}

--- a/Tests/IMsgCoreTests/UtilityTests.swift
+++ b/Tests/IMsgCoreTests/UtilityTests.swift
@@ -575,37 +575,3 @@ func errorDescriptionsIncludeDetails() {
   #expect(permissionDescription.contains("built-in Terminal.app") == true)
   #expect(permissionDescription.contains("stale entries") == true)
 }
-
-@Test
-func attachmentResolverConversionTimesOutOnHungConverter() throws {
-  let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
-  try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-  defer { try? FileManager.default.removeItem(at: dir) }
-
-  // `exec` replaces the shell with sleep so the Process PID is the sleeper
-  // itself (no orphan child after we kill the converter PID).
-  let hung = dir.appendingPathComponent("ffmpeg")
-  try """
-  #!/bin/sh
-  exec sleep 30
-  """.write(to: hung, atomically: true, encoding: .utf8)
-  try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: hung.path)
-
-  let clock = ContinuousClock()
-  let start = clock.now
-  let status = try AttachmentResolver.runConversionProcess(
-    executableURL: hung,
-    arguments: ["-i", "in", "out"],
-    timeout: 0.4
-  )
-  let elapsed = start.duration(to: clock.now)
-
-  #expect(status != 0)
-  #expect(elapsed < .seconds(5))
-  #expect(elapsed >= .milliseconds(300))
-
-  // No leftover sleeper: Process.terminationStatus is only valid after exit,
-  // and waitUntilExit inside the helper already reaped the child.
-  #expect(status == 128 + SIGTERM || status != 0)
-}
-

--- a/Tests/IMsgCoreTests/UtilityTests.swift
+++ b/Tests/IMsgCoreTests/UtilityTests.swift
@@ -575,3 +575,31 @@ func errorDescriptionsIncludeDetails() {
   #expect(permissionDescription.contains("built-in Terminal.app") == true)
   #expect(permissionDescription.contains("stale entries") == true)
 }
+
+@Test
+func attachmentResolverConversionTimesOutOnHungConverter() throws {
+  let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+  try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+  defer { try? FileManager.default.removeItem(at: dir) }
+
+  let hung = dir.appendingPathComponent("ffmpeg")
+  try """
+  #!/bin/sh
+  sleep 30
+  exit 0
+  """.write(to: hung, atomically: true, encoding: .utf8)
+  try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: hung.path)
+
+  let start = Date()
+  let status = try AttachmentResolver.runConversionProcess(
+    executableURL: hung,
+    arguments: ["-i", "in", "out"],
+    timeout: 0.4
+  )
+  let elapsed = Date().timeIntervalSince(start)
+
+  #expect(status != 0)
+  #expect(elapsed < 5.0)
+  #expect(elapsed >= 0.3)
+}
+

--- a/Tests/IMsgCoreTests/UtilityTests.swift
+++ b/Tests/IMsgCoreTests/UtilityTests.swift
@@ -582,24 +582,30 @@ func attachmentResolverConversionTimesOutOnHungConverter() throws {
   try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
   defer { try? FileManager.default.removeItem(at: dir) }
 
+  // `exec` replaces the shell with sleep so the Process PID is the sleeper
+  // itself (no orphan child after we kill the converter PID).
   let hung = dir.appendingPathComponent("ffmpeg")
   try """
   #!/bin/sh
-  sleep 30
-  exit 0
+  exec sleep 30
   """.write(to: hung, atomically: true, encoding: .utf8)
   try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: hung.path)
 
-  let start = Date()
+  let clock = ContinuousClock()
+  let start = clock.now
   let status = try AttachmentResolver.runConversionProcess(
     executableURL: hung,
     arguments: ["-i", "in", "out"],
     timeout: 0.4
   )
-  let elapsed = Date().timeIntervalSince(start)
+  let elapsed = start.duration(to: clock.now)
 
   #expect(status != 0)
-  #expect(elapsed < 5.0)
-  #expect(elapsed >= 0.3)
+  #expect(elapsed < .seconds(5))
+  #expect(elapsed >= .milliseconds(300))
+
+  // No leftover sleeper: Process.terminationStatus is only valid after exit,
+  // and waitUntilExit inside the helper already reaped the child.
+  #expect(status == 128 + SIGTERM || status != 0)
 }
 


### PR DESCRIPTION
## What Problem This Solves

`AttachmentResolver.runConversionProcess` started ffmpeg and blocked on `process.waitUntilExit()` with no deadline. A hung converter stalled attachment metadata resolution indefinitely when unsupported media conversion was enabled.

## Evidence

### Patch

- Bound conversion with a **monotonic** `ContinuousClock` deadline (default 60s).
- On timeout: SIGTERM, then SIGKILL of process and process-group (best-effort).
- Hung regression fixture uses `exec sleep 30` so the Process PID is the sleeper (no orphaned shell child).

### Real ffmpeg success (production conversion args)

CAF generated with ffmpeg, then converted with the same flags `AttachmentResolver` uses (`-nostdin -y -i … -c:a aac -b:a 128k`):

```console
$ ffmpeg -hide_banner -y -f lavfi -i sine=frequency=440:duration=0.5 -c:a pcm_s16le /tmp/imsg-176-proof/tone.caf
$ ffmpeg -hide_banner -nostdin -y -i /tmp/imsg-176-proof/tone.caf -c:a aac -b:a 128k /tmp/imsg-176-proof/tone.m4a
real 0.02
$ file /tmp/imsg-176-proof/tone.m4a
ISO Media, Apple iTunes ALAC/AAC-LC (.M4A) Audio
$ ls -la /tmp/imsg-176-proof/tone.m4a
-rw-r--r--  8544  tone.m4a
```

### Production helper path (AttachmentResolver.metadata + runConversionProcess)

On macOS with Homebrew ffmpeg on PATH, calling the patched `AttachmentResolver.metadata(… convertUnsupported: true)` for the generated CAF:

```console
PROOF real_ffmpeg convertedPath=.../Library/Caches/imsg/converted-attachments/tone-19053d020182e391.m4a
PROOF real_ffmpeg convertedMime=audio/mp4
PROOF hung_status=143 hung_elapsed=0.626815583 seconds
```

`143` is `128 + SIGTERM` from the timeout path; hung `exec sleep 30` returned in under 1s instead of blocking 30s.

### Hung bound (exec sleep fixture)

```console
$ # hung converter: #!/bin/sh + exec sleep 30; timeout 0.5s via production helper
hung_status=143 hung_elapsed≈0.63s process reaped
```

## Real behavior proof

- **Behavior or issue addressed:** Unbounded `waitUntilExit` on ffmpeg conversion could hang attachment metadata forever; conversions are now deadline-bounded and reaped.
- **Real environment tested:** macOS arm64, ffmpeg 8.1.2 (Homebrew `/opt/homebrew/bin/ffmpeg`), imsg branch `fix/ffmpeg-conversion-timeout` at tip after monotonic/process-group fix.
- **Exact steps or command run after this patch:**

  ```bash
  ffmpeg -y -f lavfi -i sine=frequency=440:duration=0.5 -c:a pcm_s16le tone.caf
  ffmpeg -nostdin -y -i tone.caf -c:a aac -b:a 128k tone.m4a
  # plus AttachmentResolver.metadata(convertUnsupported: true) on tone.caf
  # plus runConversionProcess(exec sleep 30, timeout: 0.5)
  ```

- **Evidence after fix:** terminal output above; real m4a produced; hung path returns status 143 in ~0.63s.
- **Observed result after fix:** Successful CAF→m4a conversion via the same args and metadata path; deliberately hung converter exits within the configured bound instead of sleeping 30s.
- **What was not tested:** Live Messages.app chat history with SIP disabled; conversions that legitimately need more than 60s.

## Test plan

- [x] `swift test --filter attachmentResolverConversionTimesOutOnHungConverter`
- [x] `swift test --filter attachmentResolverConversionDoesNotBlockOnConverterOutput`
- [x] Real ffmpeg CAF→m4a on this machine
- [x] Production helper hung path (status 143, sub-second)
