### PR TITLE
perf(history): drop per-URL-preview sort in coalescing lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Advanced IMCore
 - fix: restore group participant add/remove on macOS 26 by using fallback-capable handle lookup and probing both current and legacy IMChat selectors (#185, thanks @oficiallyAkshay).
 
+### Performance
+- perf: avoid a temporary SQLite sort for every URL-preview lookup in history (#191, thanks @zachwinter).
+
 ## 0.13.1 - 2026-07-17
 
 ### Highlights

--- a/Sources/IMsgCore/MessageStore+MessageConstruction.swift
+++ b/Sources/IMsgCore/MessageStore+MessageConstruction.swift
@@ -83,7 +83,9 @@ extension MessageStore {
       WHERE m.ROWID < ?
         AND cmj.chat_id = ?
         \(reactionFilter)
-      ORDER BY m.ROWID DESC
+      -- Use the join key so SQLite can satisfy this order from the
+      -- chat_message_join(chat_id, message_id) index without a temp sort.
+      ORDER BY cmj.message_id DESC
       """
     let rows = try db.prepareRowIterator(sql, bindings: [preview.rowID, preview.chatID])
     var previews = [preview]


### PR DESCRIPTION
Closes #190.

## Summary

`precedingTextMessageForURLPreview` runs once per URL-preview balloon during
history coalescing, and ordered its lookup by `m.ROWID DESC`. The planner can't
satisfy that from the `chat_message_join(chat_id, message_id)` index, so
`EXPLAIN QUERY PLAN` reports `USE TEMP B-TREE FOR ORDER BY` — every call sorts
the chat's entire preceding-message set into a temp b-tree, even though the lazy
iterator only takes the first row. A history fetch does one such sort per
preview.

Ordering by `cmj.message_id` (equal to `m.ROWID` via the join) lets the planner
reverse-scan the covering index and drop the sort. Result order and output are
identical.

```
before:  SEARCH cmj USING COVERING INDEX (chat_id=? AND message_id<?)
         USE TEMP B-TREE FOR ORDER BY
after:   SEARCH cmj USING COVERING INDEX (chat_id=? AND message_id<?)
```

## Benchmark

197k-message `chat.db`, `history --json`, best of 3, **output byte-identical**:

| chat | url-previews | main | this PR | speedup | saved |
|-----:|-------------:|-----:|--------:|--------:|------:|
| 169  | 594 | 6.06s | 2.38s | 2.55× | 3.68s |
| 426  | 98  | 7.59s | 6.26s | 1.21× | 1.33s |
| 11   | 110 | 5.04s | 4.04s | 1.25× | 1.01s |
| 23   | 114 | 2.02s | 1.71s | 1.18× | 0.31s |

Gains scale with how many URL previews a chat contains.

## Testing

- `make test` → **480 tests pass**, including the URL-preview coalescing suites
  (`MessageStoreURLPreviewTests`, `MessageStoreConsecutiveURLPreviewTests`,
  `MessageStoreURLPreviewLimitTests`, …).
- Output verified byte-identical to `main` across several real chats.
- `swift format` clean. One-line query change; no new deps; Linux read-core
  unaffected.
