### PR TITLE
chore: finish August maintenance sweep

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "24"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 ### JSON-RPC
 - feat: add bounded `messages.after` pagination with authoritative database-instance-scoped ROWID cursors, cross-chat catchup, and optional standalone reaction events (#200, #201, thanks @vincentkoc).
 
+### Dependencies
+- chore: update the documentation workflow to `actions/setup-node` 7.0.0.
+
 ## 0.13.5 - 2026-08-01
 
 ### JSON-RPC

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Documentation
 - docs: rewrite the README as a concise front door to installation, core workflows, and the full documentation site.
+- docs: explain the benign Contacts framework stderr message seen with some CardDAV accounts (#207, thanks @prashantkamani).
 
 ### JSON-RPC
 - feat: add bounded `messages.after` pagination with authoritative database-instance-scoped ROWID cursors, cross-chat catchup, and optional standalone reaction events (#200, #201, thanks @vincentkoc).

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -42,6 +42,8 @@ Grant it under **System Settings → Privacy & Security → Contacts**.
 
 If you skip this, JSON output simply leaves the resolved name fields empty. Nothing else changes.
 
+On Macs with CardDAV accounts such as Google or Yahoo, Apple's Contacts framework may periodically write `Could not fetch group … :ABGroup` reconciliation messages to stderr. These messages are benign and do not come from `imsg`; a parent process that captures `imsg rpc --json` stderr should not report this specific framework message as an `imsg` error.
+
 ## Why these grants live in three different places
 
 macOS treats each gate as a separate consent decision:


### PR DESCRIPTION
## Summary

- explain the benign Contacts framework stderr message reported in #207
- update the documentation workflow from `actions/setup-node` 6.4.0 to the verified 7.0.0 commit
- record both changes in the 0.14.0 changelog

## Proof

- `make lint` (pass; existing non-serious warnings only)
- `make test` (510 tests passed)
- `make build` (universal `imsg` plus arm64e/arm64/x86_64 bridge helper)
- `node --version` (`v24.18.0`) and `make docs-site`
- served `dist/docs-site`; `/` and `/permissions.html` returned HTTP 200 and the latter rendered the CardDAV guidance
- `./bin/imsg --version` (`0.13.5`) and `./bin/imsg --help`
- Codex autoreview clean on both commits and the combined branch

Closes #207.
