### PR TITLE
Add --redact-codes flag to strip texted security codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Safety
 - feat: add a global `--read-only` flag (and `IMSG_READ_ONLY=1` environment variable) that deterministically refuses every write or mutation across the CLI and JSON-RPC. Read commands are unaffected; write commands exit with a dedicated code (3) and a clear message, and mutating RPC methods return a well-formed JSON-RPC error (`code: -32001`) without breaking the protocol. `imsg status` reports the active mode (`read_only` in `--json`).
+- feat: add a global `--redact-codes` flag that strips texted security/verification codes (2FA, OTP) from message text wherever it's shown (`history`, `search`, `watch`, `scheduled`, and the equivalent RPC methods), for callers that shouldn't see live codes. Heuristic derived from real SMS OTP formatting mined from a live chat.db: matches `code`/`pin`/`otp`/`passcode`/`authentication` next to a digit-and-dash token in either order, replacing only the matched token with `[redacted]`.
 
 ## 0.13.2 - 2026-07-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.13.3 - Unreleased
 
+### Safety
+- feat: add a global `--read-only` flag (and `IMSG_READ_ONLY=1` environment variable) that deterministically refuses every write or mutation across the CLI and JSON-RPC. Read commands are unaffected; write commands exit with a dedicated code (3) and a clear message, and mutating RPC methods return a well-formed JSON-RPC error (`code: -32001`) without breaking the protocol. `imsg status` reports the active mode (`read_only` in `--json`).
+
 ## 0.13.2 - 2026-07-21
 
 ### Highlights

