### PR TITLE
fix: align RPC poll and attachment reply parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - docs: explain the benign Contacts framework stderr message seen with some CardDAV accounts (#207, thanks @prashantkamani).
 
 ### JSON-RPC
+- fix: match CLI poll option resolution and preserve reply part indexes for attachment sends.
 - feat: add bounded `messages.after` pagination with authoritative database-instance-scoped ROWID cursors, cross-chat catchup, and optional standalone reaction events (#200, #201, thanks @vincentkoc).
 
 ### Advanced IMCore

--- a/Sources/imsg/RPCServer+BridgeMessageHandlers.swift
+++ b/Sources/imsg/RPCServer+BridgeMessageHandlers.swift
@@ -187,16 +187,35 @@ extension RPCServer {
     guard let file = stringParam(params["file"] ?? params["path"]), !file.isEmpty else {
       throw RPCError.invalidParams("file is required")
     }
+    let reply = stringParam(
+      params["reply_to"] ?? params["replyTo"] ?? params["reply_to_guid"] ?? params["message_guid"]
+    )
+    let partIndex: Int?
+    if let rawPartIndex = params["part_index"] ?? params["partIndex"] {
+      guard
+        let parsedPartIndex = strictBridgeMessageInteger(rawPartIndex), parsedPartIndex >= 0
+      else {
+        throw RPCError.invalidParams("part_index must be a non-negative integer")
+      }
+      guard reply?.isEmpty == false else {
+        throw RPCError.invalidParams("part_index requires reply_to")
+      }
+      partIndex = parsedPartIndex
+    } else {
+      partIndex = nil
+    }
+
     var bridgeParams: [String: Any] = [
       "chatGuid": chatGUID,
       "filePath": try stageAttachment((file as NSString).expandingTildeInPath),
       "isAudioMessage": boolParam(params["audio"] ?? params["is_audio"] ?? params["as_voice"])
         ?? false,
     ]
-    if let reply = stringParam(
-      params["reply_to"] ?? params["replyTo"] ?? params["reply_to_guid"] ?? params["message_guid"]
-    ), !reply.isEmpty {
+    if let reply, !reply.isEmpty {
       bridgeParams["selectedMessageGuid"] = reply
+    }
+    if let partIndex {
+      bridgeParams["partIndex"] = partIndex
     }
     let data = try await invokeBridge(action: .sendAttachment, params: bridgeParams)
     var result: [String: Any] = ["ok": true]
@@ -289,22 +308,60 @@ extension RPCServer {
     else {
       throw RPCError.invalidParams("poll_guid is required")
     }
-    guard
-      let optionID = stringParam(
-        params["option_id"] ?? params["optionId"] ?? params["optionIdentifier"]),
-      !optionID.isEmpty
-    else {
-      throw RPCError.invalidParams("option_id is required")
+    let directOptionID = stringParam(
+      params["option_id"] ?? params["optionId"] ?? params["optionIdentifier"]
+    )?.trimmingCharacters(in: .whitespacesAndNewlines)
+    let rawOptionIndex = params["option_index"] ?? params["optionIndex"]
+    let optionText = stringParam(params["option"])?
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+    let selectors = [
+      directOptionID?.isEmpty == false,
+      rawOptionIndex != nil,
+      optionText?.isEmpty == false,
+    ]
+    guard selectors.contains(true) else {
+      throw RPCError.invalidParams("one of option_id, option_index, or option is required")
     }
-    // Validate the poll exists and the option belongs to it (mirrors the CLI),
-    // so an API caller can't cast a vote against an arbitrary non-poll GUID.
+    guard selectors.filter({ $0 }).count == 1 else {
+      throw RPCError.invalidParams("choose exactly one of option_id, option_index, or option")
+    }
+
+    // Resolve every selector against decoded options, so callers cannot vote
+    // against an arbitrary non-poll GUID or supply caller-trusted option text.
     let pollOptions = try store.pollOptions(guid: pollGUID)
     guard !pollOptions.isEmpty else {
       throw RPCError.invalidParams("poll \(pollGUID) not found or not decodable")
     }
-    guard let matchedOption = pollOptions.first(where: { $0.id == optionID }) else {
-      throw RPCError.invalidParams("option_id \(optionID) is not an option of poll \(pollGUID)")
+
+    let matchedOption: MessagePollOption
+    if let directOptionID, !directOptionID.isEmpty {
+      guard let option = pollOptions.first(where: { $0.id == directOptionID }) else {
+        throw RPCError.invalidParams(
+          "option_id \(directOptionID) is not an option of poll \(pollGUID)")
+      }
+      matchedOption = option
+    } else if let rawOptionIndex {
+      guard let optionIndex = strictBridgeMessageInteger(rawOptionIndex) else {
+        throw RPCError.invalidParams("option_index must be an integer")
+      }
+      guard optionIndex >= 1, optionIndex <= pollOptions.count else {
+        throw RPCError.invalidParams(
+          "option_index \(optionIndex) out of range (1...\(pollOptions.count))")
+      }
+      matchedOption = pollOptions[optionIndex - 1]
+    } else {
+      let text = optionText ?? ""
+      guard
+        let option = pollOptions.first(where: {
+          $0.text.caseInsensitiveCompare(text) == .orderedSame
+        })
+      else {
+        let available = pollOptions.map(\.text).joined(separator: ", ")
+        throw RPCError.invalidParams("option \"\(text)\" (available: \(available))")
+      }
+      matchedOption = option
     }
+    let optionID = matchedOption.id
     var bridgeParams: [String: Any] = [
       "chatGuid": chatGUID,
       // Native votes associate to the bare poll GUID (strip a leading p:<part>/).
@@ -445,6 +502,14 @@ extension RPCServer {
     _ = try await invokeBridge(action: action, params: bridgeParams)
     respond(id: id, result: ["ok": true])
   }
+}
+
+private func strictBridgeMessageInteger(_ value: Any) -> Int? {
+  guard let number = value as? NSNumber else { return nil }
+  guard CFGetTypeID(number) != CFBooleanGetTypeID() else { return nil }
+  let type = String(cString: number.objCType)
+  guard type != "f", type != "d", type != "D" else { return nil }
+  return Int(number.stringValue)
 }
 
 func rpcPollOptionsParam(_ params: [String: Any]) throws -> [String] {

--- a/Tests/imsgTests/RPCBridgeMessageHandlersTests.swift
+++ b/Tests/imsgTests/RPCBridgeMessageHandlersTests.swift
@@ -410,13 +410,14 @@ func rpcSendAttachmentStagesFileBeforeBridgeSend() async throws {
 
   let line =
     #"{"jsonrpc":"2.0","id":"attachment","method":"send.attachment","params":{"#
-    + #""chat_id":1,"file":"~/Desktop/file.png","audio":true,"reply_to":"parent-guid"}}"#
+    + #""chat_id":1,"file":"~/Desktop/file.png","audio":true,"reply_to":"parent-guid","part_index":2}}"#
   await server.handleLineForTesting(line)
 
   #expect(stagedInput?.hasSuffix("/Desktop/file.png") == true)
   #expect(capturedParams["filePath"] as? String == "/tmp/staged-file.png")
   #expect(capturedParams["isAudioMessage"] as? Bool == true)
   #expect(capturedParams["selectedMessageGuid"] as? String == "parent-guid")
+  #expect(capturedParams["partIndex"] as? Int == 2)
   let result = output.responses.first?["result"] as? [String: Any]
   #expect(result?["message_id"] as? String == "attachment-guid")
 }

--- a/Tests/imsgTests/RPCOpenClawParityTests.swift
+++ b/Tests/imsgTests/RPCOpenClawParityTests.swift
@@ -1,0 +1,115 @@
+import Foundation
+import Testing
+
+@testable import IMsgCore
+@testable import imsg
+
+@Test
+func rpcPollVoteResolvesOneBasedOptionIndex() async throws {
+  let store = try CommandTestDatabase.makeStoreForRPCWithPollVote()
+  let output = TestRPCOutput()
+  var capturedParams: [String: Any] = [:]
+  let server = RPCServer(
+    store: store,
+    verbose: false,
+    output: output,
+    invokeBridge: { _, params in
+      capturedParams = params
+      return [:]
+    }
+  )
+
+  await server.handleLineForTesting(
+    #"{"jsonrpc":"2.0","id":"vote","method":"poll.vote","params":{"chat_id":1,"poll_guid":"poll-guid-6","option_index":2}}"#
+  )
+
+  #expect(capturedParams["optionIdentifier"] as? String == "choice-no")
+  #expect(capturedParams["optionText"] as? String == "No")
+  let result = output.responses.first?["result"] as? [String: Any]
+  #expect(result?["option_id"] as? String == "choice-no")
+  #expect(result?["option_text"] as? String == "No")
+}
+
+@Test
+func rpcPollUnvoteAliasesResolveCaseInsensitiveOptionText() async throws {
+  for method in ["poll.unvote", "polls.unvote", "messages.poll.unvote"] {
+    let store = try CommandTestDatabase.makeStoreForRPCWithOwnPollVoteSnapshot()
+    let output = TestRPCOutput()
+    var capturedAction: BridgeAction?
+    var capturedParams: [String: Any] = [:]
+    let server = RPCServer(
+      store: store,
+      verbose: false,
+      output: output,
+      invokeBridge: { action, params in
+        capturedAction = action
+        capturedParams = params
+        return [:]
+      }
+    )
+
+    let request =
+      #"{"jsonrpc":"2.0","id":"unvote","method":"\#(method)","params":{"chat_id":1,"poll_guid":"poll-guid-6","option":"yEs"}}"#
+    await server.handleLineForTesting(request)
+
+    #expect(capturedAction == .sendPollUnvote)
+    #expect(capturedParams["optionIdentifier"] as? String == "choice-yes")
+    #expect(capturedParams["optionText"] as? String == "Yes")
+    #expect(capturedParams["remainingOptionIdentifiers"] as? [String] == ["choice-no"])
+  }
+}
+
+@Test
+func rpcPollVoteRejectsInvalidSelectors() async throws {
+  let selectorCases: [(id: String, params: String, error: String)] = [
+    ("missing", "", "one of option_id, option_index, or option is required"),
+    (
+      "multiple",
+      #", "option_id":"choice-yes", "option_index":1"#,
+      "choose exactly one of option_id, option_index, or option"
+    ),
+    ("out-of-range", #", "option_index":3"#, "out of range (1...2)"),
+    ("unknown", #", "option":"Maybe""#, #"option "Maybe""#),
+  ]
+
+  for selectorCase in selectorCases {
+    let store = try CommandTestDatabase.makeStoreForRPCWithPollVote()
+    let output = TestRPCOutput()
+    let server = RPCServer(store: store, verbose: false, output: output)
+    let request =
+      #"{"jsonrpc":"2.0","id":"\#(selectorCase.id)","method":"poll.vote","params":{"#
+      + #""chat_id":1,"poll_guid":"poll-guid-6""#
+      + selectorCase.params + "}}"
+
+    await server.handleLineForTesting(request)
+
+    let error = output.errors.first?["error"] as? [String: Any]
+    #expect(error?["code"] as? Int == -32602)
+    #expect((error?["data"] as? String)?.contains(selectorCase.error) == true)
+  }
+}
+
+@Test
+func rpcSendAttachmentValidatesReplyPartIndex() async throws {
+  for params in [
+    #""reply_to":"parent-guid","partIndex":true"#,
+    #""reply_to":"parent-guid","part_index":-1"#,
+    #""part_index":1"#,
+  ] {
+    let store = try CommandTestDatabase.makeStoreForRPC()
+    let output = TestRPCOutput()
+    let server = RPCServer(
+      store: store,
+      verbose: false,
+      output: output,
+      stageAttachment: { _ in "/tmp/staged-file.png" }
+    )
+    let request =
+      #"{"jsonrpc":"2.0","id":"attachment","method":"send.attachment","params":{"chat_id":1,"file":"file.png",\#(params)}}"#
+
+    await server.handleLineForTesting(request)
+
+    let error = output.errors.first?["error"] as? [String: Any]
+    #expect(error?["code"] as? Int == -32602)
+  }
+}

--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -252,7 +252,7 @@ Missing rows return `pending` with `status_fields: null`.
 These methods require the IMCore bridge and target an existing chat with `chat_id`, `chat_identifier`, or `chat_guid`.
 
 - `send.rich` sends text with optional `effect`, `subject`, `reply_to`, `part_index`, `dd_scan`, and `text_formatting`. Alternatively, pass only one chat target plus an HTTP(S) `url` to send an Apple URL-preview balloon. URL mode is iMessage-only and rejects text/send modifiers; metadata or image lookup failure falls back to a metadata-only card, never a plain-message send.
-- `send.attachment` sends `file` or `path`, with optional `audio` / `is_audio` / `as_voice`.
+- `send.attachment` sends `file` or `path`, with optional `audio` / `is_audio` / `as_voice`. Pass `reply_to` (or `replyTo`, `reply_to_guid`, or `message_guid`) to reply to an existing message. An optional non-negative integer `part_index` / `partIndex` selects that message's part and is invalid without a reply target.
 - `tapback` sends or removes a reaction. Params: `message_id` or `message_guid`, plus `reaction` / `kind` / `emoji`, optional `remove`.
 - `message.edit` edits `message_id` / `message_guid` with `text`.
 - `message.unsend`, `message.delete`, and `message.notifyAnyways` target `message_id` / `message_guid`.
@@ -324,11 +324,12 @@ Response:
 ```
 
 `poll.vote` casts a native vote after validating the poll and option against local history.
-`polls.unvote` removes a selection with the same poll/option parameters:
+`poll.unvote`, `polls.unvote`, and `messages.poll.unvote` remove a selection with the same poll/option parameters. Pass exactly one option selector: `option_id` (stable option ID), `option_index` (one-based option position), or `option` (case-insensitive option text). The camelCase aliases `optionId` / `optionIdentifier` and `optionIndex` are also accepted. Every selector is resolved against the decoded poll options; `option_text` remains response metadata and is not trusted as a resolved input selector.
 
 ```json
 {"jsonrpc":"2.0","id":"vote","method":"poll.vote","params":{"chat_id":42,"poll_guid":"POLL-GUID","option_id":"OPTION-UUID"}}
-{"jsonrpc":"2.0","id":"unvote","method":"polls.unvote","params":{"chat_id":42,"poll_guid":"POLL-GUID","option_id":"OPTION-UUID"}}
+{"jsonrpc":"2.0","id":"vote-index","method":"poll.vote","params":{"chat_id":42,"poll_guid":"POLL-GUID","option_index":2}}
+{"jsonrpc":"2.0","id":"unvote","method":"polls.unvote","params":{"chat_id":42,"poll_guid":"POLL-GUID","option":"Sushi"}}
 ```
 
 `messages.poll.send` is accepted as an alias for `poll.send`. The caption echo is deliberately best-effort: if the poll is created but the follow-up caption send fails, the RPC still returns the poll result to avoid retrying and creating a duplicate poll.


### PR DESCRIPTION
## Summary

- let `poll.vote` and unvote aliases resolve exactly one option by stable ID, one-based index, or case-insensitive text, matching the CLI validation contract
- forward validated attachment reply `part_index` values to the IMCore bridge instead of dropping the selected message part
- document the expanded JSON-RPC contract and add deterministic regression coverage

## Why

JSON-RPC callers previously had to resolve native poll options to `option_id` themselves even though the CLI already accepted indexes and text. Attachment replies also lost the selected message part index before reaching a bridge that supports it. This removes those RPC-only limitations without changing the existing response fields or trusting caller-supplied `option_text` metadata.

## Examples

```json
{"jsonrpc":"2.0","id":"vote","method":"poll.vote","params":{"chat_id":42,"poll_guid":"POLL-GUID","option_index":2}}
```

```json
{"jsonrpc":"2.0","id":"unvote","method":"polls.unvote","params":{"chat_id":42,"poll_guid":"POLL-GUID","option":"Sushi"}}
```

```json
{"jsonrpc":"2.0","id":"attachment","method":"send.attachment","params":{"chat_id":42,"file":"photo.png","reply_to":"MESSAGE-GUID","part_index":2}}
```

## Verification

- `make lint` — passed (existing non-fatal size warnings only)
- `make test` — 514 tests passed
- `make build` — universal `imsg` and bridge helper artifacts built successfully
- focused source-blind behavior validation — 5 parity tests passed
- pre-commit autoreview — clean, no accepted/actionable findings
