### PR TITLE
chore(deps): refresh toolchain and workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
   macos:
     runs-on: macos-15
     env:
-      SWIFTLINT_VERSION: 0.64.1
+      SWIFTLINT_VERSION: 0.65.0
     steps:
       - uses: actions/checkout@v7
       - name: Swift version
@@ -29,7 +29,7 @@ jobs:
 
   linux-read-core:
     runs-on: ubuntu-latest
-    container: swift:6.2.4-noble
+    container: swift:6.3.3-noble
     steps:
       - uses: actions/checkout@v7
       - name: Swift version

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -31,7 +31,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Check out
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,7 @@ jobs:
 
   linux-release:
     runs-on: ubuntu-latest
-    container: swift:6.2.4-noble
+    container: swift:6.3.3-noble
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.13.5 - Unreleased
 
+### Dependencies
+- chore: update PhoneNumberKit, SwiftLint, the Linux Swift toolchain, and pinned GitHub Actions to current releases.
+
 ## 0.13.4 - 2026-07-27
 
 ### Highlights

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
   dependencies: [
     .package(url: "https://github.com/steipete/Commander.git", from: "0.2.4"),
     .package(url: "https://github.com/stephencelis/SQLite.swift.git", from: "0.16.0"),
-    .package(url: "https://github.com/PhoneNumberKit/PhoneNumberKit.git", from: "5.0.5"),
+    .package(url: "https://github.com/PhoneNumberKit/PhoneNumberKit.git", from: "5.0.6"),
   ],
   targets: {
     var targets: [Target] = [


### PR DESCRIPTION
## Summary

- raise the PhoneNumberKit manifest floor from 5.0.5 to 5.0.6
- update SwiftLint from 0.64.1 to 0.65.0
- update Linux CI/release validation from Swift 6.2.4 to 6.3.3
- refresh the Pages checkout pin from v7.0.0 to v7.0.1
- reconcile the Unreleased changelog

## Verification

- `actionlint`
- SwiftLint 0.65.0 full repository lint (existing warnings only)
- `make test` — 485 tests passed
- `make build ARCHES="$(uname -m)"` — release CLI and universal helper built
- `make docs-site`, serve `dist/docs-site`, fetch `/` — HTTP 200 with the imsg documentation page
- live `./bin/imsg --version` — 0.13.5
- live `./bin/imsg status --json` — valid status payload with basic features available
- local and full-branch autoreview — no actionable findings

The Pages-only `actions/setup-node` v7 major is intentionally not included: that workflow deploys only from `main`, so this lane cannot exercise the action without using the production Pages deployment as a test target. It remains the only known non-current dependency.