--- a/README.md
+++ b/README.md
@@ -209,6 +209,41 @@ Read methods: `chats.list`, `messages.history`, `messages.stats`, `messages.sche
 Bridge introspection: `handles.check`. See [docs/rpc.md](docs/rpc.md) for
 request and response shapes.
 
+## Read-only mode
+
+Pass the global `--read-only` flag (or set `IMSG_READ_ONLY=1`) to
+deterministically forbid every write or mutation. It applies to all commands
+and to `imsg rpc`, so a caller can hand the CLI to an untrusted agent and know
+it cannot send, react, edit, delete, mark read, change chats, or share Name &
+Photo.
+
+```bash
+# Reads work exactly as usual.
+imsg --read-only chats
+imsg --read-only history --chat-id 1 --json
+
+# Writes are refused before anything happens (exit code 3).
+imsg --read-only send --to +15551234567 --text hi
+# -> read-only mode: 'send' performs a write or mutation and is disabled
+
+# Enforce it for every child invocation via the environment.
+IMSG_READ_ONLY=1 imsg rpc
+```
+
+The flag is accepted before or after the subcommand (`imsg --read-only send`
+and `imsg send --read-only` are equivalent), and either the flag or the
+environment variable is enough to enable it — nothing turns it back off.
+
+Under `imsg rpc --read-only`, read methods behave normally while mutating
+methods return a well-formed JSON-RPC error instead of executing, so the
+stream and protocol are never broken:
+
+```json
+{"jsonrpc":"2.0","id":"1","error":{"code":-32001,"message":"Read-only mode: mutating method disabled","data":"send"}}
+```
+
+`imsg status` reports the active mode (a `read_only` boolean in `--json`).
+
 ## Attachments
 
 `--attachments` reports metadata only. It does not copy or upload files.

--- a/README.md
+++ b/README.md
@@ -244,6 +244,37 @@ stream and protocol are never broken:
 
 `imsg status` reports the active mode (a `read_only` boolean in `--json`).
 
+## Redacting security codes
+
+Pass the global `--redact-codes` flag to strip texted security/verification
+codes (2FA, OTP, bank and vendor verification codes) out of message text
+before it's rendered or serialized — useful when handing message access to an
+AI agent or another consumer that has no business seeing a live code. It
+applies everywhere message text is shown: `history`, `search`, `watch`,
+`scheduled`, and the equivalent JSON-RPC methods.
+
+```bash
+imsg --redact-codes history --chat-id 1
+# "873934 is your Ticketmaster code." -> "[redacted] is your Ticketmaster code."
+
+imsg --redact-codes search --query verification --json
+IMSG_READ_ONLY=1 imsg --redact-codes rpc   # combine freely with --read-only
+```
+
+Like `--read-only`, the flag is accepted before or after the subcommand.
+
+This is a heuristic derived from real SMS OTP formatting, not a guarantee:
+- Matches a `code`, `pin`, `otp`, `passcode`, or `authentication` keyword next
+  to a 4–10 character digit-and-dash token, in either order — "code: 123456"
+  and "123456 is your code" (the more common, autofill-friendly format used
+  by Google, PayPal, Coinbase, and others) are both handled.
+- Only the matched token is replaced with `[redacted]`; the rest of the
+  message is left intact.
+- Alphanumeric codes (rare — e.g. "7fpa1i") are not redacted.
+- Coupon/discount codes phrased identically to OTP language (e.g. "code
+  GREATMOVE15") may also be redacted; this is treated as an acceptable,
+  low-stakes false positive.
+
 ## Attachments
 
 `--attachments` reports metadata only. It does not copy or upload files.

--- a/Sources/IMsgCore/MessageStore+Scheduled.swift
+++ b/Sources/IMsgCore/MessageStore+Scheduled.swift
@@ -39,6 +39,23 @@ public struct ScheduledMessage: Sendable, Equatable, Codable {
     self.scheduleType = scheduleType
     self.scheduleState = scheduleState
   }
+
+  /// Returns a copy with `text` passed through `SecurityCodeRedactor`.
+  public func redactingSecurityCodes() -> ScheduledMessage {
+    ScheduledMessage(
+      rowID: rowID,
+      guid: guid,
+      chatID: chatID,
+      chatIdentifier: chatIdentifier,
+      chatGUID: chatGUID,
+      chatName: chatName,
+      text: SecurityCodeRedactor.redact(text),
+      service: service,
+      scheduledAt: scheduledAt,
+      scheduleType: scheduleType,
+      scheduleState: scheduleState
+    )
+  }
 }
 
 public enum ScheduledMessagesError: Error, CustomStringConvertible, Equatable, Sendable {

--- a/Sources/IMsgCore/Models.swift
+++ b/Sources/IMsgCore/Models.swift
@@ -450,6 +450,44 @@ public struct Message: Sendable, Equatable {
       dateRead: dateRead
     )
   }
+
+  /// Returns a copy with `text` and `replyToText` passed through
+  /// `SecurityCodeRedactor`. Used by `--redact-codes` callers so a texted
+  /// security code never reaches a renderer, JSON payload, or RPC
+  /// notification.
+  public func redactingSecurityCodes() -> Message {
+    Message(
+      rowID: rowID,
+      chatID: chatID,
+      sender: sender,
+      text: SecurityCodeRedactor.redact(text),
+      date: date,
+      isFromMe: isFromMe,
+      service: service,
+      handleID: handleID,
+      attachmentsCount: attachmentsCount,
+      guid: guid,
+      routing: RoutingMetadata(
+        replyToGUID: replyToGUID,
+        threadOriginatorGUID: threadOriginatorGUID,
+        threadOriginatorPart: threadOriginatorPart,
+        destinationCallerID: destinationCallerID,
+        replyToText: SecurityCodeRedactor.redact(replyToText),
+        replyToSender: replyToSender
+      ),
+      balloonBundleID: balloonBundleID,
+      urlPreview: urlPreview,
+      reaction: ReactionMetadata(
+        isReaction: isReaction,
+        reactionType: reactionType,
+        isReactionAdd: isReactionAdd,
+        reactedToGUID: reactedToGUID
+      ),
+      poll: poll,
+      isRead: isRead,
+      dateRead: dateRead
+    )
+  }
 }
 
 public struct AttachmentMeta: Sendable, Equatable {

--- a/Sources/IMsgCore/SecurityCodeRedactor.swift
+++ b/Sources/IMsgCore/SecurityCodeRedactor.swift
@@ -1,0 +1,103 @@
+import Foundation
+
+/// Best-effort redaction of texted security/verification codes (2FA, OTP,
+/// bank and vendor verification codes) from message text, for callers that
+/// don't want a downstream consumer — an AI agent in particular — to see live
+/// codes.
+///
+/// This is a heuristic, not a guarantee. Real-world SMS OTP messages were
+/// mined from a live chat.db to derive it: the code can appear either before
+/// or after the keyword ("123456 is your code" is at least as common as
+/// "code: 123456" — it's the autofill-friendly format several major senders
+/// use), and some senders format it with internal dashes ("657-265"). It is
+/// deliberately restricted to digits and dashes, so alphanumeric codes (e.g.
+/// "7fpa1i") are not redacted — accepted as a known, rare miss.
+public enum SecurityCodeRedactor {
+  public static let placeholder = "[redacted]"
+
+  private static let keyword = "(?:code|pin|otp|passcode|authentication)"
+  private static let token = "\\d[\\d\\-]{2,8}\\d"
+  private static let windowChars = 60
+
+  // The gap between keyword and token deliberately excludes digits. Without
+  // that restriction, a real but unmatchable code right next to the keyword
+  // (e.g. the alphanumeric "7fpa1i" in "verification code is: 7fpa1i") gets
+  // skipped over by the lazy quantifier, which then keeps searching and can
+  // latch onto an unrelated digit run later in the message (e.g. a support
+  // phone number). Excluding digits from the gap means the match fails
+  // outright at that keyword occurrence instead of reaching past it.
+  private static let forward = try! NSRegularExpression(
+    pattern: "\\b\(keyword)\\b([^\\d]{0,\(windowChars)})\\b(\(token))\\b",
+    options: [.caseInsensitive, .dotMatchesLineSeparators]
+  )
+  private static let backward = try! NSRegularExpression(
+    pattern: "\\b(\(token))\\b([^\\d]{0,\(windowChars)})\\b\(keyword)\\b",
+    options: [.caseInsensitive, .dotMatchesLineSeparators]
+  )
+  private static let url = try! NSRegularExpression(
+    pattern: "https?://\\S+|www\\.\\S+",
+    options: [.caseInsensitive]
+  )
+
+  /// Returns `text` with the nearest code-shaped token next to a security-code
+  /// keyword replaced by `placeholder`, or `text` unchanged if nothing matched.
+  public static func redact(_ text: String) -> String {
+    guard let range = bestMatchRange(in: text) else { return text }
+    return (text as NSString).replacingCharacters(in: range, with: placeholder)
+  }
+
+  public static func redact(_ text: String?) -> String? {
+    guard let text else { return nil }
+    return redact(text)
+  }
+
+  private static func bestMatchRange(in text: String) -> NSRange? {
+    let ns = text as NSString
+    let full = NSRange(location: 0, length: ns.length)
+    guard full.length > 0 else { return nil }
+    let urlRanges = url.matches(in: text, options: [], range: full).map { $0.range }
+
+    // Leftmost, URL-excluded match for a given direction. Stopping at the
+    // first valid match (rather than scanning every keyword occurrence in the
+    // message) matters: several real senders repeat "code" multiple times in
+    // one message (once naming the real code, again in a decoy like "didn't
+    // request a code? call 1-800-..."), and taking the first pairing reliably
+    // lands on the real code instead of a support phone number mentioned
+    // later near a second, unrelated "code".
+    func nearestValidMatch(_ regex: NSRegularExpression, tokenGroup: Int, gapGroup: Int) -> (
+      gap: Int, range: NSRange
+    )? {
+      var offset = 0
+      while offset < full.length {
+        let searchRange = NSRange(location: offset, length: full.length - offset)
+        guard let match = regex.firstMatch(in: text, options: [], range: searchRange) else {
+          return nil
+        }
+        let tokenRange = match.range(at: tokenGroup)
+        let overlapsURL = urlRanges.contains {
+          NSIntersectionRange($0, tokenRange).length > 0
+        }
+        if overlapsURL {
+          offset = match.range.location + max(match.range.length, 1)
+          continue
+        }
+        return (match.range(at: gapGroup).length, tokenRange)
+      }
+      return nil
+    }
+
+    let fwd = nearestValidMatch(forward, tokenGroup: 2, gapGroup: 1)
+    let bwd = nearestValidMatch(backward, tokenGroup: 1, gapGroup: 2)
+
+    switch (fwd, bwd) {
+    case (let f?, let b?):
+      return f.gap <= b.gap ? f.range : b.range
+    case (let f?, nil):
+      return f.range
+    case (nil, let b?):
+      return b.range
+    case (nil, nil):
+      return nil
+    }
+  }
+}

--- a/Sources/imsg/CommandRouter.swift
+++ b/Sources/imsg/CommandRouter.swift
@@ -2,6 +2,11 @@ import Commander
 import Foundation
 
 struct CommandRouter {
+  /// Exit code returned when a write command is refused because read-only mode
+  /// is active. Distinct from the generic failure code (1) so callers can
+  /// detect a policy denial deterministically.
+  static let readOnlyExitCode: Int32 = 3
+
   let rootName = "imsg"
   let version: String
   let specs: [CommandSpec]
@@ -75,8 +80,10 @@ struct CommandRouter {
       return 0
     }
 
+    let (readOnly, resolveArgv) = CommandRouter.extractReadOnly(argv)
+
     do {
-      let invocation = try program.resolve(argv: argv)
+      let invocation = try program.resolve(argv: resolveArgv)
       guard let commandName = invocation.path.last,
         let spec = specs.first(where: { $0.name == commandName })
       else {
@@ -84,7 +91,11 @@ struct CommandRouter {
         HelpPrinter.printRoot(version: version, rootName: rootName, commands: specs)
         return 1
       }
-      let runtime = RuntimeOptions(parsedValues: invocation.parsedValues)
+      let runtime = RuntimeOptions(parsedValues: invocation.parsedValues, readOnly: readOnly)
+      if runtime.readOnly && spec.isMutating(for: invocation.parsedValues) {
+        emitReadOnlyDenial(command: commandName, json: runtime.jsonOutput)
+        return CommandRouter.readOnlyExitCode
+      }
       do {
         try await spec.run(invocation.parsedValues, runtime)
         return 0
@@ -105,6 +116,69 @@ struct CommandRouter {
     } catch {
       StdoutWriter.writeLine(String(describing: error))
       return 1
+    }
+  }
+
+  /// Determines whether read-only mode is requested and returns an argv with any
+  /// leading (pre-subcommand) `--read-only` token removed so Commander can
+  /// resolve the subcommand normally. Read-only is enabled by the
+  /// `IMSG_READ_ONLY` environment variable or by a `--read-only` token anywhere
+  /// on the command line. A `--read-only` after the subcommand is left in place
+  /// for Commander to parse as a flag (so it is not mistaken for an option
+  /// value); `RuntimeOptions` folds that parsed flag back in.
+  static func extractReadOnly(_ argv: [String]) -> (readOnly: Bool, argv: [String]) {
+    var readOnly = envReadOnly()
+    guard argv.count > 1 else { return (readOnly, argv) }
+    var result: [String] = [argv[0]]
+    var sawCommand = false
+    for token in argv.dropFirst() {
+      if !sawCommand && token == CommandSignatures.readOnlyFlagName {
+        readOnly = true
+        continue
+      }
+      if !token.hasPrefix("-") { sawCommand = true }
+      result.append(token)
+    }
+    return (readOnly, result)
+  }
+
+  static func envReadOnly() -> Bool {
+    readOnlyEnvValue(ProcessInfo.processInfo.environment["IMSG_READ_ONLY"])
+  }
+
+  /// Pure parser for the `IMSG_READ_ONLY` value, kept separate so it can be
+  /// tested without mutating the process environment.
+  static func readOnlyEnvValue(_ raw: String?) -> Bool {
+    guard let raw else { return false }
+    switch raw.trimmingCharacters(in: .whitespaces).lowercased() {
+    case "1", "true", "yes", "on":
+      return true
+    default:
+      return false
+    }
+  }
+
+  private func emitReadOnlyDenial(command: String, json: Bool) {
+    let message =
+      "read-only mode: '\(command)' performs a write or mutation and is disabled"
+    guard json else {
+      StdoutWriter.writeLine(message)
+      return
+    }
+    let payload: [String: Any] = [
+      "ok": false,
+      "error": [
+        "code": "read_only",
+        "message": message,
+        "command": command,
+      ],
+    ]
+    if let data = try? JSONSerialization.data(withJSONObject: payload, options: []),
+      let line = String(data: data, encoding: .utf8)
+    {
+      StdoutWriter.writeLine(line)
+    } else {
+      StdoutWriter.writeLine(message)
     }
   }
 

--- a/Sources/imsg/CommandRouter.swift
+++ b/Sources/imsg/CommandRouter.swift
@@ -165,13 +165,14 @@ struct CommandRouter {
       StdoutWriter.writeLine(message)
       return
     }
+    // Matches the existing `{"success": false, "error": "<message>"}` shape
+    // used elsewhere for --json command failures (see BridgeOutput.emitError);
+    // `error_code`/`command` are additive fields for programmatic detection.
     let payload: [String: Any] = [
-      "ok": false,
-      "error": [
-        "code": "read_only",
-        "message": message,
-        "command": command,
-      ],
+      "success": false,
+      "error": message,
+      "error_code": "read_only",
+      "command": command,
     ]
     if let data = try? JSONSerialization.data(withJSONObject: payload, options: []),
       let line = String(data: data, encoding: .utf8)

--- a/Sources/imsg/CommandRouter.swift
+++ b/Sources/imsg/CommandRouter.swift
@@ -80,7 +80,7 @@ struct CommandRouter {
       return 0
     }
 
-    let (readOnly, resolveArgv) = CommandRouter.extractReadOnly(argv)
+    let (readOnly, redactCodes, resolveArgv) = CommandRouter.extractLeadingGlobalFlags(argv)
 
     do {
       let invocation = try program.resolve(argv: resolveArgv)
@@ -91,7 +91,8 @@ struct CommandRouter {
         HelpPrinter.printRoot(version: version, rootName: rootName, commands: specs)
         return 1
       }
-      let runtime = RuntimeOptions(parsedValues: invocation.parsedValues, readOnly: readOnly)
+      let runtime = RuntimeOptions(
+        parsedValues: invocation.parsedValues, readOnly: readOnly, redactCodes: redactCodes)
       if runtime.readOnly && spec.isMutating(for: invocation.parsedValues) {
         emitReadOnlyDenial(command: commandName, json: runtime.jsonOutput)
         return CommandRouter.readOnlyExitCode
@@ -119,16 +120,21 @@ struct CommandRouter {
     }
   }
 
-  /// Determines whether read-only mode is requested and returns an argv with any
-  /// leading (pre-subcommand) `--read-only` token removed so Commander can
-  /// resolve the subcommand normally. Read-only is enabled by the
-  /// `IMSG_READ_ONLY` environment variable or by a `--read-only` token anywhere
-  /// on the command line. A `--read-only` after the subcommand is left in place
-  /// for Commander to parse as a flag (so it is not mistaken for an option
-  /// value); `RuntimeOptions` folds that parsed flag back in.
-  static func extractReadOnly(_ argv: [String]) -> (readOnly: Bool, argv: [String]) {
+  /// Determines whether read-only mode and/or code redaction are requested,
+  /// and returns an argv with any leading (pre-subcommand) `--read-only` /
+  /// `--redact-codes` tokens removed so Commander can resolve the subcommand
+  /// normally — its root program expects the subcommand name as the first
+  /// token, so a global flag ahead of it must be stripped here rather than
+  /// left for the per-command signature to parse. Read-only is additionally
+  /// enabled by the `IMSG_READ_ONLY` environment variable. A flag appearing
+  /// after the subcommand is left in place for Commander to parse normally;
+  /// `RuntimeOptions` folds that parsed flag back in.
+  static func extractLeadingGlobalFlags(_ argv: [String]) -> (
+    readOnly: Bool, redactCodes: Bool, argv: [String]
+  ) {
     var readOnly = envReadOnly()
-    guard argv.count > 1 else { return (readOnly, argv) }
+    var redactCodes = false
+    guard argv.count > 1 else { return (readOnly, redactCodes, argv) }
     var result: [String] = [argv[0]]
     var sawCommand = false
     for token in argv.dropFirst() {
@@ -136,10 +142,14 @@ struct CommandRouter {
         readOnly = true
         continue
       }
+      if !sawCommand && token == CommandSignatures.redactCodesFlagName {
+        redactCodes = true
+        continue
+      }
       if !token.hasPrefix("-") { sawCommand = true }
       result.append(token)
     }
-    return (readOnly, result)
+    return (readOnly, redactCodes, result)
   }
 
   static func envReadOnly() -> Bool {

--- a/Sources/imsg/CommandSignatures.swift
+++ b/Sources/imsg/CommandSignatures.swift
@@ -12,7 +12,28 @@ enum CommandSignatures {
     ]
   }
 
+  /// Global `--read-only` flag. Registered on every command so it parses in the
+  /// usual position (`imsg <cmd> --read-only`) and shows up in `--help`. It is
+  /// also detected directly from argv / `IMSG_READ_ONLY` by `CommandRouter`, so
+  /// enforcement does not depend on Commander parsing it.
+  static let readOnlyFlagLabel = "readOnly"
+  static let readOnlyFlagName = "--read-only"
+
+  static func readOnlyFlag() -> FlagDefinition {
+    .make(
+      label: readOnlyFlagLabel,
+      names: [.long("read-only")],
+      help: "Refuse any write or mutation; only read operations are permitted"
+    )
+  }
+
   static func withRuntimeFlags(_ signature: CommandSignature) -> CommandSignature {
-    signature.withStandardRuntimeFlags()
+    let base = signature.withStandardRuntimeFlags()
+    return CommandSignature(
+      arguments: base.arguments,
+      options: base.options,
+      flags: base.flags + [readOnlyFlag()],
+      optionGroups: base.optionGroups
+    )
   }
 }

--- a/Sources/imsg/CommandSignatures.swift
+++ b/Sources/imsg/CommandSignatures.swift
@@ -27,12 +27,30 @@ enum CommandSignatures {
     )
   }
 
+  /// Global `--redact-codes` flag. Registered on every command so it parses in
+  /// the usual position (`imsg <cmd> --redact-codes`). Also pre-scanned by
+  /// `CommandRouter` alongside `--read-only` so it works before the
+  /// subcommand too (`imsg --redact-codes <cmd>`) — Commander's root program
+  /// expects the subcommand name as the first token, so any global flag ahead
+  /// of it must be stripped before `program.resolve` runs, not just left for
+  /// the per-command signature to parse.
+  static let redactCodesFlagLabel = "redactCodes"
+  static let redactCodesFlagName = "--redact-codes"
+
+  static func redactCodesFlag() -> FlagDefinition {
+    .make(
+      label: redactCodesFlagLabel,
+      names: [.long("redact-codes")],
+      help: "Redact texted security/verification codes (2FA, OTP) from message text"
+    )
+  }
+
   static func withRuntimeFlags(_ signature: CommandSignature) -> CommandSignature {
     let base = signature.withStandardRuntimeFlags()
     return CommandSignature(
       arguments: base.arguments,
       options: base.options,
-      flags: base.flags + [readOnlyFlag()],
+      flags: base.flags + [readOnlyFlag(), redactCodesFlag()],
       optionGroups: base.optionGroups
     )
   }

--- a/Sources/imsg/CommandSpec.swift
+++ b/Sources/imsg/CommandSpec.swift
@@ -1,12 +1,48 @@
 import Commander
 
+/// Whether a command mutates iMessage state (sends, reactions, edits, chat
+/// changes, read receipts, …) or only reads it. Used by `--read-only` mode to
+/// deterministically refuse anything that could write.
+///
+/// The default for a `CommandSpec` is `.write` (fail-closed): a command must
+/// explicitly opt in to `.read` to be permitted in read-only mode, so any newly
+/// added command is blocked until it has been reviewed and classified.
+enum MutationPolicy: Sendable {
+  /// Never mutates state; always allowed in read-only mode.
+  case read
+  /// Mutates state; always blocked in read-only mode.
+  case write
+  /// Mutates state only for some invocations. The predicate returns `true` when
+  /// the given parsed arguments would perform a write.
+  case conditional(@Sendable (ParsedValues) -> Bool)
+}
+
 struct CommandSpec: @unchecked Sendable {
   let name: String
   let abstract: String
   let discussion: String?
   let signature: CommandSignature
   let usageExamples: [String]
+  let mutation: MutationPolicy
   let run: (ParsedValues, RuntimeOptions) async throws -> Void
+
+  init(
+    name: String,
+    abstract: String,
+    discussion: String?,
+    signature: CommandSignature,
+    usageExamples: [String],
+    mutation: MutationPolicy = .write,
+    run: @escaping (ParsedValues, RuntimeOptions) async throws -> Void
+  ) {
+    self.name = name
+    self.abstract = abstract
+    self.discussion = discussion
+    self.signature = signature
+    self.usageExamples = usageExamples
+    self.mutation = mutation
+    self.run = run
+  }
 
   var descriptor: CommandDescriptor {
     CommandDescriptor(
@@ -15,5 +51,18 @@ struct CommandSpec: @unchecked Sendable {
       discussion: discussion,
       signature: signature
     )
+  }
+
+  /// Whether this specific invocation would mutate state, honouring
+  /// `.conditional` policies that depend on the parsed arguments.
+  func isMutating(for values: ParsedValues) -> Bool {
+    switch mutation {
+    case .read:
+      return false
+    case .write:
+      return true
+    case .conditional(let predicate):
+      return predicate(values)
+    }
   }
 }

--- a/Sources/imsg/Commands/BridgeIntroCommands.swift
+++ b/Sources/imsg/Commands/BridgeIntroCommands.swift
@@ -44,7 +44,10 @@ enum SearchCommand {
     let dbPath = values.option("db") ?? MessageStore.defaultPath
     let limit = values.optionInt("limit") ?? 50
     let store = try MessageStore(path: dbPath)
-    let messages = try store.searchMessages(query: q, match: match, limit: limit)
+    var messages = try store.searchMessages(query: q, match: match, limit: limit)
+    if runtime.redactCodes {
+      messages = messages.map { $0.redactingSecurityCodes() }
+    }
     let contacts = await contactResolverFactory()
 
     if runtime.jsonOutput {

--- a/Sources/imsg/Commands/BridgeIntroCommands.swift
+++ b/Sources/imsg/Commands/BridgeIntroCommands.swift
@@ -21,7 +21,8 @@ enum SearchCommand {
         ]
       )
     ),
-    usageExamples: ["imsg search --query 'pizza tonight' --match contains"]
+    usageExamples: ["imsg search --query 'pizza tonight' --match contains"],
+    mutation: .read
   ) { values, runtime in
     try await run(values: values, runtime: runtime)
   }
@@ -95,7 +96,8 @@ enum AccountCommand {
             help: "list accounts from local chat.db history (no SIP / bridge required)")
         ]
       )),
-    usageExamples: ["imsg account", "imsg account --local"]
+    usageExamples: ["imsg account", "imsg account --local"],
+    mutation: .read
   ) { values, runtime in
     try await run(values: values, runtime: runtime)
   }
@@ -188,7 +190,8 @@ enum WhoisCommand {
       "imsg whois --address +15551234567 --type phone",
       "imsg whois --address foo@bar.com --type email",
       "imsg whois --address foo@bar.com --local",
-    ]
+    ],
+    mutation: .read
   ) { values, runtime in
     try await run(values: values, runtime: runtime)
   }
@@ -299,7 +302,8 @@ enum NicknameCommand {
     usageExamples: [
       "imsg nickname --address +15551234567",
       "imsg nickname --address +15551234567 --local",
-    ]
+    ],
+    mutation: .read
   ) { values, runtime in
     try await run(values: values, runtime: runtime)
   }

--- a/Sources/imsg/Commands/ChatBackgroundCommand.swift
+++ b/Sources/imsg/Commands/ChatBackgroundCommand.swift
@@ -20,7 +20,8 @@ enum ChatBackgroundCommand {
     ),
     usageExamples: [
       "imsg chat-background status --chat-id 42 --json"
-    ]
+    ],
+    mutation: .read
   ) { values, runtime in
     try await run(values: values, runtime: runtime)
   }

--- a/Sources/imsg/Commands/ChatsCommand.swift
+++ b/Sources/imsg/Commands/ChatsCommand.swift
@@ -23,7 +23,8 @@ enum ChatsCommand {
       "imsg chats --limit 5",
       "imsg chats --limit 5 --json",
       "imsg chats --unread-only --json",
-    ]
+    ],
+    mutation: .read
   ) { values, runtime in
     try await run(values: values, runtime: runtime)
   }

--- a/Sources/imsg/Commands/CompletionsCommand.swift
+++ b/Sources/imsg/Commands/CompletionsCommand.swift
@@ -11,7 +11,7 @@ enum CompletionsCommand {
       arguments: [
         .make(label: "shell", help: "bash, zsh, fish, or llm", isOptional: true)
       ],
-      flags: [CommandSignatures.readOnlyFlag()]
+      flags: [CommandSignatures.readOnlyFlag(), CommandSignatures.redactCodesFlag()]
     ),
     usageExamples: [
       "imsg completions bash > ~/.bash_completion.d/imsg",

--- a/Sources/imsg/Commands/CompletionsCommand.swift
+++ b/Sources/imsg/Commands/CompletionsCommand.swift
@@ -10,14 +10,16 @@ enum CompletionsCommand {
     signature: CommandSignature(
       arguments: [
         .make(label: "shell", help: "bash, zsh, fish, or llm", isOptional: true)
-      ]
+      ],
+      flags: [CommandSignatures.readOnlyFlag()]
     ),
     usageExamples: [
       "imsg completions bash > ~/.bash_completion.d/imsg",
       "imsg completions zsh > ~/.zsh/completions/_imsg",
       "imsg completions fish > ~/.config/fish/completions/imsg.fish",
       "imsg completions llm",
-    ]
+    ],
+    mutation: .read
   ) { values, _ in
     try await run(shell: values.argument(0), specs: CommandRouter().specs)
   }

--- a/Sources/imsg/Commands/GroupCommand.swift
+++ b/Sources/imsg/Commands/GroupCommand.swift
@@ -18,7 +18,8 @@ enum GroupCommand {
     usageExamples: [
       "imsg group --chat-id 1",
       "imsg group --chat-id 1 --json",
-    ]
+    ],
+    mutation: .read
   ) { values, runtime in
     guard let chatID = values.optionInt64("chatID") else {
       throw ParsedValuesError.missingOption("chat-id")

--- a/Sources/imsg/Commands/HistoryCommand.swift
+++ b/Sources/imsg/Commands/HistoryCommand.swift
@@ -63,7 +63,10 @@ enum HistoryCommand {
     )
 
     let store = try MessageStore(path: dbPath)
-    let filtered = try store.messages(chatID: chatID, limit: limit, filter: filter)
+    var filtered = try store.messages(chatID: chatID, limit: limit, filter: filter)
+    if runtime.redactCodes {
+      filtered = filtered.map { $0.redactingSecurityCodes() }
+    }
     let contacts = await contactResolverFactory()
 
     if runtime.jsonOutput {

--- a/Sources/imsg/Commands/HistoryCommand.swift
+++ b/Sources/imsg/Commands/HistoryCommand.swift
@@ -32,7 +32,8 @@ enum HistoryCommand {
     usageExamples: [
       "imsg history --chat-id 1 --limit 10 --attachments",
       "imsg history --chat-id 1 --start 2025-01-01T00:00:00Z --json",
-    ]
+    ],
+    mutation: .read
   ) { values, runtime in
     try await run(values: values, runtime: runtime)
   }

--- a/Sources/imsg/Commands/LaunchCommand.swift
+++ b/Sources/imsg/Commands/LaunchCommand.swift
@@ -33,7 +33,8 @@ enum LaunchCommand {
       "imsg launch --kill-only",
       "imsg launch --dylib /path/to/dylib",
       "imsg launch --json",
-    ]
+    ],
+    mutation: .read
   ) { values, runtime in
     try await run(values: values, runtime: runtime)
   }

--- a/Sources/imsg/Commands/NamePhotoCommand.swift
+++ b/Sources/imsg/Commands/NamePhotoCommand.swift
@@ -25,8 +25,11 @@ enum NamePhotoCommand {
       "imsg name-photo status --chat 'iMessage;-;+15551234567'",
       "imsg name-photo share --chat 'iMessage;-;+15551234567'",
     ],
-    // `status` only reads; `share` broadcasts your Name & Photo (a write).
-    mutation: .conditional { $0.argument(0) == "share" }
+    // `status` only reads; everything else (`share`, or an unrecognized
+    // action) is treated as mutating and blocked, fail-closed — `run()`'s own
+    // validation only ever executes a write for the literal "share" action,
+    // but the classification here does not lean on that.
+    mutation: .conditional { $0.argument(0) != "status" }
   ) { values, runtime in
     try await run(values: values, runtime: runtime)
   }

--- a/Sources/imsg/Commands/NamePhotoCommand.swift
+++ b/Sources/imsg/Commands/NamePhotoCommand.swift
@@ -24,7 +24,9 @@ enum NamePhotoCommand {
     usageExamples: [
       "imsg name-photo status --chat 'iMessage;-;+15551234567'",
       "imsg name-photo share --chat 'iMessage;-;+15551234567'",
-    ]
+    ],
+    // `status` only reads; `share` broadcasts your Name & Photo (a write).
+    mutation: .conditional { $0.argument(0) == "share" }
   ) { values, runtime in
     try await run(values: values, runtime: runtime)
   }

--- a/Sources/imsg/Commands/RpcCommand.swift
+++ b/Sources/imsg/Commands/RpcCommand.swift
@@ -29,6 +29,7 @@ enum RpcCommand {
       store: store,
       verbose: runtime.verbose,
       readOnly: runtime.readOnly,
+      redactCodes: runtime.redactCodes,
       contactResolver: contacts
     )
     try await server.run()

--- a/Sources/imsg/Commands/RpcCommand.swift
+++ b/Sources/imsg/Commands/RpcCommand.swift
@@ -13,7 +13,8 @@ enum RpcCommand {
     usageExamples: [
       "imsg rpc",
       "imsg rpc --db ~/Library/Messages/chat.db",
-    ]
+    ],
+    mutation: .read
   ) { values, runtime in
     let dbPath = values.option("db") ?? MessageStore.defaultPath
     let store: MessageStore
@@ -24,7 +25,12 @@ enum RpcCommand {
       throw CommandOutputEmittedError()
     }
     let contacts = await ContactResolver.create()
-    let server = RPCServer(store: store, verbose: runtime.verbose, contactResolver: contacts)
+    let server = RPCServer(
+      store: store,
+      verbose: runtime.verbose,
+      readOnly: runtime.readOnly,
+      contactResolver: contacts
+    )
     try await server.run()
   }
 }

--- a/Sources/imsg/Commands/ScheduledCommand.swift
+++ b/Sources/imsg/Commands/ScheduledCommand.swift
@@ -53,7 +53,10 @@ enum ScheduledCommand {
     } else {
       limit = 50
     }
-    let messages = try storeFactory(dbPath).scheduledMessages(limit: limit)
+    var messages = try storeFactory(dbPath).scheduledMessages(limit: limit)
+    if runtime.redactCodes {
+      messages = messages.map { $0.redactingSecurityCodes() }
+    }
     if runtime.jsonOutput {
       for message in messages {
         try JSONLines.print(ScheduledMessagePayload(message))

--- a/Sources/imsg/Commands/ScheduledCommand.swift
+++ b/Sources/imsg/Commands/ScheduledCommand.swift
@@ -19,7 +19,8 @@ enum ScheduledCommand {
     ),
     usageExamples: [
       "imsg scheduled list --json"
-    ]
+    ],
+    mutation: .read
   ) { values, runtime in
     try await run(values: values, runtime: runtime)
   }

--- a/Sources/imsg/Commands/StatsCommand.swift
+++ b/Sources/imsg/Commands/StatsCommand.swift
@@ -24,7 +24,8 @@ enum StatsCommand {
     usageExamples: [
       "imsg stats",
       "imsg stats --chat-id 42 --time-zone Europe/Vienna --media --json",
-    ]
+    ],
+    mutation: .read
   ) { values, runtime in
     try await run(values: values, runtime: runtime)
   }

--- a/Sources/imsg/Commands/StatusCommand.swift
+++ b/Sources/imsg/Commands/StatusCommand.swift
@@ -22,7 +22,8 @@ enum StatusCommand {
     usageExamples: [
       "imsg status",
       "imsg status --json",
-    ]
+    ],
+    mutation: .read
   ) { values, runtime in
     try await run(values: values, runtime: runtime)
   }
@@ -69,7 +70,8 @@ enum StatusCommand {
         bridgeVersion: bridgeVersion,
         v2Ready: v2Ready,
         selectors: selectors,
-        rpcMethods: kSupportedRPCMethods
+        rpcMethods: kSupportedRPCMethods,
+        readOnly: runtime.readOnly
       )
       try JSONLines.print(payload)
     } else {
@@ -79,6 +81,11 @@ enum StatusCommand {
       StdoutWriter.writeLine("Version:")
       StdoutWriter.writeLine("  \(IMsgVersion.current)")
       StdoutWriter.writeLine("")
+      if runtime.readOnly {
+        StdoutWriter.writeLine("Mode:")
+        StdoutWriter.writeLine("  read-only (writes and mutations are disabled)")
+        StdoutWriter.writeLine("")
+      }
       StdoutWriter.writeLine("Basic features (send, receive, history):")
       StdoutWriter.writeLine("  Available")
       StdoutWriter.writeLine("")
@@ -153,6 +160,7 @@ private struct StatusPayload: Encodable {
   let v2Ready: Bool
   let selectors: [String: Bool]
   let rpcMethods: [String]
+  let readOnly: Bool
 
   enum CodingKeys: String, CodingKey {
     case version
@@ -166,5 +174,6 @@ private struct StatusPayload: Encodable {
     case v2Ready = "v2_ready"
     case selectors
     case rpcMethods = "rpc_methods"
+    case readOnly = "read_only"
   }
 }

--- a/Sources/imsg/Commands/WatchCommand.swift
+++ b/Sources/imsg/Commands/WatchCommand.swift
@@ -121,10 +121,11 @@ enum WatchCommand {
     }
 
     let stream = streamProvider(watcher, chatID, sinceRowID, config)
-    for try await message in stream {
-      if !filter.allows(message) {
+    for try await rawMessage in stream {
+      if !filter.allows(rawMessage) {
         continue
       }
+      let message = runtime.redactCodes ? rawMessage.redactingSecurityCodes() : rawMessage
       if runtime.jsonOutput {
         let payload = try await buildMessagePayload(
           store: store,

--- a/Sources/imsg/Commands/WatchCommand.swift
+++ b/Sources/imsg/Commands/WatchCommand.swift
@@ -45,7 +45,8 @@ enum WatchCommand {
     usageExamples: [
       "imsg watch --chat-id 1 --attachments --debounce 250ms",
       "imsg watch --chat-id 1 --participants +15551234567",
-    ]
+    ],
+    mutation: .read
   ) { values, runtime in
     try await run(values: values, runtime: runtime)
   }

--- a/Sources/imsg/RPCServer+Handlers.swift
+++ b/Sources/imsg/RPCServer+Handlers.swift
@@ -70,7 +70,10 @@ extension RPCServer {
       startISO: startISO,
       endISO: endISO
     )
-    let filtered = try store.messages(chatID: chatID, limit: max(limit, 1), filter: filter)
+    var filtered = try store.messages(chatID: chatID, limit: max(limit, 1), filter: filter)
+    if redactCodes {
+      filtered = filtered.map { $0.redactingSecurityCodes() }
+    }
     let reactionsByMessageID = try store.reactions(for: filtered)
 
     var payloads: [[String: Any]] = []
@@ -125,15 +128,17 @@ extension RPCServer {
     let localAttachmentOptions = attachmentOptions
     let localIncludeReactions = includeReactions
     let localContactResolver = contactResolver
+    let localRedactCodes = redactCodes
     let task = Task {
       do {
-        for try await message in localWatcher.stream(
+        for try await rawMessage in localWatcher.stream(
           chatID: localChatID,
           sinceRowID: localSinceRowID,
           configuration: localConfig
         ) {
           if Task.isCancelled { return }
-          if !localFilter.allows(message) { continue }
+          if !localFilter.allows(rawMessage) { continue }
+          let message = localRedactCodes ? rawMessage.redactingSecurityCodes() : rawMessage
           let payload = try await buildMessagePayload(
             store: localStore,
             cache: localCache,

--- a/Sources/imsg/RPCServer+ScheduledHandlers.swift
+++ b/Sources/imsg/RPCServer+ScheduledHandlers.swift
@@ -20,7 +20,10 @@ extension RPCServer {
     }
 
     do {
-      let messages = try store.scheduledMessages(limit: limit)
+      var messages = try store.scheduledMessages(limit: limit)
+      if redactCodes {
+        messages = messages.map { $0.redactingSecurityCodes() }
+      }
       let payloads = try messages.map { message -> [String: Any] in
         let encoded = try JSONEncoder().encode(ScheduledMessagePayload(message))
         guard let payload = try JSONSerialization.jsonObject(with: encoded) as? [String: Any]

--- a/Sources/imsg/RPCServer+Support.swift
+++ b/Sources/imsg/RPCServer+Support.swift
@@ -58,6 +58,18 @@ struct RPCError: Error {
     RPCError(code: -32603, message: "Internal error", data: message)
   }
 
+  /// Returned when a mutating method is invoked while the server runs in
+  /// read-only mode. Uses a code in the JSON-RPC implementation-defined
+  /// server-error range (-32000…-32099) so the response stays a well-formed
+  /// JSON-RPC error rather than breaking the protocol.
+  static func readOnly(_ method: String) -> RPCError {
+    RPCError(
+      code: -32001,
+      message: "Read-only mode: mutating method disabled",
+      data: method
+    )
+  }
+
   func asDictionary() -> [String: Any] {
     var dict: [String: Any] = [
       "code": code,

--- a/Sources/imsg/RPCServer.swift
+++ b/Sources/imsg/RPCServer.swift
@@ -105,6 +105,9 @@ final class RPCServer {
   let verbose: Bool
   /// When true, mutating methods are refused with `RPCError.readOnly`.
   let readOnly: Bool
+  /// When true, texted security/verification codes (2FA, OTP) are redacted
+  /// from message text in results and notifications.
+  let redactCodes: Bool
   let sendMessage: (MessageSendOptions) throws -> Void
   let resolveSentMessage: SentMessageResolver
   let bridgeInvoker: BridgeInvoker
@@ -120,6 +123,7 @@ final class RPCServer {
     store: MessageStore,
     verbose: Bool,
     readOnly: Bool = false,
+    redactCodes: Bool = false,
     output: RPCOutput = RPCWriter(),
     sendMessage: @escaping (MessageSendOptions) throws -> Void = { try MessageSender().send($0) },
     resolveSentMessage: @escaping SentMessageResolver = RPCServer.resolveSentMessage,
@@ -147,6 +151,7 @@ final class RPCServer {
     self.cache = ChatCache(store: store)
     self.verbose = verbose
     self.readOnly = readOnly
+    self.redactCodes = redactCodes
     self.output = output
     self.sendMessage = sendMessage
     self.resolveSentMessage = resolveSentMessage

--- a/Sources/imsg/RPCServer.swift
+++ b/Sources/imsg/RPCServer.swift
@@ -66,6 +66,29 @@ let kSupportedRPCMethods: [String] = [
   "handles.check",
 ]
 
+/// RPC methods that only read state. Permitted when the server runs in
+/// read-only mode (`imsg rpc --read-only`).
+///
+/// Every method in `kSupportedRPCMethods` must appear in exactly one of
+/// `kReadOnlyRPCMethods` or `kMutatingRPCMethods`; a test enforces this so any
+/// newly added method is deliberately classified (fail-closed).
+let kReadOnlyRPCMethods: Set<String> = [
+  "chats.list",
+  "messages.stats",
+  "messages.history",
+  "watch.subscribe",
+  "watch.unsubscribe",
+  "messages.scheduled",
+  "message.send_status",
+  "contacts.shouldShareContact",
+  "handles.check",
+]
+
+/// RPC methods that mutate state. Refused with `RPCError.readOnly` when the
+/// server runs in read-only mode.
+let kMutatingRPCMethods: Set<String> = Set(kSupportedRPCMethods)
+  .subtracting(kReadOnlyRPCMethods)
+
 final class RPCServer {
   let store: MessageStore
   let watcher: MessageWatcher
@@ -73,6 +96,8 @@ final class RPCServer {
   let cache: ChatCache
   let subscriptions = SubscriptionStore()
   let verbose: Bool
+  /// When true, mutating methods are refused with `RPCError.readOnly`.
+  let readOnly: Bool
   let sendMessage: (MessageSendOptions) throws -> Void
   let resolveSentMessage: SentMessageResolver
   let bridgeInvoker: BridgeInvoker
@@ -87,6 +112,7 @@ final class RPCServer {
   init(
     store: MessageStore,
     verbose: Bool,
+    readOnly: Bool = false,
     output: RPCOutput = RPCWriter(),
     sendMessage: @escaping (MessageSendOptions) throws -> Void = { try MessageSender().send($0) },
     resolveSentMessage: @escaping SentMessageResolver = RPCServer.resolveSentMessage,
@@ -113,6 +139,7 @@ final class RPCServer {
     self.watcher = MessageWatcher(store: store)
     self.cache = ChatCache(store: store)
     self.verbose = verbose
+    self.readOnly = readOnly
     self.output = output
     self.sendMessage = sendMessage
     self.resolveSentMessage = resolveSentMessage
@@ -156,6 +183,11 @@ final class RPCServer {
     let method = request.method
     let params = request.params
     let id = request.id
+
+    if readOnly && kMutatingRPCMethods.contains(method) {
+      output.sendError(id: id, error: RPCError.readOnly(method))
+      return
+    }
 
     do {
       switch method {

--- a/Sources/imsg/RPCServer.swift
+++ b/Sources/imsg/RPCServer.swift
@@ -66,12 +66,17 @@ let kSupportedRPCMethods: [String] = [
   "handles.check",
 ]
 
-/// RPC methods that only read state. Permitted when the server runs in
-/// read-only mode (`imsg rpc --read-only`).
+/// RPC methods that only read state. This is the allow-list consulted by the
+/// read-only gate in `handleLine`: when the server runs in read-only mode
+/// (`imsg rpc --read-only`), only methods in this set are permitted — every
+/// other method name, known or not, is refused. Being an allow-list (rather
+/// than a block-list of mutating methods) keeps the gate fail-closed even if a
+/// future mutating method is added to the dispatch switch below but not
+/// registered in `kSupportedRPCMethods`.
 ///
 /// Every method in `kSupportedRPCMethods` must appear in exactly one of
 /// `kReadOnlyRPCMethods` or `kMutatingRPCMethods`; a test enforces this so any
-/// newly added method is deliberately classified (fail-closed).
+/// newly added method is deliberately classified.
 let kReadOnlyRPCMethods: Set<String> = [
   "chats.list",
   "messages.stats",
@@ -84,8 +89,10 @@ let kReadOnlyRPCMethods: Set<String> = [
   "handles.check",
 ]
 
-/// RPC methods that mutate state. Refused with `RPCError.readOnly` when the
-/// server runs in read-only mode.
+/// RPC methods that mutate state. Not consulted by the runtime gate directly
+/// (see `kReadOnlyRPCMethods`); kept for documentation and to let a test
+/// assert that every advertised method is classified as exactly one of read
+/// or mutating.
 let kMutatingRPCMethods: Set<String> = Set(kSupportedRPCMethods)
   .subtracting(kReadOnlyRPCMethods)
 
@@ -184,7 +191,12 @@ final class RPCServer {
     let params = request.params
     let id = request.id
 
-    if readOnly && kMutatingRPCMethods.contains(method) {
+    // Allow-list, not block-list: only methods explicitly known to be
+    // read-only pass through. This stays fail-closed even if a future
+    // mutating method is added to the switch below but someone forgets to
+    // register it in `kSupportedRPCMethods` — it is denied by omission
+    // rather than silently permitted.
+    if readOnly && !kReadOnlyRPCMethods.contains(method) {
       output.sendError(id: id, error: RPCError.readOnly(method))
       return
     }

--- a/Sources/imsg/RuntimeOptions.swift
+++ b/Sources/imsg/RuntimeOptions.swift
@@ -4,10 +4,15 @@ struct RuntimeOptions: Sendable {
   let jsonOutput: Bool
   let verbose: Bool
   let logLevel: String?
+  /// When true, the CLI refuses any write or mutation. Set by the global
+  /// `--read-only` flag or the `IMSG_READ_ONLY` environment variable.
+  let readOnly: Bool
 
-  init(parsedValues: ParsedValues) {
+  init(parsedValues: ParsedValues, readOnly: Bool = false) {
     self.jsonOutput = parsedValues.flags.contains("jsonOutput")
     self.verbose = parsedValues.flags.contains("verbose")
     self.logLevel = parsedValues.options["logLevel"]?.last
+    self.readOnly =
+      readOnly || parsedValues.flags.contains(CommandSignatures.readOnlyFlagLabel)
   }
 }

--- a/Sources/imsg/RuntimeOptions.swift
+++ b/Sources/imsg/RuntimeOptions.swift
@@ -7,12 +7,18 @@ struct RuntimeOptions: Sendable {
   /// When true, the CLI refuses any write or mutation. Set by the global
   /// `--read-only` flag or the `IMSG_READ_ONLY` environment variable.
   let readOnly: Bool
+  /// When true, texted security/verification codes (2FA, OTP) are redacted
+  /// from message text before it is rendered or serialized. Set by the
+  /// global `--redact-codes` flag.
+  let redactCodes: Bool
 
-  init(parsedValues: ParsedValues, readOnly: Bool = false) {
+  init(parsedValues: ParsedValues, readOnly: Bool = false, redactCodes: Bool = false) {
     self.jsonOutput = parsedValues.flags.contains("jsonOutput")
     self.verbose = parsedValues.flags.contains("verbose")
     self.logLevel = parsedValues.options["logLevel"]?.last
     self.readOnly =
       readOnly || parsedValues.flags.contains(CommandSignatures.readOnlyFlagLabel)
+    self.redactCodes =
+      redactCodes || parsedValues.flags.contains(CommandSignatures.redactCodesFlagLabel)
   }
 }

--- a/Tests/IMsgCoreTests/SecurityCodeRedactorTests.swift
+++ b/Tests/IMsgCoreTests/SecurityCodeRedactorTests.swift
@@ -1,0 +1,194 @@
+import Foundation
+import Testing
+
+@testable import IMsgCore
+
+// Fixtures below are real SMS text shapes mined from a live chat.db while
+// building this feature (senders redacted where irrelevant; every literal
+// code is long expired). They exist to keep the regex honest against
+// real-world formatting rather than synthetic examples.
+
+@Test
+func redactsCodeThenDigitsForward() {
+  let text = "Verification code: 8353"
+  #expect(SecurityCodeRedactor.redact(text) == "Verification code: [redacted]")
+}
+
+@Test
+func redactsDigitsThenCodeBackward() {
+  // The more common real-world shape: autofill-friendly senders (Google,
+  // PayPal, Coinbase, Schwab, Walgreens, Citi, Ticketmaster, ...) put the
+  // code first.
+  let text = "873934 is your Ticketmaster code."
+  #expect(SecurityCodeRedactor.redact(text) == "[redacted] is your Ticketmaster code.")
+}
+
+@Test
+func redactsWebOTPStylePrefix() {
+  let text = "G-164937 is your Google verification code."
+  #expect(SecurityCodeRedactor.redact(text) == "G-[redacted] is your Google verification code.")
+}
+
+@Test
+func redactsDashedCode() {
+  let text = "Your WhatsApp code is 657-265 but you can simply tap on this link to verify."
+  #expect(
+    SecurityCodeRedactor.redact(text)
+      == "Your WhatsApp code is [redacted] but you can simply tap on this link to verify.")
+}
+
+@Test
+func redactsPasscodeKeyword() {
+  let text = "USPS Identity Services: Your one time passcode is 974539."
+  #expect(
+    SecurityCodeRedactor.redact(text)
+      == "USPS Identity Services: Your one time passcode is [redacted]."
+  )
+}
+
+@Test
+func redactsAuthenticationKeyword() {
+  let text = "Use 015048 for two-factor authentication on Facebook."
+  #expect(
+    SecurityCodeRedactor.redact(text) == "Use [redacted] for two-factor authentication on Facebook."
+  )
+}
+
+@Test
+func redactsPinKeyword() {
+  let text = "Free Text Msg: enter pin 3590068 to confirm."
+  #expect(SecurityCodeRedactor.redact(text) == "Free Text Msg: enter pin [redacted] to confirm.")
+}
+
+@Test
+func doesNotRedactAlphanumericCodes() {
+  // Deliberate, accepted miss: token must be digits-and-dashes only.
+  let text =
+    "State Farm: Your verification code is: 7fpa1i. If you didn't request this, call 888-559-1922."
+  #expect(SecurityCodeRedactor.redact(text) == text)
+}
+
+@Test
+func doesNotRedactDressCodeIdiom() {
+  let text = "Do we have an update on the dress code for tomorrow?"
+  #expect(SecurityCodeRedactor.redact(text) == text)
+}
+
+@Test
+func doesNotRedactCouponCode() {
+  // Coupon codes phrased identically to OTP language are an accepted,
+  // low-stakes false-positive risk in general, but this one happens to be
+  // alphanumeric, so it's excluded by the digit-only token rule too.
+  let text = "Get up to 15% off with code GREATMOVE15."
+  #expect(SecurityCodeRedactor.redact(text) == text)
+}
+
+@Test
+func doesNotRedactTokenInsideURL() {
+  let text = "714740 is your Google Voice verification code. Don't share it. https://goo.gl/UERgF7"
+  let result = SecurityCodeRedactor.redact(text)
+  #expect(
+    result
+      == "[redacted] is your Google Voice verification code. Don't share it. https://goo.gl/UERgF7")
+  #expect(result.contains("UERgF7"))
+}
+
+@Test
+func picksRealCodeOverDecoyPhoneNumberNearRepeatedKeyword() {
+  // Real message shape: "code" is repeated, with a support phone number
+  // appearing near a later, unrelated mention. The nearest pairing to the
+  // FIRST keyword occurrence must win.
+  let text =
+    "Your E*TRADE verification code is 758227. No one from E*TRADE will contact you for this "
+    + "code unless initiated by you. Didn't request a code? Call 1-800-387-2331"
+  let result = SecurityCodeRedactor.redact(text)
+  #expect(result.contains("[redacted]"))
+  #expect(!result.contains("758227"))
+  #expect(result.contains("1-800-387-2331"))
+}
+
+@Test
+func doesNotRedactMessageWithNoCodePresent() {
+  let text = "Your Eligibility Code is available now! Present it at the front desk."
+  #expect(SecurityCodeRedactor.redact(text) == text)
+}
+
+@Test
+func doesNotRedactUnrelatedMessage() {
+  let text = "Are we still on for dinner tonight?"
+  #expect(SecurityCodeRedactor.redact(text) == text)
+}
+
+@Test
+func onlyRedactsClosestOccurrenceNotEveryDigitRun() {
+  let text = "Free Msg: Enter code 104414 to activate your Wallet. Contact us at 800-945-3114."
+  let result = SecurityCodeRedactor.redact(text)
+  #expect(
+    result == "Free Msg: Enter code [redacted] to activate your Wallet. Contact us at 800-945-3114."
+  )
+}
+
+@Test
+func replyToTextIsAlsoRedacted() {
+  let message = Message(
+    rowID: 1,
+    chatID: 1,
+    sender: "12345",
+    text: "sure, thanks",
+    date: .init(),
+    isFromMe: true,
+    service: "SMS",
+    handleID: nil,
+    attachmentsCount: 0,
+    replyToText: "662902 is your verification code."
+  )
+  let redacted = message.redactingSecurityCodes()
+  #expect(redacted.replyToText == "[redacted] is your verification code.")
+  #expect(redacted.text == "sure, thanks")
+}
+
+@Test
+func redactingPreservesAllOtherFields() {
+  let date = Date(timeIntervalSince1970: 1_700_000_000)
+  let message = Message(
+    rowID: 42,
+    chatID: 7,
+    sender: "555000",
+    text: "Your code is 123456",
+    date: date,
+    isFromMe: false,
+    service: "SMS",
+    handleID: 99,
+    attachmentsCount: 0,
+    guid: "ABC-GUID"
+  )
+  let redacted = message.redactingSecurityCodes()
+  #expect(redacted.rowID == message.rowID)
+  #expect(redacted.chatID == message.chatID)
+  #expect(redacted.sender == message.sender)
+  #expect(redacted.date == message.date)
+  #expect(redacted.isFromMe == message.isFromMe)
+  #expect(redacted.guid == message.guid)
+  #expect(redacted.text == "Your code is [redacted]")
+}
+
+@Test
+func scheduledMessageRedactionOnlyTouchesText() {
+  let scheduled = ScheduledMessage(
+    rowID: 1,
+    guid: "GUID",
+    chatID: 2,
+    chatIdentifier: "id",
+    chatGUID: "guid",
+    chatName: "name",
+    text: "here's the code: 445566",
+    service: "iMessage",
+    scheduledAt: Date(timeIntervalSince1970: 0),
+    scheduleType: 0,
+    scheduleState: 0
+  )
+  let redacted = scheduled.redactingSecurityCodes()
+  #expect(redacted.text == "here's the code: [redacted]")
+  #expect(redacted.guid == scheduled.guid)
+  #expect(redacted.chatID == scheduled.chatID)
+}

--- a/Tests/imsgTests/ReadOnlyModeCommandTests.swift
+++ b/Tests/imsgTests/ReadOnlyModeCommandTests.swift
@@ -1,0 +1,139 @@
+import Commander
+import Foundation
+import Testing
+
+@testable import IMsgCore
+@testable import imsg
+
+// MARK: - RuntimeOptions
+
+@Test
+func runtimeOptionsReadOnlyDefaultsFalse() {
+  let values = ParsedValues(positional: [], options: [:], flags: [])
+  let runtime = RuntimeOptions(parsedValues: values)
+  #expect(runtime.readOnly == false)
+}
+
+@Test
+func runtimeOptionsReadOnlyFromExplicitFlag() {
+  let values = ParsedValues(positional: [], options: [:], flags: [])
+  let runtime = RuntimeOptions(parsedValues: values, readOnly: true)
+  #expect(runtime.readOnly == true)
+}
+
+@Test
+func runtimeOptionsReadOnlyFromParsedFlag() {
+  let values = ParsedValues(
+    positional: [], options: [:], flags: [CommandSignatures.readOnlyFlagLabel])
+  let runtime = RuntimeOptions(parsedValues: values)
+  #expect(runtime.readOnly == true)
+}
+
+// MARK: - Env parsing
+
+@Test
+func readOnlyEnvValueTruthy() {
+  for raw in ["1", "true", "TRUE", "Yes", "on", " on "] {
+    #expect(CommandRouter.readOnlyEnvValue(raw) == true, "expected truthy for \(raw)")
+  }
+}
+
+@Test
+func readOnlyEnvValueFalsy() {
+  for raw in [nil, "", "0", "false", "no", "off", "banana"] {
+    #expect(CommandRouter.readOnlyEnvValue(raw) == false, "expected falsy for \(raw ?? "nil")")
+  }
+}
+
+// MARK: - argv extraction
+
+@Test
+func extractReadOnlyDropsLeadingFlagBeforeSubcommand() {
+  let (readOnly, argv) = CommandRouter.extractReadOnly(
+    ["imsg", "--read-only", "send", "--to", "x"])
+  #expect(readOnly == true)
+  // Leading global flag is removed so Commander can resolve the subcommand.
+  #expect(argv == ["imsg", "send", "--to", "x"])
+}
+
+@Test
+func extractReadOnlyKeepsFlagAfterSubcommand() {
+  let (readOnly, argv) = CommandRouter.extractReadOnly(["imsg", "send", "--read-only"])
+  // Post-subcommand flag is left for Commander to parse; RuntimeOptions folds it in.
+  #expect(argv == ["imsg", "send", "--read-only"])
+  // extractReadOnly itself only reports env / leading-flag state here.
+  #expect(readOnly == false)
+}
+
+@Test
+func extractReadOnlyLeavesPlainArgvUnchanged() {
+  let (readOnly, argv) = CommandRouter.extractReadOnly(["imsg", "chats", "--json"])
+  #expect(readOnly == false)
+  #expect(argv == ["imsg", "chats", "--json"])
+}
+
+// MARK: - Command classification
+
+@Test
+func writeCommandsReportMutating() {
+  let anyValues = ParsedValues(positional: [], options: [:], flags: [])
+  #expect(SendCommand.spec.isMutating(for: anyValues) == true)
+  #expect(ReactCommand.spec.isMutating(for: anyValues) == true)
+  #expect(ReadCommand.spec.isMutating(for: anyValues) == true)
+  #expect(TypingCommand.spec.isMutating(for: anyValues) == true)
+  #expect(ChatMarkCommand.spec.isMutating(for: anyValues) == true)
+}
+
+@Test
+func readCommandsReportNonMutating() {
+  let anyValues = ParsedValues(positional: [], options: [:], flags: [])
+  #expect(ChatsCommand.spec.isMutating(for: anyValues) == false)
+  #expect(HistoryCommand.spec.isMutating(for: anyValues) == false)
+  #expect(StatsCommand.spec.isMutating(for: anyValues) == false)
+  #expect(WatchCommand.spec.isMutating(for: anyValues) == false)
+  #expect(SearchCommand.spec.isMutating(for: anyValues) == false)
+  #expect(StatusCommand.spec.isMutating(for: anyValues) == false)
+  #expect(RpcCommand.spec.isMutating(for: anyValues) == false)
+  #expect(LaunchCommand.spec.isMutating(for: anyValues) == false)
+}
+
+@Test
+func namePhotoIsConditionallyMutating() {
+  let statusValues = ParsedValues(positional: ["status"], options: [:], flags: [])
+  let shareValues = ParsedValues(positional: ["share"], options: [:], flags: [])
+  #expect(NamePhotoCommand.spec.isMutating(for: statusValues) == false)
+  #expect(NamePhotoCommand.spec.isMutating(for: shareValues) == true)
+}
+
+// MARK: - Router gating (end to end)
+
+@Test
+func routerBlocksWriteCommandWithLeadingReadOnlyFlag() async {
+  let router = CommandRouter()
+  let (output, status) = await StdoutCapture.capture {
+    await router.run(argv: ["imsg", "--read-only", "send", "--to", "+15551234567", "--text", "hi"])
+  }
+  #expect(status == CommandRouter.readOnlyExitCode)
+  #expect(output.contains("read-only mode"))
+  #expect(output.contains("'send'"))
+}
+
+@Test
+func routerBlocksWriteCommandWithTrailingReadOnlyFlag() async {
+  let router = CommandRouter()
+  let (_, status) = await StdoutCapture.capture {
+    await router.run(argv: ["imsg", "send", "--to", "+15551234567", "--text", "hi", "--read-only"])
+  }
+  #expect(status == CommandRouter.readOnlyExitCode)
+}
+
+@Test
+func routerBlockedWriteEmitsJSONWhenRequested() async {
+  let router = CommandRouter()
+  let (output, status) = await StdoutCapture.capture {
+    await router.run(argv: ["imsg", "--read-only", "send", "--to", "+1", "--text", "hi", "--json"])
+  }
+  #expect(status == CommandRouter.readOnlyExitCode)
+  #expect(output.contains("\"code\":\"read_only\""))
+  #expect(output.contains("\"ok\":false"))
+}

--- a/Tests/imsgTests/ReadOnlyModeCommandTests.swift
+++ b/Tests/imsgTests/ReadOnlyModeCommandTests.swift
@@ -101,8 +101,14 @@ func readCommandsReportNonMutating() {
 func namePhotoIsConditionallyMutating() {
   let statusValues = ParsedValues(positional: ["status"], options: [:], flags: [])
   let shareValues = ParsedValues(positional: ["share"], options: [:], flags: [])
+  let emptyValues = ParsedValues(positional: [], options: [:], flags: [])
+  let garbageValues = ParsedValues(positional: ["bogus"], options: [:], flags: [])
   #expect(NamePhotoCommand.spec.isMutating(for: statusValues) == false)
   #expect(NamePhotoCommand.spec.isMutating(for: shareValues) == true)
+  // Fail-closed: an unrecognized or missing action is treated as mutating,
+  // not silently allowed through.
+  #expect(NamePhotoCommand.spec.isMutating(for: emptyValues) == true)
+  #expect(NamePhotoCommand.spec.isMutating(for: garbageValues) == true)
 }
 
 // MARK: - Router gating (end to end)
@@ -134,6 +140,10 @@ func routerBlockedWriteEmitsJSONWhenRequested() async {
     await router.run(argv: ["imsg", "--read-only", "send", "--to", "+1", "--text", "hi", "--json"])
   }
   #expect(status == CommandRouter.readOnlyExitCode)
-  #expect(output.contains("\"code\":\"read_only\""))
-  #expect(output.contains("\"ok\":false"))
+  // Matches the existing `{"success": false, "error": "..."}` shape used by
+  // other --json command failures (BridgeOutput.emitError), with additive
+  // fields for programmatic detection.
+  #expect(output.contains("\"success\":false"))
+  #expect(output.contains("\"error_code\":\"read_only\""))
+  #expect(output.contains("\"command\":\"send\""))
 }

--- a/Tests/imsgTests/ReadOnlyModeCommandTests.swift
+++ b/Tests/imsgTests/ReadOnlyModeCommandTests.swift
@@ -49,7 +49,7 @@ func readOnlyEnvValueFalsy() {
 
 @Test
 func extractReadOnlyDropsLeadingFlagBeforeSubcommand() {
-  let (readOnly, argv) = CommandRouter.extractReadOnly(
+  let (readOnly, _, argv) = CommandRouter.extractLeadingGlobalFlags(
     ["imsg", "--read-only", "send", "--to", "x"])
   #expect(readOnly == true)
   // Leading global flag is removed so Commander can resolve the subcommand.
@@ -58,16 +58,16 @@ func extractReadOnlyDropsLeadingFlagBeforeSubcommand() {
 
 @Test
 func extractReadOnlyKeepsFlagAfterSubcommand() {
-  let (readOnly, argv) = CommandRouter.extractReadOnly(["imsg", "send", "--read-only"])
+  let (readOnly, _, argv) = CommandRouter.extractLeadingGlobalFlags(["imsg", "send", "--read-only"])
   // Post-subcommand flag is left for Commander to parse; RuntimeOptions folds it in.
   #expect(argv == ["imsg", "send", "--read-only"])
-  // extractReadOnly itself only reports env / leading-flag state here.
+  // extractLeadingGlobalFlags itself only reports env / leading-flag state here.
   #expect(readOnly == false)
 }
 
 @Test
 func extractReadOnlyLeavesPlainArgvUnchanged() {
-  let (readOnly, argv) = CommandRouter.extractReadOnly(["imsg", "chats", "--json"])
+  let (readOnly, _, argv) = CommandRouter.extractLeadingGlobalFlags(["imsg", "chats", "--json"])
   #expect(readOnly == false)
   #expect(argv == ["imsg", "chats", "--json"])
 }

--- a/Tests/imsgTests/ReadOnlyModeRPCTests.swift
+++ b/Tests/imsgTests/ReadOnlyModeRPCTests.swift
@@ -17,7 +17,8 @@ func rpcReadOnlyRejectsMutatingMethod() async throws {
   let output = TestRPCOutput()
   let server = RPCServer(store: store, verbose: false, readOnly: true, output: output)
 
-  let line = #"{"jsonrpc":"2.0","id":"7","method":"send","params":{"to":"+15551234567","text":"hi"}}"#
+  let line =
+    #"{"jsonrpc":"2.0","id":"7","method":"send","params":{"to":"+15551234567","text":"hi"}}"#
   await server.handleLineForTesting(line)
 
   #expect(output.responses.isEmpty)

--- a/Tests/imsgTests/ReadOnlyModeRPCTests.swift
+++ b/Tests/imsgTests/ReadOnlyModeRPCTests.swift
@@ -1,0 +1,82 @@
+import Foundation
+import Testing
+
+@testable import IMsgCore
+@testable import imsg
+
+private func int64(_ value: Any?) -> Int64? {
+  if let value = value as? Int64 { return value }
+  if let value = value as? Int { return Int64(value) }
+  if let value = value as? NSNumber { return value.int64Value }
+  return nil
+}
+
+@Test
+func rpcReadOnlyRejectsMutatingMethod() async throws {
+  let store = try CommandTestDatabase.makeStoreForRPC()
+  let output = TestRPCOutput()
+  let server = RPCServer(store: store, verbose: false, readOnly: true, output: output)
+
+  let line = #"{"jsonrpc":"2.0","id":"7","method":"send","params":{"to":"+15551234567","text":"hi"}}"#
+  await server.handleLineForTesting(line)
+
+  #expect(output.responses.isEmpty)
+  #expect(output.errors.count == 1)
+  let envelope = output.errors[0]
+  // JSON-RPC framing is preserved: id is echoed.
+  #expect(envelope["id"] as? String == "7")
+  let error = envelope["error"] as? [String: Any]
+  #expect(int64(error?["code"]) == -32001)
+  #expect(error?["data"] as? String == "send")
+}
+
+@Test
+func rpcReadOnlyRejectsRepresentativeMutations() async throws {
+  let store = try CommandTestDatabase.makeStoreForRPC()
+  for method in ["tapback", "message.delete", "chats.markUnread", "group.leave", "typing", "read"] {
+    let output = TestRPCOutput()
+    let server = RPCServer(store: store, verbose: false, readOnly: true, output: output)
+    let line = #"{"jsonrpc":"2.0","id":"1","method":"\#(method)","params":{}}"#
+    await server.handleLineForTesting(line)
+    let error = output.errors.first?["error"] as? [String: Any]
+    #expect(int64(error?["code"]) == -32001, "\(method) should be refused in read-only mode")
+  }
+}
+
+@Test
+func rpcReadOnlyStillServesReadMethods() async throws {
+  let store = try CommandTestDatabase.makeStoreForRPC()
+  let output = TestRPCOutput()
+  let server = RPCServer(store: store, verbose: false, readOnly: true, output: output)
+
+  let line = #"{"jsonrpc":"2.0","id":"9","method":"chats.list","params":{"limit":10}}"#
+  await server.handleLineForTesting(line)
+
+  #expect(output.errors.isEmpty)
+  #expect(output.responses.count == 1)
+}
+
+@Test
+func rpcReadWriteServerStillSendsWhenNotReadOnly() async throws {
+  // Sanity: without read-only, a mutating method is not blocked by the gate
+  // (it may still fail for other reasons, but never with the read-only code).
+  let store = try CommandTestDatabase.makeStoreForRPC()
+  let output = TestRPCOutput()
+  let server = RPCServer(store: store, verbose: false, readOnly: false, output: output)
+
+  let line = #"{"jsonrpc":"2.0","id":"1","method":"send","params":{"to":"+1"}}"#
+  await server.handleLineForTesting(line)
+
+  let error = output.errors.first?["error"] as? [String: Any]
+  #expect(int64(error?["code"]) != -32001)
+}
+
+@Test
+func rpcMethodClassificationIsComplete() {
+  let supported = Set(kSupportedRPCMethods)
+  // Every advertised method is classified as exactly one of read or mutating.
+  #expect(kReadOnlyRPCMethods.isDisjoint(with: kMutatingRPCMethods))
+  #expect(kReadOnlyRPCMethods.union(kMutatingRPCMethods) == supported)
+  // Read methods must never be treated as mutating.
+  #expect(kReadOnlyRPCMethods.isSubset(of: supported))
+}

--- a/Tests/imsgTests/ReadOnlyModeRPCTests.swift
+++ b/Tests/imsgTests/ReadOnlyModeRPCTests.swift
@@ -73,6 +73,23 @@ func rpcReadWriteServerStillSendsWhenNotReadOnly() async throws {
 }
 
 @Test
+func rpcReadOnlyRejectsUnknownMethodRatherThanFailingOpen() async throws {
+  // The gate is an allow-list keyed on kReadOnlyRPCMethods, not a block-list
+  // keyed on known mutating methods, so it stays fail-closed even for a
+  // method that was never registered at all (e.g. a future handler added to
+  // the dispatch switch but forgotten in kSupportedRPCMethods).
+  let store = try CommandTestDatabase.makeStoreForRPC()
+  let output = TestRPCOutput()
+  let server = RPCServer(store: store, verbose: false, readOnly: true, output: output)
+
+  let line = #"{"jsonrpc":"2.0","id":"1","method":"totally.unregistered","params":{}}"#
+  await server.handleLineForTesting(line)
+
+  let error = output.errors.first?["error"] as? [String: Any]
+  #expect(int64(error?["code"]) == -32001)
+}
+
+@Test
 func rpcMethodClassificationIsComplete() {
   let supported = Set(kSupportedRPCMethods)
   // Every advertised method is classified as exactly one of read or mutating.

--- a/Tests/imsgTests/RedactCodesIntegrationTests.swift
+++ b/Tests/imsgTests/RedactCodesIntegrationTests.swift
@@ -1,0 +1,222 @@
+import Commander
+import Foundation
+import SQLite
+import Testing
+
+@testable import IMsgCore
+@testable import imsg
+
+/// Builds a minimal chat.db (one chat, one message with the given text) at a
+/// fresh temp path, for exercising `--redact-codes` through `HistoryCommand`,
+/// which opens its store from a `--db` path rather than accepting an
+/// injected store. Mirrors `CommandTestDatabase.seedRPCChat`'s shape.
+private func makeDBFileWithMessageText(_ text: String) throws -> String {
+  let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+  try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+  let path = dir.appendingPathComponent("chat.db").path
+  let db = try Connection(path)
+  try CommandTestDatabase.createSchema(db, includeChatHandleJoin: true)
+  try seedOneMessageChat(db, text: text)
+  return path
+}
+
+/// Builds a minimal in-memory store (one chat, one message with the given
+/// text), for exercising `--redact-codes` through `RPCServer`, which accepts
+/// an injected `MessageStore`.
+private func makeStoreWithMessageText(_ text: String) throws -> MessageStore {
+  let db = try Connection(.inMemory)
+  try CommandTestDatabase.createSchema(db, includeChatHandleJoin: true)
+  try seedOneMessageChat(db, text: text)
+  return try MessageStore(
+    connection: db,
+    path: ":memory:",
+    hasAttributedBody: false,
+    hasReactionColumns: false
+  )
+}
+
+private func seedOneMessageChat(_ db: Connection, text: String) throws {
+  try db.run(
+    """
+    INSERT INTO chat(
+      ROWID, chat_identifier, guid, display_name, service_name,
+      account_id, account_login, last_addressed_handle
+    )
+    VALUES (
+      1, 'iMessage;+;chat123', 'iMessage;+;chat123', 'Group Chat', 'iMessage',
+      'iMessage;+;me@icloud.com', 'me@icloud.com', 'me@icloud.com'
+    )
+    """
+  )
+  try db.run("INSERT INTO handle(ROWID, id) VALUES (1, '+123')")
+  try db.run("INSERT INTO chat_handle_join(chat_id, handle_id) VALUES (1, 1)")
+  try db.run(
+    """
+    INSERT INTO message(ROWID, handle_id, text, date, is_from_me, service)
+    VALUES (1, 1, ?, ?, 0, 'iMessage')
+    """,
+    text,
+    CommandTestDatabase.appleEpoch(Date())
+  )
+  try db.run("INSERT INTO chat_message_join(chat_id, message_id) VALUES (1, 1)")
+}
+
+private func jsonObject(from output: String) throws -> [String: Any] {
+  let line = output.split(separator: "\n").first.map(String.init) ?? ""
+  let data = Data(line.utf8)
+  return try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+}
+
+// MARK: - CLI: history
+
+@Test
+func historyCommandRedactsCodesWhenFlagSet() async throws {
+  let path = try makeDBFileWithMessageText("Your Ticketmaster code: 483920")
+  let values = ParsedValues(
+    positional: [],
+    options: ["db": [path], "chatID": ["1"], "limit": ["5"]],
+    flags: ["jsonOutput", CommandSignatures.redactCodesFlagLabel]
+  )
+  let runtime = RuntimeOptions(parsedValues: values)
+  let (output, _) = try await StdoutCapture.capture {
+    try await HistoryCommand.run(
+      values: values,
+      runtime: runtime,
+      contactResolverFactory: { NoOpContactResolver() }
+    )
+  }
+  let payload = try jsonObject(from: output)
+  #expect(payload["text"] as? String == "Your Ticketmaster code: [redacted]")
+}
+
+@Test
+func historyCommandLeavesTextAloneWithoutFlag() async throws {
+  let path = try makeDBFileWithMessageText("Your Ticketmaster code: 483920")
+  let values = ParsedValues(
+    positional: [],
+    options: ["db": [path], "chatID": ["1"], "limit": ["5"]],
+    flags: ["jsonOutput"]
+  )
+  let runtime = RuntimeOptions(parsedValues: values)
+  let (output, _) = try await StdoutCapture.capture {
+    try await HistoryCommand.run(
+      values: values,
+      runtime: runtime,
+      contactResolverFactory: { NoOpContactResolver() }
+    )
+  }
+  let payload = try jsonObject(from: output)
+  #expect(payload["text"] as? String == "Your Ticketmaster code: 483920")
+}
+
+// MARK: - RPC: messages.history
+
+@Test
+func rpcMessagesHistoryRedactsCodesWhenServerConfigured() async throws {
+  let store = try makeStoreWithMessageText("483920 is your verification code.")
+  let output = TestRPCOutput()
+  let server = RPCServer(store: store, verbose: false, redactCodes: true, output: output)
+
+  let line =
+    #"{"jsonrpc":"2.0","id":1,"method":"messages.history","params":{"chat_id":1,"limit":5}}"#
+  await server.handleLineForTesting(line)
+
+  let result = output.responses.first?["result"] as? [String: Any]
+  let messages = result?["messages"] as? [[String: Any]] ?? []
+  #expect(messages.count == 1)
+  #expect(messages.first?["text"] as? String == "[redacted] is your verification code.")
+}
+
+@Test
+func rpcMessagesHistoryLeavesTextAloneWithoutRedactCodes() async throws {
+  let store = try makeStoreWithMessageText("483920 is your verification code.")
+  let output = TestRPCOutput()
+  let server = RPCServer(store: store, verbose: false, redactCodes: false, output: output)
+
+  let line =
+    #"{"jsonrpc":"2.0","id":1,"method":"messages.history","params":{"chat_id":1,"limit":5}}"#
+  await server.handleLineForTesting(line)
+
+  let result = output.responses.first?["result"] as? [String: Any]
+  let messages = result?["messages"] as? [[String: Any]] ?? []
+  #expect(messages.first?["text"] as? String == "483920 is your verification code.")
+}
+
+// MARK: - RuntimeOptions
+
+@Test
+func runtimeOptionsRedactCodesDefaultsFalse() {
+  let values = ParsedValues(positional: [], options: [:], flags: [])
+  #expect(RuntimeOptions(parsedValues: values).redactCodes == false)
+}
+
+@Test
+func runtimeOptionsRedactCodesFromFlag() {
+  let values = ParsedValues(
+    positional: [], options: [:], flags: [CommandSignatures.redactCodesFlagLabel])
+  #expect(RuntimeOptions(parsedValues: values).redactCodes == true)
+}
+
+// MARK: - argv extraction (regression: --redact-codes before the subcommand
+// used to break parsing entirely, since only --read-only was pre-scanned)
+
+@Test
+func extractLeadingGlobalFlagsDropsRedactCodesBeforeSubcommand() {
+  let (readOnly, redactCodes, argv) = CommandRouter.extractLeadingGlobalFlags(
+    ["imsg", "--redact-codes", "history", "--chat-id", "1"])
+  #expect(readOnly == false)
+  #expect(redactCodes == true)
+  #expect(argv == ["imsg", "history", "--chat-id", "1"])
+}
+
+@Test
+func extractLeadingGlobalFlagsDropsBothFlagsBeforeSubcommand() {
+  let (readOnly, redactCodes, argv) = CommandRouter.extractLeadingGlobalFlags(
+    ["imsg", "--read-only", "--redact-codes", "history", "--chat-id", "1"])
+  #expect(readOnly == true)
+  #expect(redactCodes == true)
+  #expect(argv == ["imsg", "history", "--chat-id", "1"])
+}
+
+@Test
+func extractLeadingGlobalFlagsKeepsRedactCodesAfterSubcommand() {
+  let (_, redactCodes, argv) = CommandRouter.extractLeadingGlobalFlags(
+    ["imsg", "history", "--redact-codes"])
+  #expect(argv == ["imsg", "history", "--redact-codes"])
+  #expect(redactCodes == false)
+}
+
+@Test
+func routerParsesRedactCodesBeforeSubcommand() async throws {
+  // Regression test for the real bug: Commander's root program expects the
+  // subcommand name as argv[1]; --redact-codes previously wasn't stripped
+  // from that position, so the whole invocation failed with "requires a
+  // subcommand" instead of running history with redaction enabled.
+  let path = try makeDBFileWithMessageText("Your Ticketmaster code: 483920")
+  let router = CommandRouter()
+  let (output, status) = await StdoutCapture.capture {
+    await router.run(
+      argv: ["imsg", "--redact-codes", "history", "--db", path, "--chat-id", "1", "--json"])
+  }
+  #expect(status == 0)
+  #expect(!output.contains("requires a subcommand"))
+  let payload = try jsonObject(from: output)
+  #expect(payload["text"] as? String == "Your Ticketmaster code: [redacted]")
+}
+
+@Test
+func routerParsesBothGlobalFlagsBeforeSubcommand() async throws {
+  let path = try makeDBFileWithMessageText("Your Ticketmaster code: 483920")
+  let router = CommandRouter()
+  let (output, status) = await StdoutCapture.capture {
+    await router.run(
+      argv: [
+        "imsg", "--read-only", "--redact-codes", "history", "--db", path, "--chat-id", "1",
+        "--json",
+      ])
+  }
+  #expect(status == 0)
+  #expect(!output.contains("requires a subcommand"))
+  let payload = try jsonObject(from: output)
+  #expect(payload["text"] as? String == "Your Ticketmaster code: [redacted]")
+}

--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -22,6 +22,27 @@ description: "Long-running JSON-RPC 2.0 over stdio for chats, history, watch, an
 
 The pattern intentionally mirrors language servers and the way `imsg`'s parent gateway (Clawdis) supervises subprocesses — a single signal-style child that exits cleanly when stdin closes.
 
+## Read-only mode
+
+Start the server with `imsg rpc --read-only` (or `IMSG_READ_ONLY=1 imsg rpc`)
+to forbid every mutating method for the lifetime of the process. Read methods
+(`chats.list`, `messages.history`, `messages.stats`, `messages.scheduled`,
+`watch.subscribe`, `watch.unsubscribe`, `message.send_status`,
+`contacts.shouldShareContact`, `handles.check`) behave normally.
+
+Any mutating method (`send`, `send.rich`, `send.attachment`, `send.sticker`,
+`poll.*`, `tapback`, `typing`, `read`, `message.edit`/`unsend`/`delete`/`notifyAnyways`,
+`chats.create`/`delete`/`markUnread`, `group.*`, `contacts.shareContactCard`)
+is refused with a standard JSON-RPC error — the request `id` is echoed and the
+protocol is never broken:
+
+```json
+{"jsonrpc":"2.0","id":"1","error":{"code":-32001,"message":"Read-only mode: mutating method disabled","data":"send"}}
+```
+
+The error `code` (`-32001`) is in the JSON-RPC implementation-defined
+server-error range; `data` carries the rejected method name.
+
 ## Methods
 
 ### `chats.list`

--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -43,6 +43,16 @@ protocol is never broken:
 The error `code` (`-32001`) is in the JSON-RPC implementation-defined
 server-error range; `data` carries the rejected method name.
 
+## Redacting security codes
+
+Start the server with `imsg rpc --redact-codes` to strip texted security/
+verification codes (2FA, OTP) out of message `text` wherever it appears in
+results and notifications — `messages.history`, `watch.subscribe`, and
+`messages.scheduled`. Only the matched code token is replaced with
+`[redacted]`; the rest of the message is untouched. See the "Redacting
+security codes" section in the top-level README for how the heuristic works
+and its known limitations. Combine freely with `--read-only`.
+
 ## Methods
 
 ### `chats.list`


### PR DESCRIPTION
## Summary
- Adds a global `--redact-codes` flag (same design as `--read-only`: accepted before or after the subcommand, combinable) that redacts texted security/verification codes (2FA, OTP) from message text wherever it's shown — `history`, `search`, `watch`, `scheduled`, and the equivalent JSON-RPC methods (`messages.history`, `watch.subscribe`, `messages.scheduled`).
- The matching heuristic was derived empirically: mined 218 real OTP/PIN messages from a live chat.db (keyword search + a full sweep of every SMS short-code sender) and cross-checked against 1,589 ordinary messages to measure false positives before writing the regex. Full writeup of findings is in the commit message.
- Notable design points: matches digits before *or* after the keyword (the "123456 is your code" autofill format is at least as common as "code: 123456"), allows dash-formatted codes (WhatsApp/Cash App), intentionally limited to digit/dash tokens (alphanumeric codes are an accepted rare miss), excludes URL-embedded false positives, and is not restricted to short-code senders (Uber/Toast send real 2FA codes from ordinary phone numbers).
- Fixed a real bug found during manual smoke testing: `--redact-codes` before the subcommand broke argument parsing entirely (only `--read-only` had a pre-subcommand scan). Generalized `CommandRouter`'s flag pre-scan to cover both flags, with regression tests.

## Test plan
- [x] `swift build` clean
- [x] `swift test` — 531/531 passing
- [x] `swift format lint` clean
- [x] Manual smoke test against the real local chat.db in `--read-only` mode confirming correct redaction (Marcus, OpenTable, Ring, Apple, Premise Health, Amex, Walmart driver passcode, etc.) with no observed false positives in a live sample
- [x] Regression test for the `--redact-codes`-before-subcommand parsing bug

🤖 Generated with [Claude Code](https://claude.com/claude-code)