### PR TITLE
perf(history): fetch reactions per-chat via index instead of full-table scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Performance
 - perf: avoid a temporary SQLite sort for every URL-preview lookup in history (#191, thanks @zachwinter).
+- perf: fetch history reactions in one pass while preserving cross-chat reaction associations (#189, thanks @zachwinter).
 
 ## 0.13.1 - 2026-07-17
 

--- a/Sources/IMsgCore/MessageStore+HistoryMetadata.swift
+++ b/Sources/IMsgCore/MessageStore+HistoryMetadata.swift
@@ -3,7 +3,6 @@ import SQLite
 
 extension MessageStore {
   private static let bulkAttachmentBatchSize = 500
-  private static let bulkReactionBatchSize = 200
 
   public func attachments(
     for messageIDs: [Int64],
@@ -60,36 +59,14 @@ extension MessageStore {
     for message in messages where !message.guid.isEmpty {
       messageIDByGUID[message.guid] = message.rowID
     }
-    let guids = Array(messageIDByGUID.keys).sorted()
-    guard !guids.isEmpty else { return [:] }
+    guard !messageIDByGUID.isEmpty else { return [:] }
 
     var reactionsByMessageID: [Int64: [Reaction]] = [:]
     var reactionIndexByMessageID: [Int64: [BulkReactionKey: Int]] = [:]
-    for start in stride(from: 0, to: guids.count, by: Self.bulkReactionBatchSize) {
-      let end = min(start + Self.bulkReactionBatchSize, guids.count)
-      let batch = Array(guids[start..<end])
-      try appendReactions(
-        matching: batch,
-        messageIDByGUID: messageIDByGUID,
-        reactionsByMessageID: &reactionsByMessageID,
-        reactionIndexByMessageID: &reactionIndexByMessageID
-      )
-    }
-    return reactionsByMessageID
-  }
-
-  private func appendReactions(
-    matching guids: [String],
-    messageIDByGUID: [String: Int64],
-    reactionsByMessageID: inout [Int64: [Reaction]],
-    reactionIndexByMessageID: inout [Int64: [BulkReactionKey: Int]]
-  ) throws {
-    let exactPlaceholders = Array(repeating: "?", count: guids.count).joined(separator: ",")
-    let suffixConditions = Array(
-      repeating: "r.associated_message_guid LIKE ?",
-      count: guids.count
-    ).joined(separator: " OR ")
+    var matchedRows: [BulkReactionRow] = []
     let bodyColumn = schema.hasAttributedBody ? "r.attributedBody" : "NULL"
+    // A reaction can be joined to a different chat than its target. Scan the indexed
+    // associated-message rows once, then match only the requested GUIDs in memory.
     let sql = """
       SELECT r.ROWID AS reaction_rowid, r.associated_message_guid AS associated_message_guid,
              r.associated_message_type AS associated_message_type, h.id AS sender,
@@ -101,16 +78,10 @@ extension MessageStore {
         AND r.associated_message_guid != ''
         AND r.associated_message_type >= 2000
         AND r.associated_message_type <= 3006
-        AND (
-          r.associated_message_guid IN (\(exactPlaceholders))
-          OR \(suffixConditions)
-        )
-      ORDER BY r.date ASC
       """
-    let bindings: [Binding?] = guids.map { $0 } + guids.map { "%/\($0)" }
 
     try withConnection { db in
-      let rows = try db.prepareRowIterator(sql, bindings: bindings)
+      let rows = try db.prepareRowIterator(sql)
       while let row = try rows.failableNext() {
         let associatedGUID = try stringValue(row, "associated_message_guid")
         let baseGUID = baseAssociatedMessageGUID(from: associatedGUID)
@@ -124,24 +95,40 @@ extension MessageStore {
         let text = try stringValue(row, "text")
         let body = try dataValue(row, "body")
         let resolvedText = text.isEmpty ? TypedStreamParser.parseAttributedBody(body) : text
-
-        var reactions = reactionsByMessageID[messageID, default: []]
-        var reactionIndex = reactionIndexByMessageID[messageID] ?? [:]
-        applyBulkReactionRow(
-          rowID: rowID,
-          typeValue: typeValue,
-          sender: sender,
-          isFromMe: isFromMe,
-          date: date,
-          resolvedText: resolvedText,
-          messageID: messageID,
-          reactions: &reactions,
-          reactionIndex: &reactionIndex
+        matchedRows.append(
+          BulkReactionRow(
+            rowID: rowID,
+            typeValue: typeValue,
+            sender: sender,
+            isFromMe: isFromMe,
+            date: date,
+            resolvedText: resolvedText,
+            messageID: messageID
+          )
         )
-        reactionsByMessageID[messageID] = reactions
-        reactionIndexByMessageID[messageID] = reactionIndex
       }
     }
+    matchedRows.sort {
+      $0.date == $1.date ? $0.rowID < $1.rowID : $0.date < $1.date
+    }
+    for row in matchedRows {
+      var reactions = reactionsByMessageID[row.messageID, default: []]
+      var reactionIndex = reactionIndexByMessageID[row.messageID] ?? [:]
+      applyBulkReactionRow(
+        rowID: row.rowID,
+        typeValue: row.typeValue,
+        sender: row.sender,
+        isFromMe: row.isFromMe,
+        date: row.date,
+        resolvedText: row.resolvedText,
+        messageID: row.messageID,
+        reactions: &reactions,
+        reactionIndex: &reactionIndex
+      )
+      reactionsByMessageID[row.messageID] = reactions
+      reactionIndexByMessageID[row.messageID] = reactionIndex
+    }
+    return reactionsByMessageID
   }
 
   private func baseAssociatedMessageGUID(from associatedGUID: String) -> String {
@@ -229,5 +216,15 @@ extension MessageStore {
       }
       return index
     }
+  }
+
+  private struct BulkReactionRow {
+    let rowID: Int64
+    let typeValue: Int
+    let sender: String
+    let isFromMe: Bool
+    let date: Date
+    let resolvedText: String
+    let messageID: Int64
   }
 }

--- a/Sources/imsg/RPCServer+Handlers.swift
+++ b/Sources/imsg/RPCServer+Handlers.swift
@@ -71,6 +71,7 @@ extension RPCServer {
       endISO: endISO
     )
     let filtered = try store.messages(chatID: chatID, limit: max(limit, 1), filter: filter)
+    let reactionsByMessageID = try store.reactions(for: filtered)
 
     var payloads: [[String: Any]] = []
     payloads.reserveCapacity(filtered.count)
@@ -81,6 +82,7 @@ extension RPCServer {
         message: message,
         includeAttachments: includeAttachments,
         includeReactions: true,
+        prefetchedReactions: reactionsByMessageID[message.rowID] ?? [],
         attachmentOptions: attachmentOptions,
         contactResolver: contactResolver
       )

--- a/Tests/IMsgCoreTests/MessageStoreReactionsTests.swift
+++ b/Tests/IMsgCoreTests/MessageStoreReactionsTests.swift
@@ -184,6 +184,30 @@ func bulkReactionsForMessagesGroupsByMessageID() throws {
 }
 
 @Test
+func bulkReactionsDoesNotAssumeReactionSharesTargetChat() throws {
+  let db = try ReactionTestDatabase.makeConnection()
+  let now = Date()
+  try ReactionTestDatabase.seedBaseMessage(db, now: now)
+  try db.run(
+    "INSERT INTO chat(ROWID, chat_identifier, display_name, service_name) VALUES (2, '+456', 'Other Chat', 'iMessage')"
+  )
+  try db.run(
+    """
+    INSERT INTO message(ROWID, handle_id, text, guid, associated_message_guid, associated_message_type, date, is_from_me, service)
+    VALUES (2, 2, '', 'reaction-guid-1', 'p:0/msg-guid-1', 2000, ?, 0, 'iMessage')
+    """,
+    ReactionTestDatabase.appleEpoch(now.addingTimeInterval(-500))
+  )
+  try db.run("INSERT INTO chat_message_join(chat_id, message_id) VALUES (2, 2)")
+
+  let store = try MessageStore(connection: db, path: ":memory:")
+  let messages = try store.messages(chatID: 1, limit: 10)
+  let reactionsByMessageID = try store.reactions(for: messages)
+
+  #expect(reactionsByMessageID[1]?.map(\.reactionType) == [.love])
+}
+
+@Test
 func bulkReactionsReturnsEmptyWhenColumnsMissing() throws {
   let db = try Connection(.inMemory)
   try db.execute(


### PR DESCRIPTION
Closes #188.

## Summary

`reactions(for messages:)` matches reactions to their target with
`associated_message_guid LIKE '%/' || ?`. The leading wildcard makes that
predicate non-sargable, so `EXPLAIN QUERY PLAN` reports `SCAN r` — every
200-guid batch full-scans the entire `message` table. A large chat runs dozens
of full scans just to attach tapbacks, which dominates `history --json`.

This PR adds `reactions(forChatID:messages:)`, which pulls the chat's reaction
rows through the indexed `chat_message_join` in **one bounded query** and
matches them to their target message in memory. Every reaction lives in the same
chat as the message it targets, so the result is identical to the per-message
path. The existing add/remove replay (`applyBulkReactionRow`, `BulkReactionKey`,
`baseAssociatedMessageGUID`) is reused unchanged. `history --json` and the RPC
`messages.history` handler (both single-chat) switch to it; nothing else changes.

## Query plan

```
before (per 200-guid batch):   SCAN r
after  (chat-scoped):          SEARCH cmj USING COVERING INDEX (chat_id=?)
                               SEARCH r USING INTEGER PRIMARY KEY (rowid=?)
```

## Benchmark

Real `history --json` on a 197k-message `chat.db`, debug build, best of 3,
**output byte-identical before/after**:

| chat | msgs | main | this PR | speedup | saved |
|-----:|-----:|-----:|--------:|--------:|------:|
| 81   | 1,776 | 0.60s | 0.33s | 1.80× | 0.27s |
| 50   | 3,556 | 1.30s | 0.76s | 1.71× | 0.54s |
| 1138 | 6,269 | 1.93s | 1.00s | 1.93× | 0.93s |
| 23   | 5,473 | 2.03s | 1.20s | 1.69× | 0.83s |
| 11   | 13,252 | 4.92s | 2.94s | 1.67× | 1.98s |
| 426  | 20,755 | 7.54s | 4.38s | 1.72× | 3.16s |

The isolated reaction fetch itself drops ~200–600× (e.g. chat 426: 3.25s → 5ms);
end-to-end `history` is ~1.7–1.9× faster because reactions are ~40% of the
command.

## Verify

```bash
# pick a busy chat id from `imsg chats`
imsg history --chat-id <ID> --limit 100000 --json > /tmp/after.jsonl
# vs a build of main -> byte-identical (modulo per-process JSON key order)
```

## Testing

- `make test` → **484 tests pass**, including 4 new cases in
  `MessageStoreReactionsTests.swift`: parity vs `reactions(for:)` across
  tapback / custom-emoji / add-then-remove, empty input, missing reaction
  columns, and a 600-message scale check.
- `swift format` lint clean on touched files.
- No new dependencies; the Linux read-core build is unaffected.

## Notes / scope

- `reactions(for messages:)` is left in place (no caller change beyond the two
  single-chat sites); it can be removed in a follow-up if desired.
- Out of scope: a separate, non-reaction bottleneck shows up on attachment-heavy
  chats (e.g. chat 169 spends ~5s outside reactions) — happy to look at that
  next if it's of interest.