### PR TITLE
perf(output): reuse a single ISO8601DateFormatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Performance
 - perf: avoid a temporary SQLite sort for every URL-preview lookup in history (#191, thanks @zachwinter).
 - perf: fetch history reactions in one pass while preserving cross-chat reaction associations (#189, thanks @zachwinter).
+- perf: reuse ISO-8601 date formatting safely across high-volume output (#193, thanks @zachwinter).
 
 ## 0.13.1 - 2026-07-17
 

--- a/Sources/imsg/OutputModels.swift
+++ b/Sources/imsg/OutputModels.swift
@@ -320,9 +320,24 @@ struct AttachmentPayload: Codable {
 }
 
 enum CLIISO8601 {
+  private static let formatter = LockedISO8601Formatter()
+
   static func format(_ date: Date) -> String {
-    let formatter = ISO8601DateFormatter()
-    formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-    return formatter.string(from: date)
+    formatter.string(from: date)
+  }
+
+  private final class LockedISO8601Formatter: @unchecked Sendable {
+    private let lock = NSLock()
+    private let formatter: ISO8601DateFormatter = {
+      let formatter = ISO8601DateFormatter()
+      formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+      return formatter
+    }()
+
+    func string(from date: Date) -> String {
+      self.lock.lock()
+      defer { self.lock.unlock() }
+      return self.formatter.string(from: date)
+    }
   }
 }

--- a/Tests/imsgTests/UtilitiesTests.swift
+++ b/Tests/imsgTests/UtilitiesTests.swift
@@ -176,6 +176,35 @@ func outputModelsEncodeExpectedKeys() throws {
 }
 
 @Test
+func cliISO8601MatchesFoundationFormatterConcurrently() async {
+  let dates = [
+    Date(timeIntervalSince1970: 0),
+    Date(timeIntervalSince1970: 1_752_000_000.123),
+    Date(timeIntervalSince1970: -0.001),
+    Date(timeIntervalSince1970: 1_752_000_000.999_999),
+  ]
+  let oracle = ISO8601DateFormatter()
+  oracle.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+  let expected = dates.map { oracle.string(from: $0) }
+
+  let results = await withTaskGroup(of: [String].self, returning: [[String]].self) { group in
+    for _ in 0..<16 {
+      group.addTask {
+        (0..<100).flatMap { _ in dates.map(CLIISO8601.format) }
+      }
+    }
+    var results: [[String]] = []
+    for await result in group {
+      results.append(result)
+    }
+    return results
+  }
+
+  let repeatedExpected = Array(repeating: expected, count: 100).flatMap { $0 }
+  #expect(results.allSatisfy { $0 == repeatedExpected })
+}
+
+@Test
 func parsedValuesHelpers() throws {
   let values = ParsedValues(
     positional: ["first"],


### PR DESCRIPTION
Closes #192.

## Summary

`CLIISO8601.format` allocated a fresh `ISO8601DateFormatter` on every call, and
it runs once per message (and per reaction) across `history`, `stats`, `chats`,
and the RPC payload builders. Allocating the formatter — not formatting — is the
cost:

```
20,755 formats, new formatter each call : 1.43s
20,755 formats, one shared formatter    : 0.013s   (~107x)
```

Hoist it to a cached `static let`. `ISO8601DateFormatter.string(from:)` is
thread-safe, and `nonisolated(unsafe)` documents that (the type isn't `Sendable`,
unlike the `JSONEncoder` statics already in this file). Output is byte-identical.

## Benchmark

197k-message `chat.db`, best of 3, **output byte-identical** (json and plain):

| chat | mode | main | this PR | speedup |
|-----:|:-----|-----:|--------:|--------:|
| 426  | json  | 7.53s | 5.38s | 1.40× |
| 426  | plain | 3.33s | 1.75s | 1.91× |
| 11   | json  | 4.87s | 3.53s | 1.38× |
| 11   | plain | 2.19s | 1.22s | 1.80× |

## Testing

- `make test` → **480 tests pass**.
- Output verified byte-identical to `main` across `--json` and plain paths on
  several real chats.
- `swift format` clean. One-line change; no new deps; Linux read-core unaffected.
