### PR TITLE
fix(bridge): repair group add/remove-member on macOS 26 (vend fallback + renamed selectors)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.13.2 - Unreleased
 
+### Advanced IMCore
+- fix: restore group participant add/remove on macOS 26 by using fallback-capable handle lookup and probing both current and legacy IMChat selectors (#185, thanks @oficiallyAkshay).
+
 ## 0.13.1 - 2026-07-17
 
 ### Highlights

--- a/Sources/IMsgHelper/IMsgInjected.m
+++ b/Sources/IMsgHelper/IMsgInjected.m
@@ -5775,21 +5775,12 @@ static NSDictionary *handleAddParticipant(NSInteger requestId, NSDictionary *par
 
     Class hrClass = NSClassFromString(@"IMHandleRegistrar");
     id hr = hrClass ? [hrClass performSelector:@selector(sharedInstance)] : nil;
-    // Use the same fallback-capable vend path create-chat uses. The old code
-    // called IMHandleWithID: directly and bailed on nil — but for many reachable
-    // handles that selector returns nil while getIMHandlesForID: still resolves
-    // the handle. That one-sided shortcut is why add-member failed with
-    // "Could not vend handle" even for confirmed-iMessage numbers, while
-    // create-chat (which routes through vendIMHandle) worked. Prefer the iMessage
-    // service, fall back to any resolvable handle.
+    // Match chat-create's fallback-capable iMessage handle lookup.
     id handle = vendIMHandle(hr, address, @"iMessage", YES);
     if (!handle) return errorResponse(requestId, @"Could not vend handle");
 
     @try {
-        // IMChat's participant-invite selector has drifted across macOS versions.
-        // macOS 26 (Tahoe) exposes `inviteParticipants:reason:`; older builds used
-        // `inviteParticipantsToiMessageChat:reason:`. Both take (NSArray*, NSInteger).
-        // Probe the live IMChat and use whichever it actually responds to.
+        // macOS 26 renamed this selector; retain the older spelling as fallback.
         SEL sel = 0;
         for (NSString *name in @[@"inviteParticipants:reason:",
                                  @"inviteParticipantsToiMessageChat:reason:"]) {
@@ -5833,9 +5824,7 @@ static NSDictionary *handleRemoveParticipant(NSInteger requestId, NSDictionary *
     if (!targetHandle) return errorResponse(requestId, @"Participant not found on chat");
 
     @try {
-        // Same macOS selector drift as the invite path: macOS 26 exposes
-        // `removeParticipants:reason:`, older builds `removeParticipantsFromiMessageChat:reason:`.
-        // Both take (NSArray*, NSInteger). Probe for whichever the IMChat responds to.
+        // macOS 26 renamed this selector; retain the older spelling as fallback.
         SEL sel = 0;
         for (NSString *name in @[@"removeParticipants:reason:",
                                  @"removeParticipantsFromiMessageChat:reason:"]) {

--- a/Sources/IMsgHelper/IMsgInjected.m
+++ b/Sources/IMsgHelper/IMsgInjected.m
@@ -5775,19 +5775,29 @@ static NSDictionary *handleAddParticipant(NSInteger requestId, NSDictionary *par
 
     Class hrClass = NSClassFromString(@"IMHandleRegistrar");
     id hr = hrClass ? [hrClass performSelector:@selector(sharedInstance)] : nil;
-    id handle = (hr && [hr respondsToSelector:@selector(IMHandleWithID:)])
-        ? [hr performSelector:@selector(IMHandleWithID:) withObject:address]
-        : nil;
+    // Use the same fallback-capable vend path create-chat uses. The old code
+    // called IMHandleWithID: directly and bailed on nil — but for many reachable
+    // handles that selector returns nil while getIMHandlesForID: still resolves
+    // the handle. That one-sided shortcut is why add-member failed with
+    // "Could not vend handle" even for confirmed-iMessage numbers, while
+    // create-chat (which routes through vendIMHandle) worked. Prefer the iMessage
+    // service, fall back to any resolvable handle.
+    id handle = vendIMHandle(hr, address, @"iMessage", YES);
     if (!handle) return errorResponse(requestId, @"Could not vend handle");
 
     @try {
-        // BB-verified macOS 11+ selector: `inviteParticipantsToiMessageChat:reason:`.
-        // `addParticipantsToiMessageChat:reason:` (what we used before) is not
-        // declared on IMChat; respondsToSelector returned NO and the call
-        // failed with "selector not available".
-        SEL sel = @selector(inviteParticipantsToiMessageChat:reason:);
-        if (![chat respondsToSelector:sel]) {
-            return errorResponse(requestId, @"inviteParticipantsToiMessageChat:reason: not available");
+        // IMChat's participant-invite selector has drifted across macOS versions.
+        // macOS 26 (Tahoe) exposes `inviteParticipants:reason:`; older builds used
+        // `inviteParticipantsToiMessageChat:reason:`. Both take (NSArray*, NSInteger).
+        // Probe the live IMChat and use whichever it actually responds to.
+        SEL sel = 0;
+        for (NSString *name in @[@"inviteParticipants:reason:",
+                                 @"inviteParticipantsToiMessageChat:reason:"]) {
+            SEL cand = NSSelectorFromString(name);
+            if ([chat respondsToSelector:cand]) { sel = cand; break; }
+        }
+        if (!sel) {
+            return errorResponse(requestId, @"no participant-invite selector available on this IMChat");
         }
         NSMethodSignature *sig = [chat methodSignatureForSelector:sel];
         NSInvocation *inv = [NSInvocation invocationWithMethodSignature:sig];
@@ -5823,9 +5833,17 @@ static NSDictionary *handleRemoveParticipant(NSInteger requestId, NSDictionary *
     if (!targetHandle) return errorResponse(requestId, @"Participant not found on chat");
 
     @try {
-        SEL sel = @selector(removeParticipantsFromiMessageChat:reason:);
-        if (![chat respondsToSelector:sel]) {
-            return errorResponse(requestId, @"removeParticipantsFromiMessageChat:reason: not available");
+        // Same macOS selector drift as the invite path: macOS 26 exposes
+        // `removeParticipants:reason:`, older builds `removeParticipantsFromiMessageChat:reason:`.
+        // Both take (NSArray*, NSInteger). Probe for whichever the IMChat responds to.
+        SEL sel = 0;
+        for (NSString *name in @[@"removeParticipants:reason:",
+                                 @"removeParticipantsFromiMessageChat:reason:"]) {
+            SEL cand = NSSelectorFromString(name);
+            if ([chat respondsToSelector:cand]) { sel = cand; break; }
+        }
+        if (!sel) {
+            return errorResponse(requestId, @"no participant-remove selector available on this IMChat");
         }
         NSMethodSignature *sig = [chat methodSignatureForSelector:sel];
         NSInvocation *inv = [NSInvocation invocationWithMethodSignature:sig];

--- a/Tests/imsgTests/BridgeParticipantMutationTests.swift
+++ b/Tests/imsgTests/BridgeParticipantMutationTests.swift
@@ -1,0 +1,52 @@
+import Foundation
+import Testing
+
+@Test
+func participantMutationsUseCurrentAndLegacySelectors() throws {
+  let source = try participantMutationBridgeSource()
+  let addBody = try #require(
+    participantMutationFunctionBody(named: "handleAddParticipant", in: source))
+  let removeBody = try #require(
+    participantMutationFunctionBody(named: "handleRemoveParticipant", in: source))
+
+  #expect(addBody.contains(#"vendIMHandle(hr, address, @"iMessage", YES)"#))
+  #expect(addBody.contains(#"@"inviteParticipants:reason:""#))
+  #expect(addBody.contains(#"@"inviteParticipantsToiMessageChat:reason:""#))
+  #expect(removeBody.contains(#"@"removeParticipants:reason:""#))
+  #expect(removeBody.contains(#"@"removeParticipantsFromiMessageChat:reason:""#))
+}
+
+private func participantMutationBridgeSource() throws -> String {
+  let testFile = URL(fileURLWithPath: #filePath)
+  let repoRoot =
+    testFile
+    .deletingLastPathComponent()
+    .deletingLastPathComponent()
+    .deletingLastPathComponent()
+  let helper = repoRoot.appendingPathComponent("Sources/IMsgHelper/IMsgInjected.m")
+  return try String(contentsOf: helper, encoding: .utf8)
+}
+
+private func participantMutationFunctionBody(named name: String, in source: String) -> String? {
+  var searchStart = source.startIndex
+  while let nameRange = source.range(of: name, range: searchStart..<source.endIndex) {
+    let suffix = source[nameRange.upperBound...]
+    guard let openBrace = suffix.firstIndex(of: "{") else { return nil }
+    if let semicolon = suffix.firstIndex(of: ";"), semicolon < openBrace {
+      searchStart = nameRange.upperBound
+      continue
+    }
+    var depth = 0
+    var index = openBrace
+    while index < source.endIndex {
+      if source[index] == "{" { depth += 1 }
+      if source[index] == "}" {
+        depth -= 1
+        if depth == 0 { return String(source[openBrace...index]) }
+      }
+      index = source.index(after: index)
+    }
+    return nil
+  }
+  return nil
+}


### PR DESCRIPTION
`chat-add-member` fails with `Dylib error: Could not vend handle` for every address — including confirmed-reachable iMessage numbers — while `chat-create` works fine. Root-caused live on macOS 26.0 / imsg 0.13.1 (SIP off, bridge v2) to **two stacked bugs** in the add path, plus the same class of bug in remove.

### 1. Handle vend used a no-fallback shortcut
`handleAddParticipant` called `IMHandleRegistrar`'s `IMHandleWithID:` directly and bailed on nil. That selector returns nil for many reachable handles; `getIMHandlesForID:` still resolves them. `create-chat` already routes through the `vendIMHandle()` helper (tries both selectors + service match + fallback) — add-member took the shortcut. Fix: route add-member through the same `vendIMHandle()`.

### 2. Participant-invite selector renamed on macOS 26
Once the vend was fixed, add failed with `inviteParticipantsToiMessageChat:reason: not available`. IMChat runtime introspection on macOS 26 (Tahoe) shows the selector is now **`inviteParticipants:reason:`** (same `(NSArray*, NSInteger)` shape). Fix: probe for the current selector, fall back to the old name for older macOS.

### 3. Remove has the identical rename
`chat-remove-member` fails with `removeParticipantsFromiMessageChat:reason: not available`; the current selector is **`removeParticipants:reason:`**. Fixed the same probe-with-fallback way so remove doesn't regress the instant add works.

### Verification (live, macOS 26.0 / imsg 0.13.1)
```
imsg chat-add-member --chat 'any;+;<guid>' --address +1XXXXXXXXXX --json
=> {"address":"+1XXXXXXXXXX","chatGuid":"any;+;<guid>","added":true}
```
Participant confirmed in chat.db (chat_handle_join). `create` / `rename` / `status` unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)