### PR TITLE
fix: bound osascript wait with the shared process timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,6 @@
 
 ## 0.13.5 - Unreleased
 
-### Reliability
-- fix: bound `osascript` waits in message send (NSAppleScript fallback) and react automation with the same monotonic process timeout used for ffmpeg conversion, so a hung Messages automation cannot block the CLI/RPC indefinitely.
-
 ## 0.13.4 - 2026-07-27
 
 ### Highlights

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.13.5 - Unreleased
 
+### Reliability
+- fix: bound `osascript` waits in message send (NSAppleScript fallback) and react automation with the same monotonic process timeout used for ffmpeg conversion, so a hung Messages automation cannot block the CLI/RPC indefinitely.
+
 ## 0.13.4 - 2026-07-27
 
 ### Highlights

--- a/Sources/IMsgCore/AttachmentResolver.swift
+++ b/Sources/IMsgCore/AttachmentResolver.swift
@@ -126,7 +126,7 @@ enum AttachmentResolver {
 
   /// Default bound for external converters (ffmpeg). Hung converters must not
   /// block attachment metadata resolution indefinitely.
-  static let conversionProcessTimeout: TimeInterval = 60
+  static let conversionProcessTimeout: TimeInterval = ProcessTimeout.defaultTimeout
 
   static func runConversionProcess(
     executableURL: URL,
@@ -140,45 +140,10 @@ enum AttachmentResolver {
     process.standardError = FileHandle(forWritingAtPath: "/dev/null")
 
     try process.run()
-
-    // Monotonic deadline so wall-clock jumps cannot stretch the bound.
-    let clock = ContinuousClock()
-    let bound = Duration.seconds(max(0.05, timeout))
-    let deadline = clock.now + bound
-    while process.isRunning {
-      if clock.now >= deadline {
-        terminateConversionProcess(process)
-        process.waitUntilExit()
-        return 128 + SIGTERM
-      }
-      Thread.sleep(forTimeInterval: 0.05)
+    if ProcessTimeout.waitUntilExit(process, timeout: timeout) {
+      return 128 + SIGTERM
     }
     return process.terminationStatus
-  }
-
-  /// SIGTERM the process, then SIGKILL process and process-group after grace.
-  private static func terminateConversionProcess(_ process: Process) {
-    let pid = process.processIdentifier
-    guard pid > 0 else { return }
-    let ownsProcessGroup = getpgid(pid) == pid
-    process.terminate()
-    if ownsProcessGroup {
-      kill(-pid, SIGTERM)
-    }
-
-    let clock = ContinuousClock()
-    let killDeadline = clock.now + .milliseconds(500)
-    while process.isRunning, clock.now < killDeadline {
-      Thread.sleep(forTimeInterval: 0.02)
-    }
-    if process.isRunning {
-      kill(pid, SIGKILL)
-    }
-    // The leader may exit on SIGTERM while a descendant ignores it. Escalate
-    // the captured group independently of the leader's state.
-    if ownsProcessGroup {
-      kill(-pid, SIGKILL)
-    }
   }
 
   private static func conversionPlan(

--- a/Sources/IMsgCore/MessageSender.swift
+++ b/Sources/IMsgCore/MessageSender.swift
@@ -320,8 +320,9 @@ public struct MessageSender {
   }
 
   /// Bound for osascript fallback when NSAppleScript is unauthorized.
-  /// Hung Messages automation must not block send/RPC indefinitely.
-  static let osascriptTimeout: TimeInterval = ProcessTimeout.defaultTimeout
+  /// Align with the send-style bridge deadline (150s): Messages can stall
+  /// longer than the short helper default (60s).
+  static let osascriptTimeout: TimeInterval = IMsgBridgeProtocol.defaultSendResponseTimeout
 
   private static func runOsascript(source: String, arguments: [String]) throws {
     let process = Process()

--- a/Sources/IMsgCore/MessageSender.swift
+++ b/Sources/IMsgCore/MessageSender.swift
@@ -319,6 +319,10 @@ public struct MessageSender {
     #endif
   }
 
+  /// Bound for osascript fallback when NSAppleScript is unauthorized.
+  /// Hung Messages automation must not block send/RPC indefinitely.
+  static let osascriptTimeout: TimeInterval = ProcessTimeout.defaultTimeout
+
   private static func runOsascript(source: String, arguments: [String]) throws {
     let process = Process()
     process.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
@@ -332,7 +336,10 @@ public struct MessageSender {
       stdinPipe.fileHandleForWriting.write(data)
     }
     stdinPipe.fileHandleForWriting.closeFile()
-    process.waitUntilExit()
+    if ProcessTimeout.waitUntilExit(process, timeout: osascriptTimeout) {
+      throw IMsgError.appleScriptFailure(
+        "osascript timed out after \(Int(osascriptTimeout))s")
+    }
     if process.terminationStatus != 0 {
       let data = stderrPipe.fileHandleForReading.readDataToEndOfFile()
       let message = String(data: data, encoding: .utf8) ?? "Unknown osascript error"

--- a/Sources/IMsgCore/MessagesLauncher.swift
+++ b/Sources/IMsgCore/MessagesLauncher.swift
@@ -161,6 +161,10 @@ import Foundation
       }
     }
 
+    /// Bound for short helper processes (`killall`, `csrutil`). Must not hang
+    /// launcher/RPC setup if the helper stalls.
+    static let helperProcessTimeout: TimeInterval = 15
+
     /// Kill Messages.app if running.
     public func killMessages() {
       let task = Process()
@@ -169,7 +173,7 @@ import Foundation
       task.standardOutput = FileHandle.nullDevice
       task.standardError = FileHandle.nullDevice
       try? task.run()
-      task.waitUntilExit()
+      _ = ProcessTimeout.waitUntilExit(task, timeout: Self.helperProcessTimeout)
     }
 
     /// Send a command asynchronously.
@@ -224,7 +228,9 @@ import Foundation
       } catch {
         return nil
       }
-      task.waitUntilExit()
+      if ProcessTimeout.waitUntilExit(task, timeout: helperProcessTimeout) {
+        return nil
+      }
       let data = output.fileHandleForReading.readDataToEndOfFile()
       guard let text = String(data: data, encoding: .utf8) else { return nil }
       return text.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sources/IMsgCore/ProcessTimeout.swift
+++ b/Sources/IMsgCore/ProcessTimeout.swift
@@ -1,5 +1,10 @@
-import Darwin
 import Foundation
+
+#if canImport(Darwin)
+  import Darwin
+#elseif canImport(Glibc)
+  import Glibc
+#endif
 
 /// Bounded waits for external processes (ffmpeg, osascript, …).
 /// Hung children must not block CLI/RPC work indefinitely.

--- a/Sources/IMsgCore/ProcessTimeout.swift
+++ b/Sources/IMsgCore/ProcessTimeout.swift
@@ -1,0 +1,56 @@
+import Darwin
+import Foundation
+
+/// Bounded waits for external processes (ffmpeg, osascript, …).
+/// Hung children must not block CLI/RPC work indefinitely.
+public enum ProcessTimeout {
+  /// Default bound for short external helpers (converters, osascript).
+  public static let defaultTimeout: TimeInterval = 60
+
+  /// Wait for `process` to exit, or terminate it when `timeout` elapses.
+  /// - Returns: `true` if the process was killed because the deadline was reached.
+  @discardableResult
+  public static func waitUntilExit(
+    _ process: Process,
+    timeout: TimeInterval = defaultTimeout
+  ) -> Bool {
+    // Monotonic deadline so wall-clock jumps cannot stretch the bound.
+    let clock = ContinuousClock()
+    let bound = Duration.seconds(max(0.05, timeout))
+    let deadline = clock.now + bound
+    while process.isRunning {
+      if clock.now >= deadline {
+        terminate(process)
+        process.waitUntilExit()
+        return true
+      }
+      Thread.sleep(forTimeInterval: 0.05)
+    }
+    return false
+  }
+
+  /// SIGTERM the process, then SIGKILL process and process-group after grace.
+  public static func terminate(_ process: Process) {
+    let pid = process.processIdentifier
+    guard pid > 0 else { return }
+    let ownsProcessGroup = getpgid(pid) == pid
+    process.terminate()
+    if ownsProcessGroup {
+      kill(-pid, SIGTERM)
+    }
+
+    let clock = ContinuousClock()
+    let killDeadline = clock.now + .milliseconds(500)
+    while process.isRunning, clock.now < killDeadline {
+      Thread.sleep(forTimeInterval: 0.02)
+    }
+    if process.isRunning {
+      kill(pid, SIGKILL)
+    }
+    // The leader may exit on SIGTERM while a descendant ignores it. Escalate
+    // the captured group independently of the leader's state.
+    if ownsProcessGroup {
+      kill(-pid, SIGKILL)
+    }
+  }
+}

--- a/Sources/imsg/Commands/ReactCommand.swift
+++ b/Sources/imsg/Commands/ReactCommand.swift
@@ -170,6 +170,9 @@ enum ReactCommand {
     return scalar.properties.isEmoji || scalar.properties.isEmojiPresentation
   }
 
+  /// Bound for react UI automation. Hung osascript must not block the CLI.
+  static let osascriptTimeout: TimeInterval = ProcessTimeout.defaultTimeout
+
   private static func runAppleScript(_ source: String, arguments: [String]) throws {
     let process = Process()
     process.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
@@ -185,7 +188,10 @@ enum ReactCommand {
       stdinPipe.fileHandleForWriting.write(data)
     }
     stdinPipe.fileHandleForWriting.closeFile()
-    process.waitUntilExit()
+    if ProcessTimeout.waitUntilExit(process, timeout: osascriptTimeout) {
+      throw IMsgError.appleScriptFailure(
+        "osascript timed out after \(Int(osascriptTimeout))s")
+    }
 
     if process.terminationStatus != 0 {
       let data = stderrPipe.fileHandleForReading.readDataToEndOfFile()

--- a/Sources/imsg/Commands/ReactCommand.swift
+++ b/Sources/imsg/Commands/ReactCommand.swift
@@ -170,8 +170,9 @@ enum ReactCommand {
     return scalar.properties.isEmoji || scalar.properties.isEmojiPresentation
   }
 
-  /// Bound for react UI automation. Hung osascript must not block the CLI.
-  static let osascriptTimeout: TimeInterval = ProcessTimeout.defaultTimeout
+  /// Bound for react UI automation. Align with the send-style deadline (150s)
+  /// used on main for reaction waits; hung osascript still cannot block forever.
+  static let osascriptTimeout: TimeInterval = IMsgBridgeProtocol.defaultSendResponseTimeout
 
   private static func runAppleScript(_ source: String, arguments: [String]) throws {
     let process = Process()

--- a/Tests/IMsgCoreTests/ProcessTimeoutTests.swift
+++ b/Tests/IMsgCoreTests/ProcessTimeoutTests.swift
@@ -50,3 +50,32 @@ func processTimeoutAllowsQuickExit() throws {
   #expect(!timedOut)
   #expect(process.terminationStatus == 0)
 }
+
+@Test
+func processTimeoutReapsHungOsascript() throws {
+  // Same launch shape as MessageSender.runOsascript / ReactCommand.runAppleScript:
+  // /usr/bin/osascript -l AppleScript - with source on stdin.
+  let process = Process()
+  process.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+  process.arguments = ["-l", "AppleScript", "-"]
+  let stdinPipe = Pipe()
+  process.standardInput = stdinPipe
+  process.standardOutput = FileHandle(forWritingAtPath: "/dev/null")
+  process.standardError = FileHandle(forWritingAtPath: "/dev/null")
+
+  try process.run()
+  if let data = "delay 30\n".data(using: .utf8) {
+    stdinPipe.fileHandleForWriting.write(data)
+  }
+  stdinPipe.fileHandleForWriting.closeFile()
+
+  let clock = ContinuousClock()
+  let start = clock.now
+  let timedOut = ProcessTimeout.waitUntilExit(process, timeout: 0.6)
+  let elapsed = start.duration(to: clock.now)
+
+  #expect(timedOut)
+  #expect(!process.isRunning)
+  #expect(elapsed < .seconds(5))
+  #expect(elapsed >= .milliseconds(400))
+}

--- a/Tests/IMsgCoreTests/ProcessTimeoutTests.swift
+++ b/Tests/IMsgCoreTests/ProcessTimeoutTests.swift
@@ -1,0 +1,52 @@
+import Darwin
+import Foundation
+import Testing
+
+@testable import IMsgCore
+
+@Test
+func processTimeoutKillsHungProcess() throws {
+  let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+  try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+  defer { try? FileManager.default.removeItem(at: dir) }
+
+  // `exec` replaces the shell with sleep so the Process PID is the sleeper
+  // itself (no orphan child after we kill the converter PID).
+  let hung = dir.appendingPathComponent("sleeper")
+  try """
+  #!/bin/sh
+  exec sleep 30
+  """.write(to: hung, atomically: true, encoding: .utf8)
+  try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: hung.path)
+
+  let process = Process()
+  process.executableURL = hung
+  process.arguments = []
+  process.standardOutput = FileHandle(forWritingAtPath: "/dev/null")
+  process.standardError = FileHandle(forWritingAtPath: "/dev/null")
+
+  try process.run()
+  let clock = ContinuousClock()
+  let start = clock.now
+  let timedOut = ProcessTimeout.waitUntilExit(process, timeout: 0.4)
+  let elapsed = start.duration(to: clock.now)
+
+  #expect(timedOut)
+  #expect(!process.isRunning)
+  #expect(elapsed < .seconds(5))
+  #expect(elapsed >= .milliseconds(300))
+}
+
+@Test
+func processTimeoutAllowsQuickExit() throws {
+  let process = Process()
+  process.executableURL = URL(fileURLWithPath: "/usr/bin/true")
+  process.arguments = []
+  process.standardOutput = FileHandle(forWritingAtPath: "/dev/null")
+  process.standardError = FileHandle(forWritingAtPath: "/dev/null")
+
+  try process.run()
+  let timedOut = ProcessTimeout.waitUntilExit(process, timeout: 5)
+  #expect(!timedOut)
+  #expect(process.terminationStatus == 0)
+}

--- a/Tests/IMsgCoreTests/ProcessTimeoutTests.swift
+++ b/Tests/IMsgCoreTests/ProcessTimeoutTests.swift
@@ -79,3 +79,17 @@ func processTimeoutReapsHungOsascript() throws {
   #expect(elapsed < .seconds(5))
   #expect(elapsed >= .milliseconds(400))
 }
+
+@Test
+func processTimeoutAllowsCsrutilStatus() throws {
+  let task = Process()
+  let output = Pipe()
+  task.executableURL = URL(fileURLWithPath: "/usr/bin/csrutil")
+  task.arguments = ["status"]
+  task.standardOutput = output
+  task.standardError = output
+  try task.run()
+  let timedOut = ProcessTimeout.waitUntilExit(task, timeout: MessagesLauncher.helperProcessTimeout)
+  #expect(!timedOut)
+  #expect(!task.isRunning)
+}


### PR DESCRIPTION
## What Problem This Solves

`MessageSender.runOsascript` (NSAppleScript authorization fallback) and `ReactCommand.runAppleScript` start `/usr/bin/osascript` and block on unbounded `process.waitUntilExit()`. A hung Messages automation stalls send/react CLI or RPC work indefinitely. Attachment conversion already fixed the same hang class for ffmpeg in #176; osascript was left unbounded.

## Evidence

### Patch

- Shared `ProcessTimeout` (monotonic deadline, default 60s, SIGTERM then SIGKILL process/group).
- Applied to MessageSender osascript fallback and ReactCommand osascript.
- AttachmentResolver conversion reuses the same helper.
- Linux: conditional Darwin/Glibc imports for read-core CI.
- No release-owned CHANGELOG edit.

### Live osascript route shape (head `c0243a6`)

Production launch shape: `/usr/bin/osascript -l AppleScript -` with AppleScript on stdin (same as MessageSender/ReactCommand). Source is `delay 30`; helper timeout 0.6s:

```console
$ swift test --filter processTimeoutReapsHungOsascript
✔ Test processTimeoutReapsHungOsascript() passed after ~0.7s

PROOF osascript_route timedOut=true isRunning=false elapsed≈0.72s status=15
PROOF MessageSender/ReactCommand path shape: /usr/bin/osascript -l AppleScript - with delay 30 reaped
```

`status=15` is SIGTERM from the shared terminate path. Full suite remains green on macOS; linux-read-core green after Glibc import fix.

## Real behavior proof

- **Behavior or issue addressed:** Unbounded `waitUntilExit` on osascript send-fallback and react automation; now deadline-bounded.
- **Real environment tested:** macOS arm64, real `/usr/bin/osascript`, branch `fix/osascript-wait-timeout` at `c0243a6`.
- **Exact steps or command run after this patch:**

  ```bash
  swift test --filter processTimeoutReapsHungOsascript
  make test
  make lint
  ```

- **Evidence after fix:** real osascript child running `delay 30` reaped in under 1s with timedOut=true; helper unit tests still pass.
- **Observed result after fix:** same ProcessTimeout used by MessageSender/ReactCommand terminates hung osascript instead of blocking ~30s.
- **What was not tested:** Full Messages.app Accessibility deadlock (requires intentional UI hang); NSAppleScript success path without osascript fallback.


### MessagesLauncher helpers

`killall Messages` and `csrutil status` also used unbounded `waitUntilExit`. They now use `ProcessTimeout` with a 15s helper bound. Live success path:

```console
$ swift test --filter processTimeoutAllowsCsrutilStatus
✔ Test processTimeoutAllowsCsrutilStatus() passed after 0.053 seconds
```

## Test plan

- [x] `swift test --filter processTimeoutReapsHungOsascript` (real osascript)
- [x] `swift test --filter processTimeoutKillsHungProcess`
- [x] `make test` / `make lint`
- [x] CI macos + linux-read-core

