### PR TITLE
feat: allow suppressing poll captions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.13.4 - Unreleased
 
+### Native Polls
+- feat: let CLI and JSON-RPC callers suppress automatic native poll captions with `--no-comment` or `suppress_comment` when they already render context (#196, thanks @omarshahine).
+
 ## 0.13.3 - 2026-07-23
 
 ### Highlights

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Advanced IMCore (require `imsg launch` with SIP off — see
 - `imsg send-rich [--reply-to <guid>] [--file <path>] [--url <url>]`,
   `imsg send-multipart`, `imsg send-attachment [--reply-to <guid>]`,
   `imsg send-sticker [--attach-to <guid>] [--target-part <index>]`, `imsg tapback`
-- `imsg poll send (--chat <guid> | --chat-id <id>) --question <text> [--comment <text>] --option <text> --option <text> [--reply-to <guid>]`
+- `imsg poll send (--chat <guid> | --chat-id <id>) --question <text> [--comment <text> | --no-comment] --option <text> --option <text> [--reply-to <guid>]`
 - `imsg poll vote (--chat <guid> | --chat-id <id>) --poll <guid> (--option-id <id> | --option-index <n> | --option <text>)`
 - `imsg edit`, `imsg unsend`, `imsg delete-message`, `imsg notify-anyways`
 - `imsg chat-create`, `imsg chat-name`, `imsg chat-photo`,
@@ -158,7 +158,8 @@ attaching one to a bubble also requires `selectors.stickerAttach`.
 Messages does not render the poll payload title on the balloon, so `poll send`
 also sends a best-effort plain caption message right after the poll. The
 caption defaults to `--question`; use `--comment` when the visible text should
-be different from the stored question.
+be different from the stored question, or `--no-comment` when the caller
+already sent its own visible context and needs only the poll balloon.
 
 `react` intentionally sends only the standard tapbacks Messages.app exposes
 reliably through automation. Custom emoji tapbacks can be read from

--- a/Sources/imsg/Commands/PollCommand.swift
+++ b/Sources/imsg/Commands/PollCommand.swift
@@ -17,7 +17,8 @@ enum PollCommand {
       "comment or Send" field renders — a message with no thread metadata, not a
       threaded reply). Callers pass only `--question` and the visible caption
       appears for free; `--comment` overrides the caption text when it should
-      differ from the title.
+      differ from the title. Use `--no-comment` when the caller renders its own
+      visible context before the poll.
       """,
     signature: CommandSignatures.withRuntimeFlags(
       CommandSignature(
@@ -53,6 +54,12 @@ enum PollCommand {
           .make(
             label: "optionIndex", names: [.long("option-index")],
             help: "vote/unvote: 1-based option number to select"),
+        ],
+        flags: [
+          .make(
+            label: "noComment", names: [.long("no-comment")],
+            help: "do not echo the question as a caption after the poll"
+          )
         ]
       )
     ),
@@ -141,7 +148,7 @@ enum PollCommand {
     // knowledge of this. --comment overrides the echoed text.
     let comment = values.option("comment").flatMap { $0.isEmpty ? nil : $0 } ?? question
     let pollGuid = (data["messageGuid"] as? String) ?? ""
-    if !comment.isEmpty {
+    if !values.flag("noComment"), !comment.isEmpty {
       // Best-effort, mirroring the RPC path: the poll already delivered, so a
       // caption failure must not exit nonzero — a retry would send a duplicate
       // poll. Report the failure on stderr and leave the poll success intact.

--- a/Sources/imsg/RPCServer+BridgeMessageHandlers.swift
+++ b/Sources/imsg/RPCServer+BridgeMessageHandlers.swift
@@ -252,7 +252,9 @@ extension RPCServer {
     // needs no knowledge of this. Best-effort: the poll already succeeded, so a
     // comment failure must not fail the RPC.
     let comment = stringParam(params["comment"]).flatMap { $0.isEmpty ? nil : $0 } ?? question
-    if !comment.isEmpty {
+    let suppressComment =
+      boolParam(params["suppress_comment"] ?? params["suppressComment"]) ?? false
+    if !suppressComment, !comment.isEmpty {
       do {
         _ = try await invokeBridge(
           action: .sendMessage,

--- a/Tests/imsgTests/BridgeRichCommandTests.swift
+++ b/Tests/imsgTests/BridgeRichCommandTests.swift
@@ -394,6 +394,35 @@ func pollCommandSendUsesCommentOverrideWithoutPollGuid() async throws {
 }
 
 @Test
+func pollCommandSendCanSuppressCaption() async throws {
+  let values = ParsedValues(
+    positional: ["send"],
+    options: [
+      "chat": ["iMessage;-;+15551234567"],
+      "question": ["Dinner?"],
+      "option": ["Pizza", "Sushi"],
+    ],
+    flags: ["noComment"]
+  )
+  let runtime = RuntimeOptions(parsedValues: values)
+  var calls: [(action: BridgeAction, params: [String: Any])] = []
+
+  _ = try await StdoutCapture.capture {
+    try await PollCommand.run(
+      values: values,
+      runtime: runtime,
+      invokeBridge: { action, params in
+        calls.append((action, params))
+        return ["messageGuid": "poll-guid"]
+      }
+    )
+  }
+
+  #expect(calls.count == 1)
+  #expect(calls.first?.action == .sendPoll)
+}
+
+@Test
 func pollCommandSendResolvesChatID() async throws {
   let values = ParsedValues(
     positional: ["send"],

--- a/Tests/imsgTests/RPCBridgeMessageHandlersTests.swift
+++ b/Tests/imsgTests/RPCBridgeMessageHandlersTests.swift
@@ -218,6 +218,31 @@ func rpcPollSendUsesCommentOverrideWithoutPollGuid() async throws {
 }
 
 @Test
+func rpcPollSendCanSuppressCaption() async throws {
+  let store = try CommandTestDatabase.makeStoreForRPC()
+  let output = TestRPCOutput()
+  var calls: [(action: BridgeAction, params: [String: Any])] = []
+  let server = RPCServer(
+    store: store,
+    verbose: false,
+    output: output,
+    invokeBridge: { action, params in
+      calls.append((action, params))
+      return ["messageGuid": "poll-guid"]
+    }
+  )
+
+  await server.handleLineForTesting(
+    #"{"jsonrpc":"2.0","id":"poll","method":"poll.send","params":{"#
+      + #""chat_id":1,"question":"Dinner?","options":["Pizza","Sushi"],"#
+      + #""suppress_comment":true}}"#
+  )
+
+  #expect(calls.count == 1)
+  #expect(calls.first?.action == .sendPoll)
+}
+
+@Test
 func rpcNormalizesTapbackReactionAliases() throws {
   #expect(try normalizeBridgeReactionType("heart") == "love")
   #expect(try normalizeBridgeReactionType("thumbs-up") == "like")

--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -254,7 +254,7 @@ Result:
 
 ### Native polls
 
-`poll.send` creates a native Apple Messages Polls extension balloon through the IMCore bridge. The bridge must be injected with `imsg launch`; the AppleScript transport cannot send native extension payloads. Messages does not render the poll payload title on the balloon, so `poll.send` also sends a best-effort plain caption message right after the poll. The caption defaults to `question`; pass `comment` when the visible caption should differ from the stored poll question.
+`poll.send` creates a native Apple Messages Polls extension balloon through the IMCore bridge. The bridge must be injected with `imsg launch`; the AppleScript transport cannot send native extension payloads. Messages does not render the poll payload title on the balloon, so `poll.send` also sends a best-effort plain caption message right after the poll. The caption defaults to `question`; pass `comment` when the visible caption should differ from the stored poll question, or set `suppress_comment` to `true` when the caller already sent its own visible context and needs only the poll balloon. The camelCase alias `suppressComment` is also accepted.
 
 Request:
 
@@ -266,6 +266,12 @@ With a caption override:
 
 ```json
 {"jsonrpc":"2.0","id":"poll","method":"poll.send","params":{"chat_id":42,"question":"Dinner?","comment":"Vote by 5pm","options":["Pizza","Sushi"]}}
+```
+
+Without a caption:
+
+```json
+{"jsonrpc":"2.0","id":"poll","method":"poll.send","params":{"chat_id":42,"question":"Dinner?","suppress_comment":true,"options":["Pizza","Sushi"]}}
 ```
 
 Response:


### PR DESCRIPTION
## What changed

- add `imsg poll send --no-comment`
- add the equivalent RPC `suppress_comment` parameter, with camelCase decoding support
- preserve the existing automatic caption unless suppression is explicitly requested
- document both public controls and their preserved default behavior
- cover both CLI and RPC paths with regression tests

## Why

OpenClaw approval prompts render the full approval context before sending a native Messages poll. `imsg` currently echoes the poll question as another plain message after the poll, which duplicates the approval text and puts the controls in the wrong visual order.

This opt-in flag lets callers that already rendered their own context send only the native poll balloon. Existing callers keep the current caption behavior.

Companion to openclaw/openclaw#112714.

## Live proof

Tested on July 24, 2026 in a real iMessage conversation using the development OpenClaw gateway and injected imsg bridge v2.

- approval id: `pr112714-live-poll-9`
- command: `printf pr112714-live-proof-9`
- OpenClaw sent the complete approval details as a normal message
- imsg then sent a standalone native poll with `👍 Allow Once` and `👎 Deny`
- caption suppression produced no redundant `Approve pr112714?` follow-up message
- neither message used reply or thread metadata
- Messages stored the details as row 7480 at 15:09:13 and the poll as row 7481 at 15:09:14, confirming the intended visible order
- selecting `👎 Deny` produced the native vote event and resolved the pending approval through the gateway as `deny`
- the resulting Messages UI was manually confirmed to match the requested layout

The exact proof transcript and downstream validation are preserved in [openclaw/openclaw#112714](https://github.com/openclaw/openclaw/pull/112714#issuecomment-5075094203).

## Verification

- structured Codex autoreview: clean, no actionable findings
- documentation follow-up autoreview: clean, no actionable findings
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer make lint test`
- Swift format and SwiftLint completed with 0 serious violations
- all 484 tests passed
- GitHub macOS and Linux CI passed on the implementation commit
