### PR TITLE
fix: restore Linux attachment resolver build

### DIFF
--- a/Sources/IMsgCore/AttachmentResolver.swift
+++ b/Sources/IMsgCore/AttachmentResolver.swift
@@ -1,5 +1,10 @@
-import Darwin
 import Foundation
+
+#if canImport(Darwin)
+  import Darwin
+#elseif canImport(Glibc)
+  import Glibc
+#endif
 
 #if canImport(CryptoKit)
   import CryptoKit


### PR DESCRIPTION
## Summary

- restore the Linux read-core build after #176 introduced an unconditional `Darwin` import
- use the same `canImport(Darwin)` / `canImport(Glibc)` platform pattern already used by `SecurePath`

## Reproduction

The two latest `main` workflow runs fail in `linux-read-core` while compiling `AttachmentResolver.swift`:

```text
error: no such module 'Darwin'
```

This also makes unrelated PRs appear red when GitHub tests their merge ref against current `main`.

## Verification

- current `main` failure: https://github.com/openclaw/imsg/actions/runs/29522912373
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer make lint`: exit 0 with 12 existing warnings and 0 serious violations
- `git diff --check`: passed
- macOS build and the affected `AttachmentResolver` process tests compile and run under Xcode; the full local suite reached 477 passing tests before two unrelated rich-link image-staging tests failed
- the PR Linux lane is the authoritative proof for the restored `Glibc` build
