### PR TITLE
chore(deps): update Swift dependencies

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,9 +9,9 @@ let package = Package(
     .executable(name: "imsg", targets: ["imsg"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/steipete/Commander.git", from: "0.2.3"),
+    .package(url: "https://github.com/steipete/Commander.git", from: "0.2.4"),
     .package(url: "https://github.com/stephencelis/SQLite.swift.git", from: "0.16.0"),
-    .package(url: "https://github.com/PhoneNumberKit/PhoneNumberKit.git", from: "5.0.4"),
+    .package(url: "https://github.com/PhoneNumberKit/PhoneNumberKit.git", from: "5.0.5"),
   ],
   targets: {
     var targets: [Target] = [


### PR DESCRIPTION
## Summary

- require Commander 0.2.4, the latest stable release
- require PhoneNumberKit 5.0.5, the latest stable release and metadata/9.0.35 refresh
- keep SQLite.swift 0.16.0, already latest stable

## Verification

- `swift package resolve`: Commander 0.2.4, PhoneNumberKit 5.0.5, SQLite.swift 0.16.0
- `make lint`: exit 0; 12 pre-existing warnings, 0 serious violations
- `make test`: 479 tests passed
- `make build`: universal CLI and bridge helper built
- `./bin/imsg --version`: `0.13.0`
- `./bin/imsg history --help`: command help rendered successfully through the real built CLI
- AutoReview: clean, no accepted/actionable findings
