### PR TITLE
fix(rpc): reject malformed requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@
 ### JSON-RPC
 - fix: match CLI poll option resolution and preserve reply part indexes for attachment sends.
 - feat: add bounded `messages.after` pagination with authoritative database-instance-scoped ROWID cursors, cross-chat catchup, and optional standalone reaction events (#200, #201, thanks @vincentkoc).
-- fix: validate JSON-RPC framing, IDs, named params, types, aliases, and chat-target conflicts consistently so malformed requests cannot broaden or redirect operations.
 
 ### Advanced IMCore
 - fix: open trusted sticker staging roots directly so sandboxed Messages can send staged stickers (#211, thanks @clawcrab).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### JSON-RPC
 - fix: match CLI poll option resolution and preserve reply part indexes for attachment sends.
 - feat: add bounded `messages.after` pagination with authoritative database-instance-scoped ROWID cursors, cross-chat catchup, and optional standalone reaction events (#200, #201, thanks @vincentkoc).
+- fix: validate JSON-RPC framing, IDs, named params, types, aliases, and chat-target conflicts consistently so malformed requests cannot broaden or redirect operations.
 
 ### Advanced IMCore
 - fix: open trusted sticker staging roots directly so sandboxed Messages can send staged stickers (#211, thanks @clawcrab).

--- a/Sources/imsg/RPCParameters.swift
+++ b/Sources/imsg/RPCParameters.swift
@@ -1,0 +1,172 @@
+import CoreFoundation
+import Foundation
+
+struct RPCParameters {
+  private let values: [String: Any]
+
+  init(_ values: [String: Any], method: String, supportedKeys: Set<String>) throws {
+    if let unknown = values.keys.filter({ !supportedKeys.contains($0) }).sorted().first {
+      throw RPCError.invalidParams("unknown \(method) param: \(unknown)")
+    }
+    self.values = values
+  }
+
+  func contains(_ key: String) -> Bool {
+    values.keys.contains(key)
+  }
+
+  func string(_ key: String, aliases: [String] = []) throws -> String? {
+    guard let (name, value) = try selected(key, aliases: aliases) else { return nil }
+    guard let value = value as? String else {
+      throw RPCError.invalidParams("\(name) must be a string")
+    }
+    return value
+  }
+
+  func integer(_ key: String, aliases: [String] = []) throws -> Int? {
+    guard let (name, value) = try selected(key, aliases: aliases) else { return nil }
+    guard let number = strictIntegerNumber(value), let parsed = Int(number.stringValue) else {
+      throw RPCError.invalidParams("\(name) must be an integer")
+    }
+    return parsed
+  }
+
+  func int64(_ key: String, aliases: [String] = []) throws -> Int64? {
+    guard let (name, value) = try selected(key, aliases: aliases) else { return nil }
+    guard let number = strictIntegerNumber(value), let parsed = Int64(number.stringValue) else {
+      throw RPCError.invalidParams("\(name) must be an integer")
+    }
+    return parsed
+  }
+
+  func boolean(_ key: String, aliases: [String] = []) throws -> Bool? {
+    guard let (name, value) = try selected(key, aliases: aliases) else { return nil }
+    guard
+      let number = value as? NSNumber,
+      CFGetTypeID(number) == CFBooleanGetTypeID()
+    else {
+      throw RPCError.invalidParams("\(name) must be a boolean")
+    }
+    return number.boolValue
+  }
+
+  func stringArray(_ key: String, aliases: [String] = []) throws -> [String]? {
+    guard let (name, value) = try selected(key, aliases: aliases) else { return nil }
+    guard let rawValues = value as? [Any] else {
+      throw RPCError.invalidParams("\(name) must be an array of strings")
+    }
+    var result: [String] = []
+    result.reserveCapacity(rawValues.count)
+    for rawValue in rawValues {
+      guard let string = rawValue as? String else {
+        throw RPCError.invalidParams("\(name) must be an array of strings")
+      }
+      result.append(string)
+    }
+    return result
+  }
+
+  func objectArray(_ key: String, aliases: [String] = []) throws -> [[String: Any]]? {
+    guard let (name, value) = try selected(key, aliases: aliases) else { return nil }
+    guard let rawValues = value as? [Any] else {
+      throw RPCError.invalidParams("\(name) must be an array of objects")
+    }
+    var result: [[String: Any]] = []
+    result.reserveCapacity(rawValues.count)
+    for rawValue in rawValues {
+      guard let object = rawValue as? [String: Any] else {
+        throw RPCError.invalidParams("\(name) must be an array of objects")
+      }
+      result.append(object)
+    }
+    return result
+  }
+
+  func chatTarget(required: Bool = true) throws -> ChatTargetInput {
+    let selectorKeys = ["chat_id", "chat_identifier", "chat_guid"]
+    let supplied = selectorKeys.filter(contains)
+    if supplied.count > 1 || (required && supplied.count != 1) {
+      throw RPCError.invalidParams(
+        "exactly one of chat_id, chat_identifier, or chat_guid is required"
+      )
+    }
+    guard let key = supplied.first else {
+      return ChatTargetInput(recipient: "", chatID: nil, chatIdentifier: "", chatGUID: "")
+    }
+    switch key {
+    case "chat_id":
+      guard let chatID = try int64("chat_id"), chatID > 0 else {
+        throw RPCError.invalidParams("chat_id must be a positive integer")
+      }
+      return ChatTargetInput(
+        recipient: "", chatID: chatID, chatIdentifier: "", chatGUID: "")
+    case "chat_identifier":
+      guard let identifier = try string("chat_identifier"), !identifier.isEmpty else {
+        throw RPCError.invalidParams("chat_identifier must be a non-empty string")
+      }
+      return ChatTargetInput(
+        recipient: "", chatID: nil, chatIdentifier: identifier, chatGUID: "")
+    case "chat_guid":
+      guard let guid = try string("chat_guid"), !guid.isEmpty else {
+        throw RPCError.invalidParams("chat_guid must be a non-empty string")
+      }
+      return ChatTargetInput(recipient: "", chatID: nil, chatIdentifier: "", chatGUID: guid)
+    default:
+      preconditionFailure("unsupported chat selector")
+    }
+  }
+
+  func recipientOrChatTarget() throws -> ChatTargetInput {
+    let hasRecipient = contains("to")
+    let selectorCount = ["chat_id", "chat_identifier", "chat_guid"].filter(contains).count
+    if hasRecipient && selectorCount > 0 {
+      throw RPCError.invalidParams("use to or exactly one chat selector; not both")
+    }
+    if hasRecipient {
+      guard let recipient = try string("to"), !recipient.isEmpty else {
+        throw RPCError.invalidParams("to must be a non-empty string")
+      }
+      return ChatTargetInput(
+        recipient: recipient, chatID: nil, chatIdentifier: "", chatGUID: "")
+    }
+    return try chatTarget()
+  }
+
+  private func selected(_ key: String, aliases: [String]) throws -> (String, Any)? {
+    let keys = [key] + aliases
+    let supplied = keys.filter(contains)
+    guard supplied.count <= 1 else {
+      throw RPCError.invalidParams("use only one of \(keys.joined(separator: ", "))")
+    }
+    guard let name = supplied.first, let value = values[name] else { return nil }
+    guard !(value is NSNull) else {
+      throw RPCError.invalidParams("\(name) must not be null")
+    }
+    return (name, value)
+  }
+
+  private func strictIntegerNumber(_ value: Any) -> NSNumber? {
+    guard let number = value as? NSNumber else { return nil }
+    guard CFGetTypeID(number) != CFBooleanGetTypeID() else { return nil }
+    let type = String(cString: number.objCType)
+    guard !["f", "d", "D"].contains(type) else { return nil }
+    return number
+  }
+}
+
+enum RPCParameterKeys {
+  static let chatTarget: Set<String> = ["chat_id", "chat_identifier", "chat_guid"]
+  static let replyTarget: Set<String> = [
+    "reply_to", "replyTo", "reply_to_guid", "message_guid",
+  ]
+  static let messageTarget: Set<String> = [
+    "message_id", "messageId", "message_guid", "messageGuid", "message",
+  ]
+  static let partIndex: Set<String> = ["part_index", "partIndex"]
+
+  static func combining(_ sets: Set<String>...) -> Set<String> {
+    sets.reduce(into: Set<String>()) { result, set in
+      result.formUnion(set)
+    }
+  }
+}

--- a/Sources/imsg/RPCPayloads.swift
+++ b/Sources/imsg/RPCPayloads.swift
@@ -98,58 +98,14 @@ func isGroupHandle(identifier: String, guid: String) -> Bool {
   return guid.contains(";+;") || identifier.contains(";+;")
 }
 
-func stringParam(_ value: Any?) -> String? {
-  if let value = value as? String { return value }
-  if let number = value as? NSNumber { return number.stringValue }
-  return nil
-}
-
-func intParam(_ value: Any?) -> Int? {
-  if let value = value as? Int { return value }
-  if let value = value as? NSNumber { return value.intValue }
-  if let value = value as? String { return Int(value) }
-  return nil
-}
-
-func int64Param(_ value: Any?) -> Int64? {
-  if let value = value as? Int64 { return value }
-  if let value = value as? Int { return Int64(value) }
-  if let value = value as? NSNumber { return value.int64Value }
-  if let value = value as? String { return Int64(value) }
-  return nil
-}
-
-func boolParam(_ value: Any?) -> Bool? {
-  if let value = value as? Bool { return value }
-  if let value = value as? NSNumber { return value.boolValue }
-  if let value = value as? String {
-    if value == "true" { return true }
-    if value == "false" { return false }
-  }
-  return nil
-}
-
-func stringArrayParam(_ value: Any?) -> [String] {
-  if let list = value as? [String] { return list }
-  if let list = value as? [Any] {
-    return list.compactMap { stringParam($0) }
-  }
-  if let str = value as? String {
-    return
-      str
-      .split(separator: ",")
-      .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-      .filter { !$0.isEmpty }
-  }
-  return []
-}
-
 let defaultRPCWatchDebounceInterval: TimeInterval = 0.5
 
-func watchDebounceIntervalParam(_ params: [String: Any]) throws -> TimeInterval {
-  let raw = params["debounce_ms"] ?? params["debounceMs"]
-  guard let raw else { return defaultRPCWatchDebounceInterval }
-  guard let milliseconds = intParam(raw), milliseconds >= 0 else {
+func watchDebounceIntervalParam(_ params: RPCParameters) throws -> TimeInterval {
+  guard let milliseconds = try params.integer("debounce_ms", aliases: ["debounceMs"])
+  else {
+    return defaultRPCWatchDebounceInterval
+  }
+  guard milliseconds >= 0 else {
     throw RPCError.invalidParams("debounce_ms must be a non-negative integer")
   }
   return Double(milliseconds) / 1000

--- a/Sources/imsg/RPCRequestParser.swift
+++ b/Sources/imsg/RPCRequestParser.swift
@@ -1,15 +1,18 @@
+import CoreFoundation
 import Foundation
 
 struct RPCRequest {
   let id: Any?
   let method: String
   let params: [String: Any]
-  let paramsAreNamed: Bool
+
+  var isNotification: Bool { id == nil }
 }
 
 struct RPCParseFailure {
   let id: Any?
   let error: RPCError
+  let shouldRespond: Bool
 }
 
 enum RPCRequestParseResult {
@@ -20,36 +23,77 @@ enum RPCRequestParseResult {
 enum RPCRequestParser {
   static func parse(_ line: String) -> RPCRequestParseResult {
     guard let data = line.data(using: .utf8) else {
-      return .failure(RPCParseFailure(id: nil, error: RPCError.parseError("invalid utf8")))
+      return .failure(
+        RPCParseFailure(id: nil, error: RPCError.parseError("invalid utf8"), shouldRespond: true))
     }
     let json: Any
     do {
       json = try JSONSerialization.jsonObject(with: data, options: [])
     } catch {
       return .failure(
-        RPCParseFailure(id: nil, error: RPCError.parseError(error.localizedDescription)))
+        RPCParseFailure(
+          id: nil, error: RPCError.parseError(error.localizedDescription), shouldRespond: true))
     }
     guard let request = json as? [String: Any] else {
       return .failure(
-        RPCParseFailure(id: nil, error: RPCError.invalidRequest("request must be an object")))
+        RPCParseFailure(
+          id: nil,
+          error: RPCError.invalidRequest("request must be an object"),
+          shouldRespond: true
+        ))
     }
+    let hasID = request.keys.contains("id")
     let id = request["id"]
-    let jsonrpc = request["jsonrpc"] as? String
-    if jsonrpc != nil && jsonrpc != "2.0" {
+    if hasID, !isValidID(id) {
       return .failure(
-        RPCParseFailure(id: id, error: RPCError.invalidRequest("jsonrpc must be 2.0")))
+        RPCParseFailure(
+          id: nil,
+          error: RPCError.invalidRequest("id must be a string, number, or null"),
+          shouldRespond: true
+        ))
+    }
+    guard let jsonrpc = request["jsonrpc"] as? String, jsonrpc == "2.0" else {
+      return .failure(
+        RPCParseFailure(
+          id: hasID ? id : nil,
+          error: RPCError.invalidRequest("jsonrpc must be exactly 2.0"),
+          shouldRespond: true
+        ))
     }
     guard let method = request["method"] as? String, !method.isEmpty else {
-      return .failure(RPCParseFailure(id: id, error: RPCError.invalidRequest("method is required")))
+      return .failure(
+        RPCParseFailure(
+          id: hasID ? id : nil,
+          error: RPCError.invalidRequest("method is required"),
+          shouldRespond: true
+        ))
     }
-    let rawParams = request["params"]
-    let params = rawParams as? [String: Any] ?? [:]
+    let params: [String: Any]
+    if let rawParams = request["params"] {
+      guard let namedParams = rawParams as? [String: Any] else {
+        return .failure(
+          RPCParseFailure(
+            id: hasID ? id : nil,
+            error: RPCError.invalidParams("params must be an object when present"),
+            shouldRespond: hasID
+          ))
+      }
+      params = namedParams
+    } else {
+      params = [:]
+    }
     return .success(
       RPCRequest(
-        id: id,
+        id: hasID ? id : nil,
         method: method,
-        params: params,
-        paramsAreNamed: rawParams == nil || rawParams is [String: Any]
+        params: params
       ))
+  }
+
+  private static func isValidID(_ value: Any?) -> Bool {
+    guard let value else { return false }
+    if value is NSNull || value is String { return true }
+    guard let number = value as? NSNumber else { return false }
+    return CFGetTypeID(number) != CFBooleanGetTypeID()
   }
 }

--- a/Sources/imsg/RPCServer+BridgeMessageHandlers.swift
+++ b/Sources/imsg/RPCServer+BridgeMessageHandlers.swift
@@ -1,39 +1,47 @@
-import CoreFoundation
 import Foundation
 import IMsgCore
 
 extension RPCServer {
   func handleSendRich(params: [String: Any], id: Any?) async throws {
-    let retiredRichLinkKeys = ["link", "rich_link", "richLink", "rich_link_url"]
-    if let key = retiredRichLinkKeys.first(where: { params.keys.contains($0) }) {
-      throw RPCError.invalidParams("\(key) is not supported; pass url without rich-link modifiers")
-    }
-    if params.keys.contains("url") {
+    let supportedKeys = RPCParameterKeys.combining(
+      RPCParameterKeys.chatTarget,
+      RPCParameterKeys.replyTarget,
+      RPCParameterKeys.partIndex,
+      [
+        "text", "message", "url", "dd_scan", "ddScan", "effect_id", "effectId", "effect",
+        "subject", "text_formatting", "textFormatting",
+      ]
+    )
+    let params = try RPCParameters(params, method: "send.rich", supportedKeys: supportedKeys)
+    if params.contains("url") {
       try await handleSendRichLink(params: params, id: id)
       return
     }
+    let text = try params.string("text", aliases: ["message"]) ?? ""
+    let partIndex = try params.integer("part_index", aliases: ["partIndex"]) ?? 0
+    let ddScan = try params.boolean("dd_scan", aliases: ["ddScan"]) ?? true
+    let effect = try params.string("effect_id", aliases: ["effectId", "effect"])
+    let subject = try params.string("subject")
+    let reply = try params.string(
+      "reply_to", aliases: ["replyTo", "reply_to_guid", "message_guid"])
+    let formatting = try params.objectArray("text_formatting", aliases: ["textFormatting"])
     let chatGUID = try await resolveChatGUIDParam(params)
-    let text = stringParam(params["text"]) ?? stringParam(params["message"]) ?? ""
     var bridgeParams: [String: Any] = [
       "chatGuid": chatGUID,
       "message": text,
-      "partIndex": intParam(params["part_index"] ?? params["partIndex"]) ?? 0,
-      "ddScan": boolParam(params["dd_scan"] ?? params["ddScan"]) ?? true,
+      "partIndex": partIndex,
+      "ddScan": ddScan,
     ]
-    if let effect = stringParam(params["effect_id"] ?? params["effectId"] ?? params["effect"]),
-      !effect.isEmpty
-    {
+    if let effect, !effect.isEmpty {
       bridgeParams["effectId"] = ExpressiveSendEffect.expand(effect)
     }
-    if let subject = stringParam(params["subject"]), !subject.isEmpty {
+    if let subject, !subject.isEmpty {
       bridgeParams["subject"] = subject
     }
-    if let reply = stringParam(
-      params["reply_to"] ?? params["replyTo"] ?? params["reply_to_guid"] ?? params["message_guid"]
-    ), !reply.isEmpty {
+    if let reply, !reply.isEmpty {
       bridgeParams["selectedMessageGuid"] = reply
     }
-    if let formatting = params["text_formatting"] ?? params["textFormatting"] {
+    if let formatting {
       bridgeParams["textFormatting"] = formatting
     }
 
@@ -44,7 +52,7 @@ extension RPCServer {
       result["queued"] = queued
     }
     let chatID =
-      int64Param(params["chat_id"])
+      (try params.int64("chat_id"))
       ?? (try? store.chatInfo(matchingTarget: chatGUID)?.id)
     let options = MessageSendOptions(
       recipient: "",
@@ -68,13 +76,17 @@ extension RPCServer {
     respond(id: id, result: result)
   }
 
-  private func handleSendRichLink(params: [String: Any], id: Any?) async throws {
-    let allowedKeys: Set<String> = ["chat_id", "chat_identifier", "chat_guid", "url"]
-    if let unsupported = params.keys.sorted().first(where: { !allowedKeys.contains($0) }) {
+  private func handleSendRichLink(params: RPCParameters, id: Any?) async throws {
+    let incompatibleKeys = [
+      "text", "message", "dd_scan", "ddScan", "effect_id", "effectId", "effect", "subject",
+      "reply_to", "replyTo", "reply_to_guid", "message_guid", "part_index", "partIndex",
+      "text_formatting", "textFormatting",
+    ]
+    if let unsupported = incompatibleKeys.first(where: params.contains) {
       throw RPCError.invalidParams("\(unsupported) is not supported with url")
     }
-    guard let rawURL = params["url"] as? String else {
-      throw RPCError.invalidParams("url must be a string")
+    guard let rawURL = try params.string("url") else {
+      throw RPCError.invalidParams("url is required")
     }
 
     let chatInfo = try await strictRichLinkChatInfo(params)
@@ -135,41 +147,19 @@ extension RPCServer {
     respond(id: id, result: result)
   }
 
-  private func strictRichLinkChatInfo(_ params: [String: Any]) async throws -> ChatInfo {
-    let targetKeys = ["chat_id", "chat_identifier", "chat_guid"]
-    let supplied = targetKeys.filter { params.keys.contains($0) }
-    guard supplied.count == 1, let key = supplied.first else {
-      throw RPCError.invalidParams(
-        "exactly one of chat_id, chat_identifier, or chat_guid is required")
-    }
+  private func strictRichLinkChatInfo(_ params: RPCParameters) async throws -> ChatInfo {
+    let target = try params.chatTarget()
 
     let info: ChatInfo?
-    switch key {
-    case "chat_id":
-      guard
-        let number = params[key] as? NSNumber,
-        CFGetTypeID(number) != CFBooleanGetTypeID(),
-        !["f", "d", "D"].contains(String(cString: number.objCType)),
-        let chatID = Int64(number.stringValue),
-        chatID > 0
-      else {
-        throw RPCError.invalidParams("chat_id must be a positive integer")
-      }
+    if let chatID = target.chatID {
       info = try await cache.info(chatID: chatID)
-    case "chat_identifier", "chat_guid":
-      guard let target = params[key] as? String, !target.isEmpty else {
-        throw RPCError.invalidParams("\(key) must be a non-empty string")
-      }
-      if key == "chat_identifier" {
-        info = try store.chatInfo(
-          matchingExactIdentifier: target,
-          preferredServices: ["iMessage", "iMessageLite"]
-        )
-      } else {
-        info = try store.chatInfo(matchingExactGUID: target)
-      }
-    default:
-      info = nil
+    } else if !target.chatIdentifier.isEmpty {
+      info = try store.chatInfo(
+        matchingExactIdentifier: target.chatIdentifier,
+        preferredServices: ["iMessage", "iMessageLite"]
+      )
+    } else {
+      info = try store.chatInfo(matchingExactGUID: target.chatGUID)
     }
 
     guard let info, !info.guid.isEmpty else {
@@ -183,33 +173,34 @@ extension RPCServer {
   }
 
   func handleSendAttachment(params: [String: Any], id: Any?) async throws {
-    let chatGUID = try await resolveChatGUIDParam(params)
-    guard let file = stringParam(params["file"] ?? params["path"]), !file.isEmpty else {
+    let supportedKeys = RPCParameterKeys.combining(
+      RPCParameterKeys.chatTarget,
+      RPCParameterKeys.replyTarget,
+      RPCParameterKeys.partIndex,
+      ["file", "path", "audio", "is_audio", "as_voice"]
+    )
+    let params = try RPCParameters(
+      params, method: "send.attachment", supportedKeys: supportedKeys)
+    guard let file = try params.string("file", aliases: ["path"]), !file.isEmpty else {
       throw RPCError.invalidParams("file is required")
     }
-    let reply = stringParam(
-      params["reply_to"] ?? params["replyTo"] ?? params["reply_to_guid"] ?? params["message_guid"]
-    )
-    let partIndex: Int?
-    if let rawPartIndex = params["part_index"] ?? params["partIndex"] {
-      guard
-        let parsedPartIndex = strictBridgeMessageInteger(rawPartIndex), parsedPartIndex >= 0
-      else {
+    let audio = try params.boolean("audio", aliases: ["is_audio", "as_voice"]) ?? false
+    let reply = try params.string(
+      "reply_to", aliases: ["replyTo", "reply_to_guid", "message_guid"])
+    let partIndex = try params.integer("part_index", aliases: ["partIndex"])
+    if let partIndex {
+      guard partIndex >= 0 else {
         throw RPCError.invalidParams("part_index must be a non-negative integer")
       }
       guard reply?.isEmpty == false else {
         throw RPCError.invalidParams("part_index requires reply_to")
       }
-      partIndex = parsedPartIndex
-    } else {
-      partIndex = nil
     }
-
+    let chatGUID = try await resolveChatGUIDParam(params)
     var bridgeParams: [String: Any] = [
       "chatGuid": chatGUID,
       "filePath": try stageAttachment((file as NSString).expandingTildeInPath),
-      "isAudioMessage": boolParam(params["audio"] ?? params["is_audio"] ?? params["as_voice"])
-        ?? false,
+      "isAudioMessage": audio,
     ]
     if let reply, !reply.isEmpty {
       bridgeParams["selectedMessageGuid"] = reply
@@ -227,24 +218,35 @@ extension RPCServer {
   }
 
   func handlePollSend(params: [String: Any], id: Any?) async throws {
-    let chatGUID = try await resolveChatGUIDParam(params)
-    guard let question = stringParam(params["question"]), !question.isEmpty else {
+    let supportedKeys = RPCParameterKeys.combining(
+      RPCParameterKeys.chatTarget,
+      RPCParameterKeys.replyTarget,
+      [
+        "question", "options", "option", "creator_handle", "creatorHandle", "comment",
+        "suppress_comment", "suppressComment",
+      ]
+    )
+    let params = try RPCParameters(params, method: "poll.send", supportedKeys: supportedKeys)
+    guard let question = try params.string("question"), !question.isEmpty else {
       throw RPCError.invalidParams("question is required")
     }
     let options = try rpcPollOptionsParam(params)
+    let creatorHandle = try params.string("creator_handle", aliases: ["creatorHandle"])
+    let reply = try params.string(
+      "reply_to", aliases: ["replyTo", "reply_to_guid", "message_guid"])
+    let commentValue = try params.string("comment")
+    let suppressComment =
+      try params.boolean("suppress_comment", aliases: ["suppressComment"]) ?? false
+    let chatGUID = try await resolveChatGUIDParam(params)
     var bridgeParams: [String: Any] = [
       "chatGuid": chatGUID,
       "question": question,
       "options": options,
     ]
-    if let creatorHandle = stringParam(params["creator_handle"] ?? params["creatorHandle"]),
-      !creatorHandle.isEmpty
-    {
+    if let creatorHandle, !creatorHandle.isEmpty {
       bridgeParams["creatorHandle"] = creatorHandle
     }
-    if let reply = stringParam(
-      params["reply_to"] ?? params["replyTo"] ?? params["reply_to_guid"] ?? params["message_guid"]
-    ), !reply.isEmpty {
+    if let reply, !reply.isEmpty {
       bridgeParams["selectedMessageGuid"] = reply
     }
 
@@ -270,9 +272,7 @@ extension RPCServer {
     // Callers pass only `question`; the caption appears for free and the agent
     // needs no knowledge of this. Best-effort: the poll already succeeded, so a
     // comment failure must not fail the RPC.
-    let comment = stringParam(params["comment"]).flatMap { $0.isEmpty ? nil : $0 } ?? question
-    let suppressComment =
-      boolParam(params["suppress_comment"] ?? params["suppressComment"]) ?? false
+    let comment = commentValue.flatMap { $0.isEmpty ? nil : $0 } ?? question
     if !suppressComment, !comment.isEmpty {
       do {
         _ = try await invokeBridge(
@@ -292,31 +292,46 @@ extension RPCServer {
   }
 
   func handlePollVote(params: [String: Any], id: Any?) async throws {
-    try await handlePollVoteMutation(params: params, id: id, remove: false)
+    try await handlePollVoteMutation(
+      params: params, id: id, remove: false, method: "poll.vote")
   }
 
   func handlePollUnvote(params: [String: Any], id: Any?) async throws {
-    try await handlePollVoteMutation(params: params, id: id, remove: true)
+    try await handlePollVoteMutation(
+      params: params, id: id, remove: true, method: "poll.unvote")
   }
 
-  private func handlePollVoteMutation(params: [String: Any], id: Any?, remove: Bool) async throws {
-    let chatGUID = try await resolveChatGUIDParam(params)
+  private func handlePollVoteMutation(
+    params rawParams: [String: Any],
+    id: Any?,
+    remove: Bool,
+    method: String
+  ) async throws {
+    let supportedKeys = RPCParameterKeys.combining(
+      RPCParameterKeys.chatTarget,
+      [
+        "poll_guid", "pollGuid", "poll_message_guid", "message_guid", "message_id",
+        "option_id", "optionId", "optionIdentifier", "option_index", "optionIndex", "option",
+      ]
+    )
+    let params = try RPCParameters(rawParams, method: method, supportedKeys: supportedKeys)
     guard
-      let pollGUID = stringParam(
-        params["poll_guid"] ?? params["pollGuid"] ?? params["poll_message_guid"]
-          ?? params["message_guid"] ?? params["message_id"]), !pollGUID.isEmpty
+      let pollGUID = try params.string(
+        "poll_guid",
+        aliases: ["pollGuid", "poll_message_guid", "message_guid", "message_id"]),
+      !pollGUID.isEmpty
     else {
       throw RPCError.invalidParams("poll_guid is required")
     }
-    let directOptionID = stringParam(
-      params["option_id"] ?? params["optionId"] ?? params["optionIdentifier"]
+    let directOptionID = try params.string(
+      "option_id", aliases: ["optionId", "optionIdentifier"]
     )?.trimmingCharacters(in: .whitespacesAndNewlines)
-    let rawOptionIndex = params["option_index"] ?? params["optionIndex"]
-    let optionText = stringParam(params["option"])?
+    let optionIndex = try params.integer("option_index", aliases: ["optionIndex"])
+    let optionText = try params.string("option")?
       .trimmingCharacters(in: .whitespacesAndNewlines)
     let selectors = [
       directOptionID?.isEmpty == false,
-      rawOptionIndex != nil,
+      optionIndex != nil,
       optionText?.isEmpty == false,
     ]
     guard selectors.contains(true) else {
@@ -325,9 +340,9 @@ extension RPCServer {
     guard selectors.filter({ $0 }).count == 1 else {
       throw RPCError.invalidParams("choose exactly one of option_id, option_index, or option")
     }
-
     // Resolve every selector against decoded options, so callers cannot vote
     // against an arbitrary non-poll GUID or supply caller-trusted option text.
+    let chatGUID = try await resolveChatGUIDParam(params)
     let pollOptions = try store.pollOptions(guid: pollGUID)
     guard !pollOptions.isEmpty else {
       throw RPCError.invalidParams("poll \(pollGUID) not found or not decodable")
@@ -340,10 +355,7 @@ extension RPCServer {
           "option_id \(directOptionID) is not an option of poll \(pollGUID)")
       }
       matchedOption = option
-    } else if let rawOptionIndex {
-      guard let optionIndex = strictBridgeMessageInteger(rawOptionIndex) else {
-        throw RPCError.invalidParams("option_index must be an integer")
-      }
+    } else if let optionIndex {
       guard optionIndex >= 1, optionIndex <= pollOptions.count else {
         throw RPCError.invalidParams(
           "option_index \(optionIndex) out of range (1...\(pollOptions.count))")
@@ -402,14 +414,23 @@ extension RPCServer {
   }
 
   func handleTapback(params: [String: Any], id: Any?) async throws {
-    let chatGUID = try await resolveChatGUIDParam(params)
-    guard let messageGUID = rpcMessageGUIDParam(params) else {
+    let supportedKeys = RPCParameterKeys.combining(
+      RPCParameterKeys.chatTarget,
+      RPCParameterKeys.messageTarget,
+      RPCParameterKeys.partIndex,
+      ["reaction", "kind", "emoji", "remove"]
+    )
+    let params = try RPCParameters(params, method: "tapback", supportedKeys: supportedKeys)
+    guard let messageGUID = try rpcMessageGUIDParam(params) else {
       throw RPCError.invalidParams("message_id or message_guid is required")
     }
-    let rawReaction = stringParam(params["reaction"] ?? params["kind"] ?? params["emoji"]) ?? ""
+    let rawReaction = try params.string("reaction", aliases: ["kind", "emoji"]) ?? ""
+    let remove = try params.boolean("remove") ?? false
+    let partIndex = try params.integer("part_index", aliases: ["partIndex"]) ?? 0
+    let chatGUID = try await resolveChatGUIDParam(params)
     let reactionType = try normalizeBridgeReactionType(
       rawReaction,
-      remove: boolParam(params["remove"]) ?? false
+      remove: remove
     )
     _ = try await invokeBridge(
       action: .sendReaction,
@@ -417,34 +438,48 @@ extension RPCServer {
         "chatGuid": chatGUID,
         "selectedMessageGuid": messageGUID,
         "reactionType": reactionType,
-        "partIndex": intParam(params["part_index"] ?? params["partIndex"]) ?? 0,
+        "partIndex": partIndex,
       ]
     )
     respond(id: id, result: ["ok": true, "reaction": reactionType])
   }
 
   func handleMessageEdit(params: [String: Any], id: Any?) async throws {
-    let chatGUID = try await resolveChatGUIDParam(params)
-    guard let messageGUID = rpcMessageGUIDParam(params) else {
+    let supportedKeys = RPCParameterKeys.combining(
+      RPCParameterKeys.chatTarget,
+      RPCParameterKeys.messageTarget,
+      RPCParameterKeys.partIndex,
+      [
+        "text", "new_text", "newText", "edited_message", "backwards_compatibility_message",
+        "backwardsCompatibilityMessage", "bc_text", "bcText",
+      ]
+    )
+    let params = try RPCParameters(params, method: "message.edit", supportedKeys: supportedKeys)
+    guard let messageGUID = try rpcMessageGUIDParam(params) else {
       throw RPCError.invalidParams("message_id or message_guid is required")
     }
     guard
-      let text = stringParam(
-        params["text"] ?? params["new_text"] ?? params["newText"] ?? params["edited_message"]
-      ), !text.isEmpty
+      let text = try params.string(
+        "text", aliases: ["new_text", "newText", "edited_message"]),
+      !text.isEmpty
     else {
       throw RPCError.invalidParams("text is required")
     }
+    let compatibilityText =
+      try params.string(
+        "backwards_compatibility_message",
+        aliases: ["backwardsCompatibilityMessage", "bc_text", "bcText"]
+      ) ?? text
+    let partIndex = try params.integer("part_index", aliases: ["partIndex"]) ?? 0
+    let chatGUID = try await resolveChatGUIDParam(params)
     _ = try await invokeBridge(
       action: .editMessage,
       params: [
         "chatGuid": chatGUID,
         "messageGuid": messageGUID,
         "editedMessage": text,
-        "backwardsCompatibilityMessage": stringParam(
-          params["backwards_compatibility_message"] ?? params["backwardsCompatibilityMessage"]
-            ?? params["bc_text"] ?? params["bcText"]) ?? text,
-        "partIndex": intParam(params["part_index"] ?? params["partIndex"]) ?? 0,
+        "backwardsCompatibilityMessage": compatibilityText,
+        "partIndex": partIndex,
       ]
     )
     respond(id: id, result: ["ok": true])
@@ -455,19 +490,27 @@ extension RPCServer {
       action: .unsendMessage,
       params: params,
       id: id,
-      includePartIndex: true
+      includePartIndex: true,
+      method: "message.unsend"
     )
   }
 
   func handleMessageDelete(params: [String: Any], id: Any?) async throws {
-    try await invokeMessageGUIDBridgeAction(action: .deleteMessage, params: params, id: id)
+    try await invokeMessageGUIDBridgeAction(
+      action: .deleteMessage, params: params, id: id, method: "message.delete")
   }
 
   func handleMessageNotifyAnyways(params: [String: Any], id: Any?) async throws {
-    try await invokeMessageGUIDBridgeAction(action: .notifyAnyways, params: params, id: id)
+    try await invokeMessageGUIDBridgeAction(
+      action: .notifyAnyways, params: params, id: id, method: "message.notifyAnyways")
   }
 
   func handleNamePhotoStatus(params: [String: Any], id: Any?) async throws {
+    let params = try RPCParameters(
+      params,
+      method: "contacts.shouldShareContact",
+      supportedKeys: RPCParameterKeys.chatTarget
+    )
     let chatGUID = try await resolveChatGUIDParam(params)
     let data = try await invokeBridge(
       action: .shouldOfferNicknameSharing,
@@ -477,6 +520,11 @@ extension RPCServer {
   }
 
   func handleNamePhotoShare(params: [String: Any], id: Any?) async throws {
+    let params = try RPCParameters(
+      params,
+      method: "contacts.shareContactCard",
+      supportedKeys: RPCParameterKeys.chatTarget
+    )
     let chatGUID = try await resolveChatGUIDParam(params)
     let data = try await invokeBridge(action: .shareNickname, params: ["chatGuid": chatGUID])
     respond(id: id, result: data.merging(["ok": true]) { current, _ in current })
@@ -486,95 +534,29 @@ extension RPCServer {
     action: BridgeAction,
     params: [String: Any],
     id: Any?,
-    includePartIndex: Bool = false
+    includePartIndex: Bool = false,
+    method: String
   ) async throws {
-    let chatGUID = try await resolveChatGUIDParam(params)
-    guard let messageGUID = rpcMessageGUIDParam(params) else {
+    let supportedKeys = RPCParameterKeys.combining(
+      RPCParameterKeys.chatTarget,
+      RPCParameterKeys.messageTarget,
+      includePartIndex ? RPCParameterKeys.partIndex : []
+    )
+    let params = try RPCParameters(params, method: method, supportedKeys: supportedKeys)
+    guard let messageGUID = try rpcMessageGUIDParam(params) else {
       throw RPCError.invalidParams("message_id or message_guid is required")
     }
+    let partIndex =
+      includePartIndex ? (try params.integer("part_index", aliases: ["partIndex"]) ?? 0) : nil
+    let chatGUID = try await resolveChatGUIDParam(params)
     var bridgeParams: [String: Any] = [
       "chatGuid": chatGUID,
       "messageGuid": messageGUID,
     ]
-    if includePartIndex {
-      bridgeParams["partIndex"] = intParam(params["part_index"] ?? params["partIndex"]) ?? 0
+    if let partIndex {
+      bridgeParams["partIndex"] = partIndex
     }
     _ = try await invokeBridge(action: action, params: bridgeParams)
     respond(id: id, result: ["ok": true])
   }
-}
-
-private func strictBridgeMessageInteger(_ value: Any) -> Int? {
-  guard let number = value as? NSNumber else { return nil }
-  guard CFGetTypeID(number) != CFBooleanGetTypeID() else { return nil }
-  let type = String(cString: number.objCType)
-  guard type != "f", type != "d", type != "D" else { return nil }
-  return Int(number.stringValue)
-}
-
-func rpcPollOptionsParam(_ params: [String: Any]) throws -> [String] {
-  let raw = params["options"] ?? params["option"]
-  let values: [Any]
-  if let array = raw as? [Any] {
-    values = array
-  } else if let string = raw as? String {
-    values = [string]
-  } else {
-    throw RPCError.invalidParams("options is required")
-  }
-
-  let options = values.compactMap { value -> String? in
-    guard let string = stringParam(value) else { return nil }
-    let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
-    return trimmed.isEmpty ? nil : trimmed
-  }
-  if options.count < 2 {
-    throw RPCError.invalidParams("at least two poll options are required")
-  }
-  return options
-}
-
-func rpcMessageGUIDParam(_ params: [String: Any]) -> String? {
-  let raw = stringParam(
-    params["message_id"] ?? params["messageId"] ?? params["message_guid"] ?? params["messageGuid"]
-      ?? params["message"]
-  )
-  let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-  return trimmed.isEmpty ? nil : trimmed
-}
-
-func normalizeBridgeReactionType(_ raw: String, remove: Bool = false) throws -> String {
-  var value = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-  if value.isEmpty {
-    throw RPCError.invalidParams("reaction, kind, or emoji is required")
-  }
-  var shouldRemove = remove
-  if value.hasPrefix("remove-") {
-    shouldRemove = true
-    value.removeFirst("remove-".count)
-  }
-  let normalized: String
-  switch value {
-  case "love", "heart", "❤️", "❤":
-    normalized = "love"
-  case "like", "thumbsup", "thumbs-up", "+1", "👍":
-    normalized = "like"
-  case "dislike", "thumbsdown", "thumbs-down", "-1", "👎":
-    normalized = "dislike"
-  case "laugh", "haha", "lol", "😂", "🤣":
-    normalized = "laugh"
-  case "emphasize", "emphasis", "!!", "‼", "‼️":
-    normalized = "emphasize"
-  case "question", "?", "❓":
-    normalized = "question"
-  default:
-    throw RPCError.invalidParams(
-      "unsupported tapback reaction \(raw); use love, like, dislike, laugh, emphasize, or question"
-    )
-  }
-  let result = shouldRemove ? "remove-\(normalized)" : normalized
-  guard BridgeReactionKind(rawValue: result) != nil else {
-    throw RPCError.invalidParams("unsupported tapback reaction \(raw)")
-  }
-  return result
 }

--- a/Sources/imsg/RPCServer+BridgeMessageSupport.swift
+++ b/Sources/imsg/RPCServer+BridgeMessageSupport.swift
@@ -1,0 +1,60 @@
+import Foundation
+import IMsgCore
+
+func rpcPollOptionsParam(_ params: RPCParameters) throws -> [String] {
+  guard let values = try params.stringArray("options", aliases: ["option"]) else {
+    throw RPCError.invalidParams("options is required")
+  }
+
+  let options = values.compactMap { value -> String? in
+    let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+    return trimmed.isEmpty ? nil : trimmed
+  }
+  if options.count < 2 {
+    throw RPCError.invalidParams("at least two poll options are required")
+  }
+  return options
+}
+
+func rpcMessageGUIDParam(_ params: RPCParameters) throws -> String? {
+  let raw = try params.string(
+    "message_id", aliases: ["messageId", "message_guid", "messageGuid", "message"])
+  let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+  return trimmed.isEmpty ? nil : trimmed
+}
+
+func normalizeBridgeReactionType(_ raw: String, remove: Bool = false) throws -> String {
+  var value = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+  if value.isEmpty {
+    throw RPCError.invalidParams("reaction, kind, or emoji is required")
+  }
+  var shouldRemove = remove
+  if value.hasPrefix("remove-") {
+    shouldRemove = true
+    value.removeFirst("remove-".count)
+  }
+  let normalized: String
+  switch value {
+  case "love", "heart", "❤️", "❤":
+    normalized = "love"
+  case "like", "thumbsup", "thumbs-up", "+1", "👍":
+    normalized = "like"
+  case "dislike", "thumbsdown", "thumbs-down", "-1", "👎":
+    normalized = "dislike"
+  case "laugh", "haha", "lol", "😂", "🤣":
+    normalized = "laugh"
+  case "emphasize", "emphasis", "!!", "‼", "‼️":
+    normalized = "emphasize"
+  case "question", "?", "❓":
+    normalized = "question"
+  default:
+    throw RPCError.invalidParams(
+      "unsupported tapback reaction \(raw); use love, like, dislike, laugh, emphasize, or question"
+    )
+  }
+  let result = shouldRemove ? "remove-\(normalized)" : normalized
+  guard BridgeReactionKind(rawValue: result) != nil else {
+    throw RPCError.invalidParams("unsupported tapback reaction \(raw)")
+  }
+  return result
+}

--- a/Sources/imsg/RPCServer+ChatHandlers.swift
+++ b/Sources/imsg/RPCServer+ChatHandlers.swift
@@ -7,19 +7,29 @@ import IMsgCore
 /// already implements.
 extension RPCServer {
   func handleChatsCreate(id: Any?, params: [String: Any]) async throws {
-    let addresses = stringArrayParam(params["addresses"])
+    let params = try RPCParameters(
+      params,
+      method: "chats.create",
+      supportedKeys: ["addresses", "service", "name", "text"]
+    )
+    let addresses = (try params.stringArray("addresses") ?? [])
+      .map { $0.trimmingCharacters(in: .whitespaces) }
+      .filter { !$0.isEmpty }
     guard !addresses.isEmpty else {
       throw RPCError.invalidParams("addresses is required (non-empty array of phone/email)")
     }
-    let service = stringParam(params["service"]) ?? "iMessage"
+    let service = try params.string("service") ?? "iMessage"
+    guard service.caseInsensitiveCompare("iMessage") == .orderedSame else {
+      throw RPCError.invalidParams("service must be iMessage")
+    }
     var bridgeParams: [String: Any] = [
       "addresses": addresses,
-      "service": service,
+      "service": "iMessage",
     ]
-    if let name = stringParam(params["name"]), !name.isEmpty {
+    if let name = try params.string("name"), !name.isEmpty {
       bridgeParams["displayName"] = name
     }
-    if let text = stringParam(params["text"]), !text.isEmpty {
+    if let text = try params.string("text"), !text.isEmpty {
       bridgeParams["message"] = text
     }
     let data = try await invokeBridge(action: .createChat, params: bridgeParams)
@@ -37,22 +47,31 @@ extension RPCServer {
   }
 
   func handleChatsDelete(id: Any?, params: [String: Any]) async throws {
+    let params = try RPCParameters(
+      params, method: "chats.delete", supportedKeys: RPCParameterKeys.chatTarget)
     let chatGUID = try await resolveChatGUIDParam(params)
     _ = try await invokeBridge(action: .deleteChat, params: ["chatGuid": chatGUID])
     respond(id: id, result: ["ok": true])
   }
 
   func handleChatsMarkUnread(id: Any?, params: [String: Any]) async throws {
+    let params = try RPCParameters(
+      params, method: "chats.markUnread", supportedKeys: RPCParameterKeys.chatTarget)
     let chatGUID = try await resolveChatGUIDParam(params)
     _ = try await invokeBridge(action: .markChatUnread, params: ["chatGuid": chatGUID])
     respond(id: id, result: ["ok": true])
   }
 
   func handleGroupRename(id: Any?, params: [String: Any]) async throws {
-    let chatGUID = try await resolveChatGUIDParam(params)
-    guard let name = stringParam(params["name"]) else {
+    let params = try RPCParameters(
+      params,
+      method: "group.rename",
+      supportedKeys: RPCParameterKeys.combining(RPCParameterKeys.chatTarget, ["name"])
+    )
+    guard let name = try params.string("name") else {
       throw RPCError.invalidParams("name is required")
     }
+    let chatGUID = try await resolveChatGUIDParam(params)
     _ = try await invokeBridge(
       action: .setDisplayName,
       params: ["chatGuid": chatGUID, "newName": name]
@@ -61,9 +80,15 @@ extension RPCServer {
   }
 
   func handleGroupSetIcon(id: Any?, params: [String: Any]) async throws {
+    let params = try RPCParameters(
+      params,
+      method: "group.setIcon",
+      supportedKeys: RPCParameterKeys.combining(RPCParameterKeys.chatTarget, ["file"])
+    )
+    let file = try params.string("file")
     let chatGUID = try await resolveChatGUIDParam(params)
     var bridgeParams: [String: Any] = ["chatGuid": chatGUID]
-    if let file = stringParam(params["file"]), !file.isEmpty {
+    if let file, !file.isEmpty {
       bridgeParams["filePath"] = (file as NSString).expandingTildeInPath
     }
     _ = try await invokeBridge(action: .updateGroupPhoto, params: bridgeParams)
@@ -71,10 +96,15 @@ extension RPCServer {
   }
 
   func handleGroupAddParticipant(id: Any?, params: [String: Any]) async throws {
-    let chatGUID = try await resolveChatGUIDParam(params)
-    guard let address = stringParam(params["address"]), !address.isEmpty else {
+    let params = try RPCParameters(
+      params,
+      method: "group.addParticipant",
+      supportedKeys: RPCParameterKeys.combining(RPCParameterKeys.chatTarget, ["address"])
+    )
+    guard let address = try params.string("address"), !address.isEmpty else {
       throw RPCError.invalidParams("address is required")
     }
+    let chatGUID = try await resolveChatGUIDParam(params)
     _ = try await invokeBridge(
       action: .addParticipant,
       params: ["chatGuid": chatGUID, "address": address]
@@ -83,10 +113,15 @@ extension RPCServer {
   }
 
   func handleGroupRemoveParticipant(id: Any?, params: [String: Any]) async throws {
-    let chatGUID = try await resolveChatGUIDParam(params)
-    guard let address = stringParam(params["address"]), !address.isEmpty else {
+    let params = try RPCParameters(
+      params,
+      method: "group.removeParticipant",
+      supportedKeys: RPCParameterKeys.combining(RPCParameterKeys.chatTarget, ["address"])
+    )
+    guard let address = try params.string("address"), !address.isEmpty else {
       throw RPCError.invalidParams("address is required")
     }
+    let chatGUID = try await resolveChatGUIDParam(params)
     _ = try await invokeBridge(
       action: .removeParticipant,
       params: ["chatGuid": chatGUID, "address": address]
@@ -95,6 +130,8 @@ extension RPCServer {
   }
 
   func handleGroupLeave(id: Any?, params: [String: Any]) async throws {
+    let params = try RPCParameters(
+      params, method: "group.leave", supportedKeys: RPCParameterKeys.chatTarget)
     let chatGUID = try await resolveChatGUIDParam(params)
     _ = try await invokeBridge(action: .leaveChat, params: ["chatGuid": chatGUID])
     respond(id: id, result: ["ok": true])
@@ -107,18 +144,10 @@ extension RPCServer {
   /// rejecting up-front gives callers a clearer error than the dylib's
   /// downstream "chat not found".
   func resolveChatGUIDParam(
-    _ params: [String: Any],
+    _ params: RPCParameters,
     preferredServices: [String] = []
   ) async throws -> String {
-    let input = ChatTargetInput(
-      recipient: "",
-      chatID: int64Param(params["chat_id"]),
-      chatIdentifier: stringParam(params["chat_identifier"]) ?? "",
-      chatGUID: stringParam(params["chat_guid"]) ?? ""
-    )
-    if !input.hasChatTarget {
-      throw RPCError.invalidParams("chat_guid, chat_identifier, or chat_id is required")
-    }
+    let input = try params.chatTarget()
     let resolved = try await ChatTargetResolver.resolveChatTarget(
       input: input,
       lookupChat: { chatID in try await cache.info(chatID: chatID) },

--- a/Sources/imsg/RPCServer+Handlers.swift
+++ b/Sources/imsg/RPCServer+Handlers.swift
@@ -17,8 +17,13 @@ private enum RPCSendTransport: String {
 
 extension RPCServer {
   func handleChatsList(id: Any?, params: [String: Any]) async throws {
-    let limit = intParam(params["limit"]) ?? 20
-    let unreadOnly = boolParam(params["unread_only"] ?? params["unreadOnly"]) ?? false
+    let params = try RPCParameters(
+      params,
+      method: "chats.list",
+      supportedKeys: ["limit", "unread_only", "unreadOnly"]
+    )
+    let limit = try params.integer("limit") ?? 20
+    let unreadOnly = try params.boolean("unread_only", aliases: ["unreadOnly"]) ?? false
     guard !unreadOnly || store.supportsUnreadState else {
       throw RPCError.invalidParams(
         "unread_only is unavailable because this Messages database has no read-state column")
@@ -55,16 +60,27 @@ extension RPCServer {
   }
 
   func handleMessagesHistory(id: Any?, params: [String: Any]) async throws {
-    guard let chatID = int64Param(params["chat_id"]) else {
+    let params = try RPCParameters(
+      params,
+      method: "messages.history",
+      supportedKeys: [
+        "chat_id", "limit", "participants", "start", "end", "attachments",
+        "convert_attachments",
+      ]
+    )
+    guard let chatID = try params.int64("chat_id") else {
       throw RPCError.invalidParams("chat_id is required")
     }
-    let limit = intParam(params["limit"]) ?? 50
-    let participants = stringArrayParam(params["participants"])
-    let startISO = stringParam(params["start"])
-    let endISO = stringParam(params["end"])
-    let includeAttachments = boolParam(params["attachments"]) ?? false
+    guard chatID > 0 else {
+      throw RPCError.invalidParams("chat_id must be a positive integer")
+    }
+    let limit = try params.integer("limit") ?? 50
+    let participants = try params.stringArray("participants") ?? []
+    let startISO = try params.string("start")
+    let endISO = try params.string("end")
+    let includeAttachments = try params.boolean("attachments") ?? false
     let attachmentOptions = AttachmentQueryOptions(
-      convertUnsupported: boolParam(params["convert_attachments"]) ?? false)
+      convertUnsupported: try params.boolean("convert_attachments") ?? false)
     let filter = try MessageFilter.fromISO(
       participants: participants,
       startISO: startISO,
@@ -93,15 +109,26 @@ extension RPCServer {
   }
 
   func handleWatchSubscribe(id: Any?, params: [String: Any]) async throws {
-    let chatID = int64Param(params["chat_id"])
-    let sinceRowID = int64Param(params["since_rowid"])
-    let participants = stringArrayParam(params["participants"])
-    let startISO = stringParam(params["start"])
-    let endISO = stringParam(params["end"])
-    let includeAttachments = boolParam(params["attachments"]) ?? false
+    let params = try RPCParameters(
+      params,
+      method: "watch.subscribe",
+      supportedKeys: [
+        "chat_id", "since_rowid", "participants", "start", "end", "attachments",
+        "convert_attachments", "include_reactions", "debounce_ms", "debounceMs",
+      ]
+    )
+    let chatID = try params.int64("chat_id")
+    if let chatID, chatID <= 0 {
+      throw RPCError.invalidParams("chat_id must be a positive integer")
+    }
+    let sinceRowID = try params.int64("since_rowid")
+    let participants = try params.stringArray("participants") ?? []
+    let startISO = try params.string("start")
+    let endISO = try params.string("end")
+    let includeAttachments = try params.boolean("attachments") ?? false
     let attachmentOptions = AttachmentQueryOptions(
-      convertUnsupported: boolParam(params["convert_attachments"]) ?? false)
-    let includeReactions = boolParam(params["include_reactions"]) ?? false
+      convertUnsupported: try params.boolean("convert_attachments") ?? false)
+    let includeReactions = try params.boolean("include_reactions") ?? false
     let debounceInterval = try watchDebounceIntervalParam(params)
     let filter = try MessageFilter.fromISO(
       participants: participants,
@@ -163,8 +190,13 @@ extension RPCServer {
   }
 
   func handleWatchUnsubscribe(id: Any?, params: [String: Any]) async throws {
-    guard let subID = intParam(params["subscription"]) else {
+    let params = try RPCParameters(
+      params, method: "watch.unsubscribe", supportedKeys: ["subscription"])
+    guard let subID = try params.integer("subscription") else {
       throw RPCError.invalidParams("subscription is required")
+    }
+    guard subID > 0 else {
+      throw RPCError.invalidParams("subscription must be a positive integer")
     }
     if let task = await subscriptions.remove(subID) {
       task.cancel()
@@ -173,35 +205,34 @@ extension RPCServer {
   }
 
   func handleSend(params: [String: Any], id: Any?) async throws {
-    let text = stringParam(params["text"]) ?? ""
-    let file = stringParam(params["file"]) ?? ""
+    let supportedKeys = RPCParameterKeys.combining(
+      RPCParameterKeys.chatTarget,
+      RPCParameterKeys.replyTarget,
+      [
+        "to", "text", "file", "text_formatting", "textFormatting", "formatting", "service",
+        "transport", "region",
+      ]
+    )
+    let params = try RPCParameters(params, method: "send", supportedKeys: supportedKeys)
+    let text = try params.string("text") ?? ""
+    let file = try params.string("file") ?? ""
     // Optional attributed-text formatting (bold/italic/…, macOS 15+). Only the
     // IMCore bridge transport can render it; AppleScript sends stay plain.
     // Accept `text_formatting`/`textFormatting` (matching `send-rich`) plus the
     // bare `formatting` key that the OpenClaw gateway emits on its `send` calls.
-    let textFormatting =
-      params["text_formatting"] ?? params["textFormatting"] ?? params["formatting"]
-    let serviceRaw = stringParam(params["service"]) ?? "auto"
+    let textFormatting = try params.objectArray(
+      "text_formatting", aliases: ["textFormatting", "formatting"])
+    let serviceRaw = try params.string("service") ?? "auto"
     guard let service = MessageService(rawValue: serviceRaw) else {
       throw RPCError.invalidParams("invalid service")
     }
-    let transport = try RPCSendTransport.parse(stringParam(params["transport"]))
-    let region = stringParam(params["region"]) ?? "US"
-    let selectedMessageGuid = stringParam(
-      params["reply_to"] ?? params["replyTo"] ?? params["reply_to_guid"] ?? params["message_guid"]
+    let transport = try RPCSendTransport.parse(try params.string("transport"))
+    let region = try params.string("region") ?? "US"
+    let selectedMessageGuid = try params.string(
+      "reply_to", aliases: ["replyTo", "reply_to_guid", "message_guid"]
     ).flatMap { $0.isEmpty ? nil : $0 }
-    let rawRecipient = stringParam(params["to"]) ?? ""
-    let rawInput = ChatTargetInput(
-      recipient: rawRecipient,
-      chatID: int64Param(params["chat_id"]),
-      chatIdentifier: stringParam(params["chat_identifier"]) ?? "",
-      chatGUID: stringParam(params["chat_guid"]) ?? ""
-    )
-    try ChatTargetResolver.validateRecipientRequirements(
-      input: rawInput,
-      mixedTargetError: RPCError.invalidParams("use to or chat_*; not both"),
-      missingRecipientError: RPCError.invalidParams("to is required for direct sends")
-    )
+    let rawInput = try params.recipientOrChatTarget()
+    let rawRecipient = rawInput.recipient
     let recipient: String
     do {
       recipient =
@@ -368,70 +399,16 @@ extension RPCServer {
     respond(id: id, result: result)
   }
 
-  func handleHandlesCheck(params: [String: Any], id: Any?) async throws {
-    let address = stringParam(params["address"]) ?? ""
-    guard !address.isEmpty else {
-      throw RPCError.invalidParams("address is required")
-    }
-
-    let aliasType =
-      (stringParam(params["alias_type"]) ?? (address.contains("@") ? "email" : "phone"))
-      .lowercased()
-    guard aliasType == "phone" || aliasType == "email" else {
-      throw RPCError.invalidParams("alias_type must be phone or email")
-    }
-
-    let service = stringParam(params["service"]) ?? "iMessage"
-    guard service.caseInsensitiveCompare("iMessage") == .orderedSame else {
-      throw RPCError.invalidParams("handles.check only supports service iMessage")
-    }
-
-    if !isBridgeReady() {
-      throw RPCError.internalError(
-        "handles.check requires bridge transport (Messages.app must be injected)"
-      )
-    }
-
-    let data = try await bridgeInvoker(
-      .checkImessageAvailability,
-      [
-        "address": address,
-        "aliasType": aliasType,
-      ])
-
-    var result: [String: Any] = ["ok": true]
-    result["address"] = data["address"] as? String ?? address
-    result["alias_type"] = data["alias_type"] as? String ?? aliasType
-    if let destination = data["destination"] as? String, !destination.isEmpty {
-      result["destination"] = destination
-    }
-    if let idStatus = intParam(data["id_status"]) {
-      result["id_status"] = idStatus
-    }
-    if let available = boolParam(data["available"]) {
-      result["available"] = available
-    }
-    result["service"] = "iMessage"
-    respond(id: id, result: result)
-  }
-
   /// `typing` — start/stop the local-user typing indicator. Mirrors the
   /// `imsg typing` CLI surface (which is purely a wrapper over `TypingIndicator`)
   /// so callers that talk to `imsg rpc` over JSON-RPC have parity with the CLI.
   func handleTyping(params: [String: Any], id: Any?) async throws {
-    let isTyping = boolParam(params["typing"]) ?? true
-    let serviceRaw = stringParam(params["service"]) ?? "imessage"
-    let input = ChatTargetInput(
-      recipient: stringParam(params["to"]) ?? "",
-      chatID: int64Param(params["chat_id"]),
-      chatIdentifier: stringParam(params["chat_identifier"]) ?? "",
-      chatGUID: stringParam(params["chat_guid"]) ?? ""
-    )
-    try ChatTargetResolver.validateRecipientRequirements(
-      input: input,
-      mixedTargetError: RPCError.invalidParams("use to or chat_*; not both"),
-      missingRecipientError: RPCError.invalidParams("to is required")
-    )
+    let supportedKeys = RPCParameterKeys.combining(
+      RPCParameterKeys.chatTarget, ["to", "typing", "service"])
+    let params = try RPCParameters(params, method: "typing", supportedKeys: supportedKeys)
+    let isTyping = try params.boolean("typing") ?? true
+    let serviceRaw = try params.string("service") ?? "imessage"
+    let input = try params.recipientOrChatTarget()
     let resolvedTarget = try await ChatTargetResolver.resolveChatTarget(
       input: input,
       lookupChat: { chatID in try await cache.info(chatID: chatID) },
@@ -475,17 +452,9 @@ extension RPCServer {
   /// `read` — mark all messages in a chat as read on this device, which also
   /// fires a read-receipt to the sender if the chat has receipts enabled.
   func handleRead(params: [String: Any], id: Any?) async throws {
-    let input = ChatTargetInput(
-      recipient: stringParam(params["to"]) ?? "",
-      chatID: int64Param(params["chat_id"]),
-      chatIdentifier: stringParam(params["chat_identifier"]) ?? "",
-      chatGUID: stringParam(params["chat_guid"]) ?? ""
-    )
-    try ChatTargetResolver.validateRecipientRequirements(
-      input: input,
-      mixedTargetError: RPCError.invalidParams("use to or chat_*; not both"),
-      missingRecipientError: RPCError.invalidParams("to is required")
-    )
+    let supportedKeys = RPCParameterKeys.combining(RPCParameterKeys.chatTarget, ["to"])
+    let params = try RPCParameters(params, method: "read", supportedKeys: supportedKeys)
+    let input = try params.recipientOrChatTarget()
     let resolvedTarget = try await ChatTargetResolver.resolveChatTarget(
       input: input,
       lookupChat: { chatID in try await cache.info(chatID: chatID) },

--- a/Sources/imsg/RPCServer+HandlesCheckHandler.swift
+++ b/Sources/imsg/RPCServer+HandlesCheckHandler.swift
@@ -1,0 +1,56 @@
+import Foundation
+import IMsgCore
+
+extension RPCServer {
+  func handleHandlesCheck(params: [String: Any], id: Any?) async throws {
+    let params = try RPCParameters(
+      params,
+      method: "handles.check",
+      supportedKeys: ["address", "alias_type", "service"]
+    )
+    let address = try params.string("address") ?? ""
+    guard !address.isEmpty else {
+      throw RPCError.invalidParams("address is required")
+    }
+
+    let aliasType =
+      (try params.string("alias_type") ?? (address.contains("@") ? "email" : "phone"))
+      .lowercased()
+    guard aliasType == "phone" || aliasType == "email" else {
+      throw RPCError.invalidParams("alias_type must be phone or email")
+    }
+
+    let service = try params.string("service") ?? "iMessage"
+    guard service.caseInsensitiveCompare("iMessage") == .orderedSame else {
+      throw RPCError.invalidParams("handles.check only supports service iMessage")
+    }
+
+    if !isBridgeReady() {
+      throw RPCError.internalError(
+        "handles.check requires bridge transport (Messages.app must be injected)"
+      )
+    }
+
+    let data = try await bridgeInvoker(
+      .checkImessageAvailability,
+      [
+        "address": address,
+        "aliasType": aliasType,
+      ])
+
+    var result: [String: Any] = ["ok": true]
+    result["address"] = data["address"] as? String ?? address
+    result["alias_type"] = data["alias_type"] as? String ?? aliasType
+    if let destination = data["destination"] as? String, !destination.isEmpty {
+      result["destination"] = destination
+    }
+    if let idStatus = data["id_status"] as? NSNumber {
+      result["id_status"] = idStatus.intValue
+    }
+    if let available = data["available"] as? Bool {
+      result["available"] = available
+    }
+    result["service"] = "iMessage"
+    respond(id: id, result: result)
+  }
+}

--- a/Sources/imsg/RPCServer+MessageStatusHandlers.swift
+++ b/Sources/imsg/RPCServer+MessageStatusHandlers.swift
@@ -3,7 +3,10 @@ import IMsgCore
 
 extension RPCServer {
   func handleMessageSendStatus(params: [String: Any], id: Any?) async throws {
-    let guid = (stringParam(params["guid"]) ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+    let params = try RPCParameters(
+      params, method: "message.send_status", supportedKeys: ["guid"])
+    let guid = (try params.string("guid") ?? "").trimmingCharacters(
+      in: .whitespacesAndNewlines)
     guard !guid.isEmpty else {
       throw RPCError.invalidParams("guid is required")
     }

--- a/Sources/imsg/RPCServer+MessagesAfterHandlers.swift
+++ b/Sources/imsg/RPCServer+MessagesAfterHandlers.swift
@@ -1,28 +1,28 @@
-import CoreFoundation
 import Foundation
 import IMsgCore
 
 extension RPCServer {
   func handleMessagesAfter(id: Any?, params: [String: Any]) async throws {
-    let supportedParams: Set<String> = [
-      "since_rowid",
-      "chat_id",
-      "limit",
-      "attachments",
-      "convert_attachments",
-      "include_reactions",
-    ]
-    if let unknown = params.keys.filter({ !supportedParams.contains($0) }).sorted().first {
-      throw RPCError.invalidParams("unknown messages.after param: \(unknown)")
-    }
+    let params = try RPCParameters(
+      params,
+      method: "messages.after",
+      supportedKeys: [
+        "since_rowid",
+        "chat_id",
+        "limit",
+        "attachments",
+        "convert_attachments",
+        "include_reactions",
+      ]
+    )
 
-    guard let sinceRowID = strictMessagesAfterInt64(params["since_rowid"]), sinceRowID >= 0 else {
+    guard let sinceRowID = try params.int64("since_rowid"), sinceRowID >= 0 else {
       throw RPCError.invalidParams("since_rowid must be a non-negative integer")
     }
 
     let chatID: Int64?
-    if let rawChatID = params["chat_id"] {
-      guard let parsed = strictMessagesAfterInt64(rawChatID), parsed > 0 else {
+    if params.contains("chat_id") {
+      guard let parsed = try params.int64("chat_id"), parsed > 0 else {
         throw RPCError.invalidParams("chat_id must be a positive integer")
       }
       chatID = parsed
@@ -31,8 +31,8 @@ extension RPCServer {
     }
 
     let limit: Int
-    if let rawLimit = params["limit"] {
-      guard let parsed = strictMessagesAfterInt(rawLimit), (1...500).contains(parsed) else {
+    if params.contains("limit") {
+      guard let parsed = try params.integer("limit"), (1...500).contains(parsed) else {
         throw RPCError.invalidParams("limit must be an integer between 1 and 500")
       }
       limit = parsed
@@ -40,23 +40,14 @@ extension RPCServer {
       limit = 100
     }
 
-    let includeAttachments = try strictMessagesAfterBool(
-      params["attachments"],
-      name: "attachments"
-    )
+    let includeAttachments = try params.boolean("attachments") ?? false
     let attachmentOptions = AttachmentQueryOptions(
-      convertUnsupported: try strictMessagesAfterBool(
-        params["convert_attachments"],
-        name: "convert_attachments"
-      ))
+      convertUnsupported: try params.boolean("convert_attachments") ?? false)
     let page = try store.messagesAfterPage(
       afterRowID: sinceRowID,
       chatID: chatID,
       limit: limit,
-      includeReactions: try strictMessagesAfterBool(
-        params["include_reactions"],
-        name: "include_reactions"
-      )
+      includeReactions: try params.boolean("include_reactions") ?? false
     )
     let reactionsByMessageID = try store.reactions(for: page.messages)
     var payloads: [[String: Any]] = []
@@ -84,24 +75,4 @@ extension RPCServer {
       ]
     )
   }
-}
-
-private func strictMessagesAfterInt64(_ value: Any?) -> Int64? {
-  guard let number = value as? NSNumber else { return nil }
-  guard CFGetTypeID(number) != CFBooleanGetTypeID() else { return nil }
-  return Int64(number.stringValue)
-}
-
-private func strictMessagesAfterInt(_ value: Any?) -> Int? {
-  guard let number = value as? NSNumber else { return nil }
-  guard CFGetTypeID(number) != CFBooleanGetTypeID() else { return nil }
-  return Int(number.stringValue)
-}
-
-private func strictMessagesAfterBool(_ value: Any?, name: String) throws -> Bool {
-  guard let value else { return false }
-  guard let number = value as? NSNumber, CFGetTypeID(number) == CFBooleanGetTypeID() else {
-    throw RPCError.invalidParams("\(name) must be a boolean")
-  }
-  return number.boolValue
 }

--- a/Sources/imsg/RPCServer+ScheduledHandlers.swift
+++ b/Sources/imsg/RPCServer+ScheduledHandlers.swift
@@ -1,17 +1,14 @@
-import CoreFoundation
 import Foundation
 import IMsgCore
 
 extension RPCServer {
   func handleMessagesScheduled(params: [String: Any], id: Any?) async throws {
-    let supportedParams: Set<String> = ["limit"]
-    if let unknown = params.keys.filter({ !supportedParams.contains($0) }).sorted().first {
-      throw RPCError.invalidParams("unknown messages.scheduled param: \(unknown)")
-    }
+    let params = try RPCParameters(
+      params, method: "messages.scheduled", supportedKeys: ["limit"])
 
     let limit: Int
-    if let value = params["limit"] {
-      guard let parsed = strictScheduledLimit(value) else {
+    if params.contains("limit") {
+      guard let parsed = try params.integer("limit"), parsed > 0 else {
         throw RPCError.invalidParams("limit must be a positive integer")
       }
       limit = parsed
@@ -34,11 +31,4 @@ extension RPCServer {
       throw RPCError.invalidParams(error.description)
     }
   }
-}
-
-private func strictScheduledLimit(_ value: Any) -> Int? {
-  guard let number = value as? NSNumber else { return nil }
-  guard CFGetTypeID(number) != CFBooleanGetTypeID() else { return nil }
-  guard let parsed = Int(number.stringValue), parsed > 0 else { return nil }
-  return parsed
 }

--- a/Sources/imsg/RPCServer+StatsHandlers.swift
+++ b/Sources/imsg/RPCServer+StatsHandlers.swift
@@ -1,17 +1,17 @@
-import CoreFoundation
 import Foundation
 import IMsgCore
 
 extension RPCServer {
   func handleMessagesStats(id: Any?, params: [String: Any]) async throws {
-    let supportedParams: Set<String> = ["chat_id", "include_media", "time_zone"]
-    if let unknown = params.keys.filter({ !supportedParams.contains($0) }).sorted().first {
-      throw RPCError.invalidParams("unknown messages.stats param: \(unknown)")
-    }
+    let params = try RPCParameters(
+      params,
+      method: "messages.stats",
+      supportedKeys: ["chat_id", "include_media", "time_zone"]
+    )
 
     let chatID: Int64?
-    if let value = params["chat_id"] {
-      guard let parsed = strictStatsInt64(value) else {
+    if params.contains("chat_id") {
+      guard let parsed = try params.int64("chat_id") else {
         throw RPCError.invalidParams("chat_id must be an integer")
       }
       chatID = parsed
@@ -20,24 +20,10 @@ extension RPCServer {
     }
 
     let includeMedia: Bool
-    if let value = params["include_media"] {
-      guard let parsed = strictStatsBool(value) else {
-        throw RPCError.invalidParams("include_media must be a boolean")
-      }
-      includeMedia = parsed
-    } else {
-      includeMedia = false
-    }
+    includeMedia = try params.boolean("include_media") ?? false
 
     let timeZone: String?
-    if let value = params["time_zone"] {
-      guard let parsed = value as? String else {
-        throw RPCError.invalidParams("time_zone must be a string")
-      }
-      timeZone = parsed
-    } else {
-      timeZone = nil
-    }
+    timeZone = try params.string("time_zone")
 
     do {
       let stats = try store.messageStats(
@@ -50,18 +36,6 @@ extension RPCServer {
       throw RPCError.invalidParams(error.description)
     }
   }
-}
-
-private func strictStatsInt64(_ value: Any) -> Int64? {
-  guard let number = value as? NSNumber else { return nil }
-  guard CFGetTypeID(number) != CFBooleanGetTypeID() else { return nil }
-  return Int64(number.stringValue)
-}
-
-private func strictStatsBool(_ value: Any) -> Bool? {
-  guard let number = value as? NSNumber else { return nil }
-  guard CFGetTypeID(number) == CFBooleanGetTypeID() else { return nil }
-  return number.boolValue
 }
 
 private func dictionary<T: Encodable>(from value: T) throws -> [String: Any] {

--- a/Sources/imsg/RPCServer+StickerHandlers.swift
+++ b/Sources/imsg/RPCServer+StickerHandlers.swift
@@ -1,30 +1,25 @@
-import CoreFoundation
 import Foundation
 import IMsgCore
 
 extension RPCServer {
   func handleSendSticker(params: [String: Any], id: Any?) async throws {
-    let supportedParams: Set<String> = [
-      "chat_id", "chat_identifier", "chat_guid", "file", "attach_to", "part_index",
-    ]
-    if let unknown = params.keys.filter({ !supportedParams.contains($0) }).sorted().first {
-      throw RPCError.invalidParams("unknown send.sticker param: \(unknown)")
+    let params = try RPCParameters(
+      params,
+      method: "send.sticker",
+      supportedKeys: RPCParameterKeys.combining(
+        RPCParameterKeys.chatTarget, ["file", "attach_to", "part_index"])
+    )
+    let targetInput = try params.chatTarget()
+    guard let file = try params.string("file"), !file.isEmpty else {
+      throw RPCError.invalidParams("file is required")
     }
-    let chatKeys = ["chat_id", "chat_identifier", "chat_guid"].filter { params[$0] != nil }
-    guard chatKeys.count == 1 else {
-      throw RPCError.invalidParams(
-        "exactly one of chat_id, chat_identifier, or chat_guid is required"
-      )
-    }
-    if let rawChatID = params["chat_id"] {
-      guard let chatID = strictStickerInt(rawChatID), chatID > 0 else {
-        throw RPCError.invalidParams("chat_id must be a positive integer")
-      }
-    } else {
-      let key = chatKeys[0]
-      guard let value = params[key] as? String, !value.isEmpty else {
-        throw RPCError.invalidParams("\(key) must be a nonempty string")
-      }
+    let explicitPart = try params.integer("part_index")
+    let rawTarget = try params.string("attach_to")
+    let target: StickerSendTarget?
+    do {
+      target = try StickerSendTarget.resolve(rawTarget: rawTarget, explicitPart: explicitPart)
+    } catch let error as StickerSendValidationError {
+      throw RPCError.invalidParams(error.description)
     }
     let requestedChatGUID = try await resolveChatGUIDParam(
       params,
@@ -40,7 +35,7 @@ extension RPCServer {
         preferredServices: ["iMessage", "iMessageLite"]
       )
     let chatGUID: String
-    if params["chat_guid"] != nil,
+    if !targetInput.chatGUID.isEmpty,
       let directGUID = directStickerChatGUID(requestedChatGUID)
     {
       chatGUID = directGUID
@@ -51,34 +46,6 @@ extension RPCServer {
       chatGUID = chatInfo.guid
     } else {
       throw RPCError.invalidParams(StickerSendValidationError.iMessageRequired.description)
-    }
-    guard let file = params["file"] as? String, !file.isEmpty else {
-      throw RPCError.invalidParams("file is required")
-    }
-
-    let explicitPart: Int?
-    if let rawPart = params["part_index"] {
-      guard let parsed = strictStickerInt(rawPart) else {
-        throw RPCError.invalidParams("part_index must be an integer")
-      }
-      explicitPart = parsed
-    } else {
-      explicitPart = nil
-    }
-    let rawTarget: String?
-    if let value = params["attach_to"] {
-      guard let parsed = value as? String else {
-        throw RPCError.invalidParams("attach_to must be a string")
-      }
-      rawTarget = parsed
-    } else {
-      rawTarget = nil
-    }
-    let target: StickerSendTarget?
-    do {
-      target = try StickerSendTarget.resolve(rawTarget: rawTarget, explicitPart: explicitPart)
-    } catch let error as StickerSendValidationError {
-      throw RPCError.invalidParams(error.description)
     }
     if let target {
       let belongsToChat = try store.messageBelongsToChat(
@@ -125,13 +92,4 @@ extension RPCServer {
     }
     respond(id: id, result: result)
   }
-}
-
-private func strictStickerInt(_ value: Any) -> Int? {
-  guard let number = value as? NSNumber else { return nil }
-  guard CFGetTypeID(number) != CFBooleanGetTypeID() else { return nil }
-  // Keep JSON integers distinct from integral floats/exponents on Darwin and Linux.
-  let type = String(cString: number.objCType)
-  guard type != "f", type != "d", type != "D" else { return nil }
-  return Int(number.stringValue)
 }

--- a/Sources/imsg/RPCServer.swift
+++ b/Sources/imsg/RPCServer.swift
@@ -151,7 +151,9 @@ final class RPCServer {
     case .success(let parsed):
       request = parsed
     case .failure(let failure):
-      output.sendError(id: failure.id, error: failure.error)
+      if failure.shouldRespond {
+        output.sendError(id: failure.id, error: failure.error)
+      }
       return
     }
     let method = request.method
@@ -163,16 +165,10 @@ final class RPCServer {
       case "chats.list":
         try await handleChatsList(id: id, params: params)
       case "messages.stats":
-        guard request.paramsAreNamed else {
-          throw RPCError.invalidParams("messages.stats params must be an object")
-        }
         try await handleMessagesStats(id: id, params: params)
       case "messages.history":
         try await handleMessagesHistory(id: id, params: params)
       case "messages.after":
-        guard request.paramsAreNamed else {
-          throw RPCError.invalidParams("messages.after params must be an object")
-        }
         try await handleMessagesAfter(id: id, params: params)
       case "watch.subscribe":
         try await handleWatchSubscribe(id: id, params: params)
@@ -185,14 +181,8 @@ final class RPCServer {
       case "send.attachment":
         try await handleSendAttachment(params: params, id: id)
       case "send.sticker":
-        guard request.paramsAreNamed else {
-          throw RPCError.invalidParams("send.sticker params must be an object")
-        }
         try await handleSendSticker(params: params, id: id)
       case "messages.scheduled":
-        guard request.paramsAreNamed else {
-          throw RPCError.invalidParams("messages.scheduled params must be an object")
-        }
         try await handleMessagesScheduled(params: params, id: id)
       case "poll.send", "messages.poll.send":
         try await handlePollSend(params: params, id: id)
@@ -233,34 +223,31 @@ final class RPCServer {
       case "group.leave":
         try await handleGroupLeave(id: id, params: params)
       case "contacts.shouldShareContact":
-        guard request.paramsAreNamed else {
-          throw RPCError.invalidParams("contacts.shouldShareContact params must be an object")
-        }
         try await handleNamePhotoStatus(params: params, id: id)
       case "contacts.shareContactCard":
-        guard request.paramsAreNamed else {
-          throw RPCError.invalidParams("contacts.shareContactCard params must be an object")
-        }
         try await handleNamePhotoShare(params: params, id: id)
       case "handles.check":
         try await handleHandlesCheck(params: params, id: id)
       default:
-        output.sendError(id: id, error: RPCError.methodNotFound(method))
+        if !request.isNotification {
+          output.sendError(id: id, error: RPCError.methodNotFound(method))
+        }
       }
     } catch let err as RPCError {
-      output.sendError(id: id, error: err)
+      if !request.isNotification {
+        output.sendError(id: id, error: err)
+      }
     } catch let err as IMsgError {
-      switch err {
-      case .invalidService, .invalidChatTarget:
-        output.sendError(
-          id: id,
-          error: RPCError.invalidParams(err.errorDescription ?? "invalid params")
-        )
-      default:
+      guard !request.isNotification else { return }
+      if err.isCallerCausedRPCError {
+        output.sendError(id: id, error: RPCError.invalidParams(err.localizedDescription))
+      } else {
         output.sendError(id: id, error: RPCError.internalError(err.localizedDescription))
       }
     } catch {
-      output.sendError(id: id, error: RPCError.internalError(error.localizedDescription))
+      if !request.isNotification {
+        output.sendError(id: id, error: RPCError.internalError(error.localizedDescription))
+      }
     }
   }
 
@@ -276,5 +263,17 @@ final class RPCServer {
       chatID: chatID,
       sentAt: sentAt
     )
+  }
+}
+
+extension IMsgError {
+  fileprivate var isCallerCausedRPCError: Bool {
+    switch self {
+    case .invalidISODate, .invalidService, .unsupportedService, .invalidChatTarget,
+      .invalidReaction, .unsupportedReaction, .chatNotFound:
+      return true
+    case .permissionDenied, .appleScriptFailure, .typingIndicatorFailed:
+      return false
+    }
   }
 }

--- a/Sources/imsg/RPCStartupErrorServer.swift
+++ b/Sources/imsg/RPCStartupErrorServer.swift
@@ -22,9 +22,13 @@ final class RPCStartupErrorServer {
   func handleLineForTesting(_ line: String) async {
     switch RPCRequestParser.parse(line) {
     case .success(let request):
-      output.sendError(id: request.id, error: RPCError.internalError(errorMessage))
+      if !request.isNotification {
+        output.sendError(id: request.id, error: RPCError.internalError(errorMessage))
+      }
     case .failure(let failure):
-      output.sendError(id: failure.id, error: failure.error)
+      if failure.shouldRespond {
+        output.sendError(id: failure.id, error: failure.error)
+      }
     }
   }
 }

--- a/Tests/imsgTests/RPCBridgeMessageHandlersTests.swift
+++ b/Tests/imsgTests/RPCBridgeMessageHandlersTests.swift
@@ -113,8 +113,7 @@ func rpcPollVoteValidatesAndResolvesOption() async throws {
 
   let request =
     #"{"jsonrpc":"2.0","id":"vote","method":"poll.vote","params":{"chat_id":1,"#
-    + #""poll_guid":"p:0/poll-guid-6","option_id":"choice-no","option_text":"spoofed","#
-    + #""voter_handle":"spoofed"}}"#
+    + #""poll_guid":"p:0/poll-guid-6","option_id":"choice-no"}}"#
   await server.handleLineForTesting(request)
 
   #expect(capturedAction == .sendPollVote)

--- a/Tests/imsgTests/RPCContractValidationTests.swift
+++ b/Tests/imsgTests/RPCContractValidationTests.swift
@@ -1,0 +1,390 @@
+import Foundation
+import Testing
+
+@testable import IMsgCore
+@testable import imsg
+
+@Test
+func rpcMalformedWatchParamsDoNotAllocateSubscription() async throws {
+  let store = try CommandTestDatabase.makeStoreForRPC()
+  let output = TestRPCOutput()
+  let server = RPCServer(store: store, verbose: false, output: output)
+  let invalidRequests = [
+    #"{"jsonrpc":"2.0","id":"array","method":"watch.subscribe","params":[]}"#,
+    #"{"jsonrpc":"2.0","id":"chat","method":"watch.subscribe","params":{"chat_id":"bogus"}}"#,
+    #"{"jsonrpc":"2.0","id":"typo","method":"watch.subscribe","params":{"chatId":1}}"#,
+    #"{"jsonrpc":"2.0","id":"participants","method":"watch.subscribe","params":{"participants":["+123",1]}}"#,
+    #"{"jsonrpc":"2.0","id":"boolean","method":"watch.subscribe","params":{"attachments":"false"}}"#,
+  ]
+
+  for request in invalidRequests {
+    await server.handleLineForTesting(request)
+  }
+
+  #expect(output.responses.isEmpty)
+  #expect(output.errors.count == invalidRequests.count)
+  #expect(output.errors.allSatisfy { rpcErrorCode($0) == -32602 })
+
+  await server.handleLineForTesting(
+    #"{"jsonrpc":"2.0","id":"valid","method":"watch.subscribe","params":{"chat_id":1,"since_rowid":999}}"#
+  )
+  let result = output.responses.first?["result"] as? [String: Any]
+  #expect(rpcInt64(result?["subscription"]) == 1)
+
+  await server.handleLineForTesting(
+    #"{"jsonrpc":"2.0","id":"cleanup","method":"watch.unsubscribe","params":{"subscription":1}}"#
+  )
+}
+
+@Test
+func rpcRejectsUnknownKeysAcrossHandlerFamilies() async throws {
+  let store = try CommandTestDatabase.makeStoreForRPC()
+  let output = TestRPCOutput()
+  var sent = false
+  var bridgeCalls = 0
+  let server = RPCServer(
+    store: store,
+    verbose: false,
+    output: output,
+    sendMessage: { _ in sent = true },
+    invokeBridge: { _, _ in
+      bridgeCalls += 1
+      return [:]
+    }
+  )
+  let requests = [
+    #"{"jsonrpc":"2.0","id":"read","method":"messages.history","params":{"chat_id":1,"extra":true}}"#,
+    #"{"jsonrpc":"2.0","id":"send","method":"send","params":{"to":"+123","text":"hi","extra":true}}"#,
+    #"{"jsonrpc":"2.0","id":"chat","method":"chats.delete","params":{"chat_id":1,"extra":true}}"#,
+    #"{"jsonrpc":"2.0","id":"bridge","method":"message.delete","params":{"chat_id":1,"message_id":"m","extra":true}}"#,
+  ]
+
+  for request in requests {
+    await server.handleLineForTesting(request)
+  }
+
+  #expect(output.errors.count == requests.count)
+  #expect(output.errors.allSatisfy { rpcErrorCode($0) == -32602 })
+  #expect(!sent)
+  #expect(bridgeCalls == 0)
+}
+
+@Test
+func rpcChatsCreateRejectsInvalidServiceAndAddressesBeforeBridge() async throws {
+  let store = try CommandTestDatabase.makeStoreForRPC()
+  let output = TestRPCOutput()
+  var bridgeCalls = 0
+  let server = RPCServer(
+    store: store,
+    verbose: false,
+    output: output,
+    invokeBridge: { _, _ in
+      bridgeCalls += 1
+      return [:]
+    }
+  )
+  let invalidParams = [
+    #"{"addresses":["+123"],"service":"auto"}"#,
+    #"{"addresses":["+123"],"service":"sms"}"#,
+    #"{"addresses":["+123"],"service":""}"#,
+    #"{"addresses":[]}"#,
+    #"{"addresses":["","   "]}"#,
+    #"{"addresses":["+123",42]}"#,
+  ]
+
+  for (index, params) in invalidParams.enumerated() {
+    await server.handleLineForTesting(
+      "{\"jsonrpc\":\"2.0\",\"id\":\"invalid-\(index)\","
+        + "\"method\":\"chats.create\",\"params\":\(params)}"
+    )
+  }
+
+  #expect(output.responses.isEmpty)
+  #expect(output.errors.count == invalidParams.count)
+  #expect(output.errors.allSatisfy { rpcErrorCode($0) == -32602 })
+  #expect(bridgeCalls == 0)
+}
+
+@Test
+func rpcRejectsConflictingTargetsBeforeMutations() async throws {
+  let store = try CommandTestDatabase.makeStoreForRPC()
+  let output = TestRPCOutput()
+  var sent = false
+  var bridgeCalls = 0
+  let server = RPCServer(
+    store: store,
+    verbose: false,
+    output: output,
+    sendMessage: { _ in sent = true },
+    invokeBridge: { _, _ in
+      bridgeCalls += 1
+      return [:]
+    }
+  )
+
+  await server.handleLineForTesting(
+    #"{"jsonrpc":"2.0","id":"selectors","method":"chats.delete","params":{"chat_id":1,"chat_guid":"iMessage;+;other"}}"#
+  )
+  await server.handleLineForTesting(
+    #"{"jsonrpc":"2.0","id":"recipient","method":"send","params":{"to":"+123","chat_id":1,"text":"hi"}}"#
+  )
+
+  #expect(output.errors.count == 2)
+  #expect(output.errors.allSatisfy { rpcErrorCode($0) == -32602 })
+  #expect(!sent)
+  #expect(bridgeCalls == 0)
+}
+
+@Test
+func rpcRejectsCoercedNumericAndBooleanValues() async throws {
+  let store = try CommandTestDatabase.makeStoreForRPC()
+  let output = TestRPCOutput()
+  let server = RPCServer(store: store, verbose: false, output: output)
+  let requests = [
+    #"{"jsonrpc":"2.0","id":"string","method":"messages.history","params":{"chat_id":"1"}}"#,
+    #"{"jsonrpc":"2.0","id":"bool-chat","method":"messages.history","params":{"chat_id":true}}"#,
+    #"{"jsonrpc":"2.0","id":"bool-limit","method":"chats.list","params":{"limit":false}}"#,
+    #"{"jsonrpc":"2.0","id":"number-bool","method":"chats.list","params":{"unread_only":1}}"#,
+  ]
+
+  for request in requests {
+    await server.handleLineForTesting(request)
+  }
+
+  #expect(output.responses.isEmpty)
+  #expect(output.errors.count == requests.count)
+  #expect(output.errors.allSatisfy { rpcErrorCode($0) == -32602 })
+}
+
+@Test
+func rpcRejectsDocumentedInvalidSemanticValuesBeforeSideEffects() async throws {
+  let store = try CommandTestDatabase.makeStoreForRPCWithStickerTarget()
+  let output = TestRPCOutput()
+  var bridgeCalls = 0
+  var stageCalls = 0
+  let server = RPCServer(
+    store: store,
+    verbose: false,
+    output: output,
+    invokeBridge: { _, _ in
+      bridgeCalls += 1
+      return [:]
+    },
+    stageSticker: { _ in
+      stageCalls += 1
+      throw StickerAssetError.couldNotStage("must not stage")
+    }
+  )
+  let requests = [
+    #"{"jsonrpc":"2.0","id":"history-id","method":"messages.history","params":{"chat_id":0}}"#,
+    #"{"jsonrpc":"2.0","id":"watch-id","method":"watch.subscribe","params":{"chat_id":-1}}"#,
+    #"{"jsonrpc":"2.0","id":"send-id","method":"send","params":{"chat_id":0,"text":"hi"}}"#,
+    #"{"jsonrpc":"2.0","id":"subscription","method":"watch.unsubscribe","params":{"subscription":0}}"#,
+    #"{"jsonrpc":"2.0","id":"empty-to","method":"read","params":{"to":""}}"#,
+    #"{"jsonrpc":"2.0","id":"empty-chat","method":"chats.delete","params":{"chat_guid":""}}"#,
+    #"{"jsonrpc":"2.0","id":"empty-address","method":"group.addParticipant","params":{"chat_id":1,"address":""}}"#,
+    #"{"jsonrpc":"2.0","id":"negative-part","method":"send.sticker","params":{"#
+      + #""chat_id":1,"file":"sticker.png","attach_to":"parent-guid","part_index":-1}}"#,
+  ]
+
+  for request in requests {
+    await server.handleLineForTesting(request)
+  }
+
+  #expect(output.responses.isEmpty)
+  #expect(output.errors.count == requests.count)
+  #expect(output.errors.allSatisfy { rpcErrorCode($0) == -32602 })
+  #expect(bridgeCalls == 0)
+  #expect(stageCalls == 0)
+}
+
+@Test
+func rpcRejectsConflictingAliasesBeforeSideEffects() async throws {
+  let store = try CommandTestDatabase.makeStoreForRPC()
+  let output = TestRPCOutput()
+  var bridgeCalls = 0
+  var sendCalls = 0
+  let server = RPCServer(
+    store: store,
+    verbose: false,
+    output: output,
+    sendMessage: { _ in sendCalls += 1 },
+    invokeBridge: { _, _ in
+      bridgeCalls += 1
+      return [:]
+    }
+  )
+  let requests = [
+    #"{"jsonrpc":"2.0","id":"chat-list","method":"chats.list","params":{"unread_only":false,"unreadOnly":false}}"#,
+    #"{"jsonrpc":"2.0","id":"watch","method":"watch.subscribe","params":{"debounce_ms":1,"debounceMs":1}}"#,
+    #"{"jsonrpc":"2.0","id":"send-format","method":"send","params":{"to":"+123","text":"hi","formatting":[],"textFormatting":[]}}"#,
+    #"{"jsonrpc":"2.0","id":"send-reply","method":"send","params":{"to":"+123","text":"hi","reply_to":"a","replyTo":"a"}}"#,
+    #"{"jsonrpc":"2.0","id":"rich","method":"send.rich","params":{"chat_id":1,"text":"hi","message":"hi"}}"#,
+    #"{"jsonrpc":"2.0","id":"attachment","method":"send.attachment","params":{"chat_id":1,"file":"a","path":"a"}}"#,
+    #"{"jsonrpc":"2.0","id":"attachment-audio","method":"send.attachment","params":{"#
+      + #""chat_id":1,"file":"a","audio":false,"is_audio":false}}"#,
+    #"{"jsonrpc":"2.0","id":"attachment-part","method":"send.attachment","params":{"#
+      + #""chat_id":1,"file":"a","reply_to":"m","part_index":0,"partIndex":0}}"#,
+    #"{"jsonrpc":"2.0","id":"poll","method":"poll.send","params":{"#
+      + #""chat_id":1,"question":"Q","options":["A","B"],"suppress_comment":false,"#
+      + #""suppressComment":false}}"#,
+    #"{"jsonrpc":"2.0","id":"poll-vote","method":"poll.vote","params":{"chat_id":1,"poll_guid":"p","pollGuid":"p","option_id":"o"}}"#,
+    #"{"jsonrpc":"2.0","id":"poll-option","method":"poll.vote","params":{"#
+      + #""chat_id":1,"poll_guid":"p","option_id":"o","optionIndex":1}}"#,
+    #"{"jsonrpc":"2.0","id":"tapback","method":"tapback","params":{"chat_id":1,"message_id":"m","reaction":"like","kind":"like"}}"#,
+    #"{"jsonrpc":"2.0","id":"edit","method":"message.edit","params":{"chat_id":1,"message_id":"m","text":"x","newText":"x"}}"#,
+    #"{"jsonrpc":"2.0","id":"part","method":"message.unsend","params":{"chat_id":1,"message_id":"m","part_index":0,"partIndex":0}}"#,
+    #"{"jsonrpc":"2.0","id":"message","method":"message.delete","params":{"chat_id":1,"message_id":"m","messageId":"m"}}"#,
+  ]
+
+  for request in requests {
+    await server.handleLineForTesting(request)
+  }
+
+  #expect(output.responses.isEmpty)
+  #expect(output.errors.count == requests.count)
+  #expect(output.errors.allSatisfy { rpcErrorCode($0) == -32602 })
+  #expect(bridgeCalls == 0)
+  #expect(sendCalls == 0)
+}
+
+@Test
+func rpcMapsInvalidISODatesToInvalidParams() async throws {
+  let store = try CommandTestDatabase.makeStoreForRPC()
+  let output = TestRPCOutput()
+  let server = RPCServer(store: store, verbose: false, output: output)
+
+  await server.handleLineForTesting(
+    #"{"jsonrpc":"2.0","id":"history","method":"messages.history","params":{"chat_id":1,"start":"not-a-date"}}"#
+  )
+  await server.handleLineForTesting(
+    #"{"jsonrpc":"2.0","id":"watch","method":"watch.subscribe","params":{"end":"still-not-a-date"}}"#
+  )
+
+  #expect(output.errors.count == 2)
+  #expect(output.errors.allSatisfy { rpcErrorCode($0) == -32602 })
+  let data = (output.errors.first?["error"] as? [String: Any])?["data"] as? String
+  #expect(data?.contains("Invalid ISO8601 date") == true)
+}
+
+@Test
+func rpcNotificationsNeverEmitResponsesOrErrors() async throws {
+  let store = try CommandTestDatabase.makeStoreForRPC()
+  let output = TestRPCOutput()
+  let server = RPCServer(store: store, verbose: false, output: output)
+
+  await server.handleLineForTesting(
+    #"{"jsonrpc":"2.0","method":"chats.list","params":{"limit":1}}"#
+  )
+  await server.handleLineForTesting(
+    #"{"jsonrpc":"2.0","method":"watch.subscribe","params":{"chat_id":"bogus"}}"#
+  )
+  await server.handleLineForTesting(
+    #"{"jsonrpc":"2.0","method":"missing.method","params":{}}"#
+  )
+  await server.handleLineForTesting(
+    #"{"jsonrpc":"2.0","method":"chats.list","params":[]}"#
+  )
+
+  #expect(output.responses.isEmpty)
+  #expect(output.errors.isEmpty)
+}
+
+@Test
+func rpcRequiresVersionAndValidRequestIDs() async throws {
+  let store = try CommandTestDatabase.makeStoreForRPC()
+  let output = TestRPCOutput()
+  let server = RPCServer(store: store, verbose: false, output: output)
+  let requests = [
+    #"{"id":"missing-version","method":"chats.list"}"#,
+    #"{"jsonrpc":"2.0","id":true,"method":"chats.list"}"#,
+    #"{"jsonrpc":"2.0","id":{},"method":"chats.list"}"#,
+    #"{"jsonrpc":"2.0","id":[],"method":"chats.list"}"#,
+  ]
+
+  for request in requests {
+    await server.handleLineForTesting(request)
+  }
+
+  #expect(output.errors.count == requests.count)
+  #expect(output.errors.allSatisfy { rpcErrorCode($0) == -32600 })
+  #expect(output.errors.dropFirst().allSatisfy { $0["id"] is NSNull })
+  #expect(output.errors.first?["id"] as? String == "missing-version")
+}
+
+@Test
+func rpcNullIDRemainsARequestWhileAbsentIDRemainsANotification() async throws {
+  let store = try CommandTestDatabase.makeStoreForRPC()
+  let output = TestRPCOutput()
+  let server = RPCServer(store: store, verbose: false, output: output)
+
+  await server.handleLineForTesting(
+    #"{"jsonrpc":"2.0","id":null,"method":"chats.list","params":{"limit":1}}"#
+  )
+  await server.handleLineForTesting(
+    #"{"jsonrpc":"2.0","method":"chats.list","params":{"limit":1}}"#
+  )
+
+  #expect(output.responses.count == 1)
+  #expect(output.responses.first?["id"] is NSNull)
+  #expect(output.errors.isEmpty)
+}
+
+@Test
+func rpcRejectsNullAndScalarParams() async throws {
+  let store = try CommandTestDatabase.makeStoreForRPC()
+  let output = TestRPCOutput()
+  let server = RPCServer(store: store, verbose: false, output: output)
+  for request in [
+    #"{"jsonrpc":"2.0","id":"null","method":"chats.list","params":null}"#,
+    #"{"jsonrpc":"2.0","id":"scalar","method":"chats.list","params":1}"#,
+    #"{"jsonrpc":"2.0","id":"array","method":"chats.list","params":[]}"#,
+  ] {
+    await server.handleLineForTesting(request)
+  }
+
+  #expect(output.errors.count == 3)
+  #expect(output.errors.allSatisfy { rpcErrorCode($0) == -32602 })
+}
+
+@Test
+func rpcOpenClawFormattingAliasesRemainSupported() async throws {
+  let store = try CommandTestDatabase.makeStoreForRPCDirectChat()
+  let output = TestRPCOutput()
+  var formattingPayloads: [[[String: Any]]] = []
+  let server = RPCServer(
+    store: store,
+    verbose: false,
+    output: output,
+    invokeBridge: { _, params in
+      formattingPayloads.append(params["textFormatting"] as? [[String: Any]] ?? [])
+      return ["messageGuid": "sent-guid"]
+    },
+    isBridgeReady: { true }
+  )
+
+  for alias in ["formatting", "textFormatting", "text_formatting"] {
+    let request =
+      #"{"jsonrpc":"2.0","id":"\#(alias)","method":"send","params":{"#
+      + #""to":"+123","text":"hello","\#(alias)":[{"start":0,"length":5,"styles":["bold"]}]}}"#
+    await server.handleLineForTesting(
+      request
+    )
+  }
+
+  #expect(output.errors.isEmpty)
+  #expect(output.responses.count == 3)
+  #expect(formattingPayloads.count == 3)
+  #expect(formattingPayloads.allSatisfy { $0.first?["styles"] as? [String] == ["bold"] })
+}
+
+private func rpcErrorCode(_ envelope: [String: Any]) -> Int64? {
+  rpcInt64((envelope["error"] as? [String: Any])?["code"])
+}
+
+private func rpcInt64(_ value: Any?) -> Int64? {
+  if let value = value as? Int64 { return value }
+  if let value = value as? Int { return Int64(value) }
+  if let value = value as? NSNumber { return value.int64Value }
+  return nil
+}

--- a/Tests/imsgTests/RPCPayloadsTests.swift
+++ b/Tests/imsgTests/RPCPayloadsTests.swift
@@ -323,19 +323,36 @@ func messagePayloadOmitsEmptyReplyToGuid() throws {
 
 @Test
 func watchDebounceIntervalDefaultsToHalfSecond() throws {
-  #expect(try watchDebounceIntervalParam([:]) == 0.5)
+  let params = try RPCParameters(
+    [:], method: "watch.subscribe", supportedKeys: ["debounce_ms", "debounceMs"])
+  #expect(try watchDebounceIntervalParam(params) == 0.5)
 }
 
 @Test
 func watchDebounceIntervalAcceptsSnakeAndCamelCaseMilliseconds() throws {
-  #expect(try watchDebounceIntervalParam(["debounce_ms": 750]) == 0.75)
-  #expect(try watchDebounceIntervalParam(["debounceMs": "125"]) == 0.125)
+  let snake = try RPCParameters(
+    ["debounce_ms": 750],
+    method: "watch.subscribe",
+    supportedKeys: ["debounce_ms", "debounceMs"]
+  )
+  let camel = try RPCParameters(
+    ["debounceMs": 125],
+    method: "watch.subscribe",
+    supportedKeys: ["debounce_ms", "debounceMs"]
+  )
+  #expect(try watchDebounceIntervalParam(snake) == 0.75)
+  #expect(try watchDebounceIntervalParam(camel) == 0.125)
 }
 
 @Test
 func watchDebounceIntervalRejectsInvalidValues() {
   do {
-    _ = try watchDebounceIntervalParam(["debounce_ms": -1])
+    let params = try RPCParameters(
+      ["debounce_ms": -1],
+      method: "watch.subscribe",
+      supportedKeys: ["debounce_ms", "debounceMs"]
+    )
+    _ = try watchDebounceIntervalParam(params)
     #expect(Bool(false))
   } catch let error as RPCError {
     #expect(error.code == -32602)
@@ -346,12 +363,21 @@ func watchDebounceIntervalRejectsInvalidValues() {
 }
 
 @Test
-func paramParsingHelpers() {
-  #expect(stringParam(123 as NSNumber) == "123")
-  #expect(intParam("42") == 42)
-  #expect(int64Param(NSNumber(value: 9_223_372_036_854_775_000 as Int64)) != nil)
-  #expect(boolParam("true") == true)
-  #expect(boolParam("false") == false)
-  #expect(stringArrayParam("a,b , c").count == 3)
-  #expect(stringArrayParam(["x", "y"]).count == 2)
+func rpcParametersPreserveStrictJSONTypes() throws {
+  let params = try RPCParameters(
+    [
+      "string": "value",
+      "integer": 42,
+      "int64": NSNumber(value: 9_223_372_036_854_775_000 as Int64),
+      "boolean": true,
+      "strings": ["x", "y"],
+    ],
+    method: "test",
+    supportedKeys: ["string", "integer", "int64", "boolean", "strings"]
+  )
+  #expect(try params.string("string") == "value")
+  #expect(try params.integer("integer") == 42)
+  #expect(try params.int64("int64") != nil)
+  #expect(try params.boolean("boolean") == true)
+  #expect(try params.stringArray("strings") == ["x", "y"])
 }

--- a/Tests/imsgTests/RPCServerTests.swift
+++ b/Tests/imsgTests/RPCServerTests.swift
@@ -106,12 +106,12 @@ func rpcChatsCreateForwardsBridgeIdentityFields() async throws {
 
   let line =
     #"{"jsonrpc":"2.0","id":"create","method":"chats.create","params":{"#
-    + #""addresses":["+123","+456"],"service":"auto","name":"Group","text":"hello"}}"#
+    + #""addresses":[" +123 ","+456"],"service":"ImEsSaGe","name":"Group","text":"hello"}}"#
   await server.handleLineForTesting(line)
 
   #expect(capturedAction == .createChat)
   #expect(capturedParams["addresses"] as? [String] == ["+123", "+456"])
-  #expect(capturedParams["service"] as? String == "auto")
+  #expect(capturedParams["service"] as? String == "iMessage")
   #expect(capturedParams["displayName"] as? String == "Group")
   #expect(capturedParams["message"] as? String == "hello")
   let result = output.responses.first?["result"] as? [String: Any]

--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -8,11 +8,47 @@ description: "Long-running JSON-RPC 2.0 over stdio for chats, history, watch, an
 ## Transport
 
 - One JSON object per line on stdin (request) and stdout (response/notification).
-- JSON-RPC 2.0 framing: `jsonrpc`, `id`, `method`, `params`.
-- Notifications omit `id`.
+- JSON-RPC 2.0 framing: `jsonrpc` must be exactly `"2.0"`; `id` may be a string,
+  number, or `null`; and `method` must be a non-empty string.
+- `params` may be omitted or provided as a named JSON object. Arrays, scalars,
+  and `null` are invalid params.
+- Notifications omit `id`. They never receive a response, including when the
+  method is unknown or its params are invalid.
 - Stderr is reserved for human-readable diagnostics.
 - Startup failures such as missing Full Disk Access are returned as JSON-RPC
   errors on the first request instead of human-readable stdout banners.
+
+Each method accepts only the keys documented for it. Unknown keys are rejected
+with `-32602` instead of being ignored. Values are type-strict: strings are not
+parsed as numbers or booleans, numbers are not converted to strings or
+booleans, booleans are not accepted as integers, and string arrays must contain
+only strings. This is deliberate fail-closed behavior for long-running agents.
+
+Supported compatibility aliases are explicit and method-specific:
+
+- `chats.list`: `unreadOnly` for `unread_only`.
+- `watch.subscribe`: `debounceMs` for `debounce_ms`.
+- `send`: `textFormatting` or `formatting` for `text_formatting`; `replyTo`,
+  `reply_to_guid`, or `message_guid` for `reply_to`.
+- `send.rich`: `message` for `text`; camelCase forms for `part_index`,
+  `dd_scan`, `effect_id`, and `text_formatting`; `effect` for `effect_id`; and
+  the same reply aliases as `send`.
+- `send.attachment`: `path` for `file`; `is_audio` or `as_voice` for `audio`;
+  `partIndex` for `part_index`; and the same reply aliases as `send`.
+- Poll methods accept their documented `messages.poll.*`/`polls.unvote` method
+  aliases plus camelCase parameter forms such as `creatorHandle`, `pollGuid`,
+  `optionId`, `optionIdentifier`, `optionIndex`, and `suppressComment`.
+- Message mutations accept the existing `messageId`, `messageGuid`, and
+  `message` target aliases, plus their documented text and part-index aliases.
+
+Other spellings, including `chatId`, are not aliases and are rejected.
+
+Protocol/framing failures use the JSON-RPC codes `-32700` (parse error),
+`-32600` (invalid request), and `-32601` (unknown method). Caller-caused value,
+selector, date, or supported-operation errors use `-32602` (invalid params).
+Runtime database, bridge, permission, and delivery failures use `-32603`
+(internal error). Parse errors and invalid requests whose ID cannot be
+established return the required `null` response ID.
 
 ## Lifecycle
 
@@ -36,6 +72,18 @@ Result:
 ```json
 { "chats": [Chat] }
 ```
+
+### `chats.create`
+
+Params:
+
+- `addresses` (non-empty array of phone/email strings, required)
+- `service` (`iMessage`, optional) — matched case-insensitively and normalized
+  to `iMessage`; other services are rejected
+- `name` (string, optional)
+- `text` (string, optional initial message)
+
+This bridge-backed method is iMessage-only, matching `imsg chat-create`.
 
 ### `messages.stats`
 
@@ -200,8 +248,11 @@ Params (direct send):
 
 Params (chat target):
 
-- `chat_id` *or* `chat_identifier` *or* `chat_guid` — exactly one. `chat_id` is preferred.
+- exactly one of `chat_id`, `chat_identifier`, or `chat_guid`.
 - `text` / `file` as above.
+
+`to` and chat selectors are mutually exclusive. Direct sends require `to` and
+no chat selector; chat-target sends require exactly one selector and no `to`.
 
 Result:
 
@@ -249,7 +300,9 @@ Missing rows return `pending` with `status_fields: null`.
 
 ### Bridge Message Actions
 
-These methods require the IMCore bridge and target an existing chat with `chat_id`, `chat_identifier`, or `chat_guid`.
+These methods require the IMCore bridge and target an existing chat with
+exactly one of `chat_id`, `chat_identifier`, or `chat_guid`. Supplying multiple
+selectors is invalid and no bridge operation is attempted.
 
 - `send.rich` sends text with optional `effect`, `subject`, `reply_to`, `part_index`, `dd_scan`, and `text_formatting`. Alternatively, pass only one chat target plus an HTTP(S) `url` to send an Apple URL-preview balloon. URL mode is iMessage-only and rejects text/send modifiers; metadata or image lookup failure falls back to a metadata-only card, never a plain-message send.
 - `send.attachment` sends `file` or `path`, with optional `audio` / `is_audio` / `as_voice`. Pass `reply_to` (or `replyTo`, `reply_to_guid`, or `message_guid`) to reply to an existing message. An optional non-negative integer `part_index` / `partIndex` selects that message's part and is invalid without a reply target.


### PR DESCRIPTION
## Summary

- make every `imsg rpc` method validate named parameters through one strict decoder
- reject unknown keys, type coercions, alias conflicts, and conflicting chat targets before reads or side effects
- enforce JSON-RPC 2.0 request and notification semantics with actionable error codes
- preserve the poll selector and attachment reply behavior landed in #213

## Problem

Several older RPC handlers treated malformed values as absent. A misspelled or wrongly typed `watch.subscribe` filter could therefore become an all-chat subscription, while multiple chat selectors allowed `chat_id` to silently override a different identifier or GUID. Other invalid caller inputs were reported as internal failures, and failed notifications incorrectly emitted response envelopes.

## Solution

The RPC layer now has one typed parameter boundary with explicit method key sets and documented aliases. Strings, integers, booleans, arrays, and IDs are no longer coerced. Methods accepting chat targets require exactly one selector, and direct recipients remain mutually exclusive with chat selectors. Caller validation happens before cache access, staging, bridge invocation, or mutation.

## Compatibility decision

This intentionally stops accepting RPC input that did not conform to the documented JSON-RPC contract, including omitted protocol versions, positional params, scalar coercions, ignored unknown keys, and multiple simultaneous chat selectors. We are accepting that upgrade break rather than adding a compatibility mode because the permissive behavior could silently broaden message subscriptions or redirect mutations to a different chat. Documented request shapes and the aliases listed in the RPC reference remain supported.

## Validation

- `make lint`
- `make test` — 527 tests across 5 suites
- `make build` — universal signed CLI and bridge helper
- `git diff --check`
- Codex autoreview — no accepted/actionable findings

## Live proof

The universal candidate was copied to an owner-only temporary directory on a private macOS test host and run against a real Messages database. The existing private bridge reported v2 ready with advanced features, typing indicators, and read receipts available.

A valid `chats.list` request succeeded. Eight malformed request classes returned `-32602` before subscription or mutation: wrong-type `chat_id`, `chatId` typo, mixed-type participants, string boolean, array params, unknown key, conflicting destructive chat selectors, and recipient plus chat selector. Two invalid notifications emitted no output. No message or chat mutation was performed, and all temporary files were removed.