### PR TITLE
fix(rpc): refresh long-lived contact and chat state

### DIFF
--- a/Sources/IMsgCore/ContactCatalog.swift
+++ b/Sources/IMsgCore/ContactCatalog.swift
@@ -1,0 +1,323 @@
+#if os(macOS)
+  import Foundation
+  @preconcurrency import Contacts
+
+  enum ContactCatalogAuthorization: Equatable, Sendable {
+    case authorized
+    case notDetermined
+    case unavailable
+  }
+
+  struct ContactCatalogRecord: Sendable {
+    let name: String
+    let phones: [String]
+    let emails: [String]
+  }
+
+  struct ContactCatalogSource: @unchecked Sendable {
+    let authorization: () -> ContactCatalogAuthorization
+    let load: () throws -> [ContactCatalogRecord]
+    let observeChanges: (@escaping @Sendable () -> Void) -> (() -> Void)
+  }
+
+  struct ContactCatalogSnapshot: Sendable {
+    let phoneToName: [String: String]
+    let emailToName: [String: String]
+    let contacts: [ContactCatalogRecord]
+  }
+
+  extension ContactResolver {
+    var cachedRegionCount: Int {
+      condition.lock()
+      defer { condition.unlock() }
+      return snapshots.count
+    }
+
+    func displayName(for handle: String, region: String) -> String? {
+      let state = snapshot(region: region)
+      guard !state.unavailable else { return nil }
+      let lookup = Self.normalizedLookupHandle(handle)
+      if lookup.contains("@") {
+        return state.catalog.emailToName[lookup.lowercased()]
+      }
+      let normalized = PhoneNumberNormalizer().normalize(lookup, region: region)
+      return state.catalog.phoneToName[normalized]
+    }
+
+    func displayNames(for handles: [String], region: String) -> [String: String] {
+      let state = snapshot(region: region)
+      guard !state.unavailable else { return [:] }
+      let lookupNormalizer = PhoneNumberNormalizer()
+      var resolved: [String: String] = [:]
+      for handle in handles {
+        let lookup = Self.normalizedLookupHandle(handle)
+        let name =
+          lookup.contains("@")
+          ? state.catalog.emailToName[lookup.lowercased()]
+          : state.catalog.phoneToName[lookupNormalizer.normalize(lookup, region: region)]
+        if let name { resolved[handle] = name }
+      }
+      return resolved
+    }
+
+    func searchByName(_ query: String, region: String) -> [ContactMatch] {
+      let state = snapshot(region: region)
+      guard !state.unavailable else { return [] }
+      let query = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+      guard !query.isEmpty else { return [] }
+
+      var matches: [ContactMatch] = []
+      for contact in state.catalog.contacts where contact.name.lowercased().contains(query) {
+        if let phone = contact.phones.first {
+          matches.append(ContactMatch(name: contact.name, handle: phone))
+        } else if let email = contact.emails.first {
+          matches.append(ContactMatch(name: contact.name, handle: email))
+        }
+      }
+      return matches
+    }
+
+    func invalidate() {
+      condition.lock()
+      invalidated = true
+      condition.broadcast()
+      condition.unlock()
+    }
+
+    func snapshot(
+      region: String
+    ) -> (catalog: ContactCatalogSnapshot, unavailable: Bool) {
+      let region = Self.normalizedRegion(region)
+      condition.lock()
+      while true {
+        let authorization = source.authorization()
+        if authorization != .authorized {
+          if refreshing {
+            condition.wait()
+            continue
+          }
+          apply(.unauthorized)
+          let catalog = regionSnapshot(region)
+          condition.unlock()
+          return (catalog, true)
+        }
+        let authorizationBecameAvailable = !authorizationWasAvailable
+        authorizationWasAvailable = true
+        let shouldRefresh = authorizationBecameAvailable || invalidated || now() >= nextRefreshAt
+        if shouldRefresh, refreshing {
+          condition.wait()
+          continue
+        }
+        if shouldRefresh {
+          refreshing = true
+          invalidated = false
+          condition.unlock()
+          let result = loadCatalog()
+          condition.lock()
+          apply(source.authorization() == .authorized ? result : .unauthorized)
+          refreshing = false
+          condition.broadcast()
+          if invalidated { continue }
+          let catalog = regionSnapshot(region)
+          let isUnavailable = unavailable
+          condition.unlock()
+          return (catalog, isUnavailable)
+        }
+
+        let catalog = regionSnapshot(region)
+        let isUnavailable = unavailable
+        condition.unlock()
+        return (catalog, isUnavailable)
+      }
+    }
+
+    private enum LoadResult {
+      case loaded([ContactCatalogRecord])
+      case transientFailure
+      case unauthorized
+    }
+
+    private func loadCatalog() -> LoadResult {
+      guard source.authorization() == .authorized else { return .unauthorized }
+      do {
+        return .loaded(try source.load())
+      } catch {
+        return .transientFailure
+      }
+    }
+
+    private func apply(_ result: LoadResult) {
+      nextRefreshAt = now() + refreshInterval
+      switch result {
+      case .loaded(let loaded):
+        records = loaded
+        snapshots.removeAll(keepingCapacity: true)
+        regionRecency.removeAll(keepingCapacity: true)
+        hasLastGoodCatalog = true
+        unavailable = false
+      case .transientFailure:
+        unavailable = !hasLastGoodCatalog
+      case .unauthorized:
+        authorizationWasAvailable = false
+        records.removeAll(keepingCapacity: false)
+        snapshots.removeAll(keepingCapacity: false)
+        regionRecency.removeAll(keepingCapacity: false)
+        hasLastGoodCatalog = false
+        unavailable = true
+      }
+    }
+
+    private func regionSnapshot(_ region: String) -> ContactCatalogSnapshot {
+      if let existing = snapshots[region] {
+        touch(region)
+        return existing
+      }
+
+      var phoneToName: [String: String] = [:]
+      var emailToName: [String: String] = [:]
+      var normalizedContacts: [ContactCatalogRecord] = []
+      normalizedContacts.reserveCapacity(records.count)
+      for contact in records {
+        let phones = contact.phones.map { normalizer.normalize($0, region: region) }
+        let emails = contact.emails.map { $0.lowercased() }
+        for phone in phones {
+          phoneToName[phone] = phoneToName[phone] ?? contact.name
+        }
+        for email in emails {
+          emailToName[email] = emailToName[email] ?? contact.name
+        }
+        normalizedContacts.append(
+          ContactCatalogRecord(name: contact.name, phones: phones, emails: emails))
+      }
+      let created = ContactCatalogSnapshot(
+        phoneToName: phoneToName,
+        emailToName: emailToName,
+        contacts: normalizedContacts
+      )
+      snapshots[region] = created
+      touch(region)
+      while snapshots.count > maximumRegionSnapshots, let oldest = regionRecency.first {
+        regionRecency.removeFirst()
+        snapshots.removeValue(forKey: oldest)
+      }
+      return created
+    }
+
+    private func touch(_ region: String) {
+      regionRecency.removeAll { $0 == region }
+      regionRecency.append(region)
+    }
+
+    static func normalizedRegion(_ region: String) -> String {
+      let normalized = region.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
+      return normalized.isEmpty ? "US" : normalized
+    }
+
+    private static func normalizedLookupHandle(_ handle: String) -> String {
+      let trimmed = handle.trimmingCharacters(in: .whitespacesAndNewlines)
+      for prefix in ["iMessage;-;", "iMessage;+;", "SMS;-;", "SMS;+;", "any;-;", "any;+;"]
+      where trimmed.hasPrefix(prefix) {
+        return String(trimmed.dropFirst(prefix.count))
+      }
+      return trimmed
+    }
+
+    static func requestAccess(store: CNContactStore) async -> Bool {
+      await withCheckedContinuation { continuation in
+        store.requestAccess(for: .contacts) { granted, _ in
+          continuation.resume(returning: granted)
+        }
+      }
+    }
+
+    static func contactSource(store: CNContactStore) -> ContactCatalogSource {
+      ContactCatalogSource(
+        authorization: {
+          catalogAuthorization(CNContactStore.authorizationStatus(for: .contacts))
+        },
+        load: { try loadRecords(store: store) },
+        observeChanges: { changed in
+          let center = NotificationCenter.default
+          let token = center.addObserver(
+            forName: .CNContactStoreDidChange,
+            object: nil,
+            queue: nil
+          ) { _ in
+            changed()
+          }
+          return { center.removeObserver(token) }
+        }
+      )
+    }
+
+    static func catalogAuthorization(
+      _ authorizationStatus: CNAuthorizationStatus
+    ) -> ContactCatalogAuthorization {
+      switch authorizationStatus {
+      case .authorized:
+        return .authorized
+      case .notDetermined:
+        return .notDetermined
+      case .denied, .restricted:
+        return .unavailable
+      @unknown default:
+        return .unavailable
+      }
+    }
+
+    static func loadRecords(store: CNContactStore) throws -> [ContactCatalogRecord] {
+      let keysToFetch: [CNKeyDescriptor] = [
+        CNContactGivenNameKey as CNKeyDescriptor,
+        CNContactFamilyNameKey as CNKeyDescriptor,
+        CNContactNicknameKey as CNKeyDescriptor,
+        CNContactPhoneNumbersKey as CNKeyDescriptor,
+        CNContactEmailAddressesKey as CNKeyDescriptor,
+      ]
+      let request = CNContactFetchRequest(keysToFetch: keysToFetch)
+      var contacts: [ContactCatalogRecord] = []
+      try store.enumerateContacts(with: request) { contact, _ in
+        guard let name = displayName(for: contact) else { return }
+        let phones = contact.phoneNumbers.map(\.value.stringValue)
+        let emails = contact.emailAddresses.map { String($0.value) }
+        if !phones.isEmpty || !emails.isEmpty {
+          contacts.append(ContactCatalogRecord(name: name, phones: phones, emails: emails))
+        }
+      }
+      return contacts
+    }
+
+    private static func displayName(for contact: CNContact) -> String? {
+      if !contact.nickname.isEmpty { return contact.nickname }
+      let name = [contact.givenName, contact.familyName]
+        .filter { !$0.isEmpty }
+        .joined(separator: " ")
+      return name.isEmpty ? nil : name
+    }
+  }
+
+  final class ContactRegionResolver: ContactResolving, Sendable {
+    private let owner: ContactResolver
+    private let region: String
+
+    init(owner: ContactResolver, region: String) {
+      self.owner = owner
+      self.region = region
+    }
+
+    var contactsUnavailable: Bool {
+      owner.snapshot(region: region).unavailable
+    }
+
+    func displayName(for handle: String) -> String? {
+      owner.displayName(for: handle, region: region)
+    }
+
+    func displayNames(for handles: [String]) -> [String: String] {
+      owner.displayNames(for: handles, region: region)
+    }
+
+    func searchByName(_ query: String) -> [ContactMatch] {
+      owner.searchByName(query, region: region)
+    }
+  }
+#endif

--- a/Sources/IMsgCore/ContactResolver.swift
+++ b/Sources/IMsgCore/ContactResolver.swift
@@ -39,30 +39,49 @@ public enum ContactsAccessPolicy: Sendable {
   case skipIfNotDetermined
 }
 
+/// A process-owned Contacts catalog. Reads stay synchronous for existing callers, while the
+/// owner refreshes on Contacts notifications and a bounded TTL fallback.
 public final class ContactResolver: ContactResolving, @unchecked Sendable {
   #if os(macOS)
-    private let phoneToName: [String: String]
-    private let emailToName: [String: String]
-    private let contacts: [ContactRecord]
-    private let normalizer = PhoneNumberNormalizer()
-    private let region: String
+    let source: ContactCatalogSource
+    let refreshInterval: TimeInterval
+    let maximumRegionSnapshots: Int
+    let now: () -> TimeInterval
+    let normalizer = PhoneNumberNormalizer()
+    let condition = NSCondition()
+    let defaultRegion: String
 
-    public let contactsUnavailable: Bool
+    var records: [ContactCatalogRecord] = []
+    var snapshots: [String: ContactCatalogSnapshot] = [:]
+    var regionRecency: [String] = []
+    var nextRefreshAt: TimeInterval = -.infinity
+    var invalidated = true
+    var refreshing = false
+    var authorizationWasAvailable = false
+    var hasLastGoodCatalog = false
+    var unavailable = true
+    var cancelObservation: (() -> Void)?
 
-    private init(
-      phoneToName: [String: String],
-      emailToName: [String: String],
-      contacts: [ContactRecord],
-      region: String
+    init(
+      region: String,
+      source: ContactCatalogSource,
+      refreshInterval: TimeInterval = 30,
+      maximumRegionSnapshots: Int = 8,
+      now: @escaping () -> TimeInterval = { ProcessInfo.processInfo.systemUptime }
     ) {
-      self.phoneToName = phoneToName
-      self.emailToName = emailToName
-      self.contacts = contacts
-      self.region = region
-      self.contactsUnavailable = false
+      self.defaultRegion = Self.normalizedRegion(region)
+      self.source = source
+      self.refreshInterval = max(0, refreshInterval)
+      self.maximumRegionSnapshots = max(1, maximumRegionSnapshots)
+      self.now = now
+      self.cancelObservation = source.observeChanges { [weak self] in
+        self?.invalidate()
+      }
     }
-  #else
-    public let contactsUnavailable = true
+
+    deinit {
+      cancelObservation?()
+    }
   #endif
 
   public static func create(
@@ -71,13 +90,11 @@ public final class ContactResolver: ContactResolving, @unchecked Sendable {
   ) async -> any ContactResolving {
     #if os(macOS)
       let store = CNContactStore()
-      return await create(
-        region: region,
-        accessPolicy: accessPolicy,
-        store: store,
-        authorizationStatus: CNContactStore.authorizationStatus(for: .contacts),
-        requestAccess: requestAccess(store:)
-      )
+      let initialStatus = CNContactStore.authorizationStatus(for: .contacts)
+      if initialStatus == .notDetermined, accessPolicy == .requestIfNeeded {
+        _ = await requestAccess(store: store)
+      }
+      return ContactResolver(region: region, source: contactSource(store: store))
     #else
       _ = region
       _ = accessPolicy
@@ -93,31 +110,43 @@ public final class ContactResolver: ContactResolving, @unchecked Sendable {
       authorizationStatus: CNAuthorizationStatus,
       requestAccess: @escaping (CNContactStore) async -> Bool
     ) async -> any ContactResolving {
-      switch authorizationStatus {
-      case .authorized:
-        return load(store: store, region: region)
-      case .notDetermined:
-        guard accessPolicy == .requestIfNeeded else {
-          return NoOpContactResolver(contactsUnavailable: true)
-        }
-        let granted = await requestAccess(store)
-        return granted
-          ? load(store: store, region: region) : NoOpContactResolver(contactsUnavailable: true)
-      case .denied, .restricted:
-        return NoOpContactResolver(contactsUnavailable: true)
-      @unknown default:
-        return NoOpContactResolver(contactsUnavailable: true)
+      let resolvedStatus: CNAuthorizationStatus
+      if authorizationStatus == .notDetermined, accessPolicy == .requestIfNeeded {
+        resolvedStatus = await requestAccess(store) ? .authorized : .denied
+      } else {
+        resolvedStatus = authorizationStatus
       }
+      let source = ContactCatalogSource(
+        authorization: { catalogAuthorization(resolvedStatus) },
+        load: { try loadRecords(store: store) },
+        observeChanges: { _ in {} }
+      )
+      return ContactResolver(region: region, source: source)
     }
   #endif
 
+  public var contactsUnavailable: Bool {
+    #if os(macOS)
+      return snapshot(region: defaultRegion).unavailable
+    #else
+      return true
+    #endif
+  }
+
+  public func resolver(region: String) -> any ContactResolving {
+    #if os(macOS)
+      let region = Self.normalizedRegion(region)
+      if region == defaultRegion { return self }
+      return ContactRegionResolver(owner: self, region: region)
+    #else
+      _ = region
+      return self
+    #endif
+  }
+
   public func displayName(for handle: String) -> String? {
     #if os(macOS)
-      let lookup = normalizedLookupHandle(handle)
-      if lookup.contains("@") {
-        return emailToName[lookup.lowercased()]
-      }
-      return phoneToName[normalizer.normalize(lookup, region: region)]
+      return displayName(for: handle, region: defaultRegion)
     #else
       _ = handle
       return nil
@@ -126,13 +155,7 @@ public final class ContactResolver: ContactResolving, @unchecked Sendable {
 
   public func displayNames(for handles: [String]) -> [String: String] {
     #if os(macOS)
-      var resolved: [String: String] = [:]
-      for handle in handles {
-        if let name = displayName(for: handle) {
-          resolved[handle] = name
-        }
-      }
-      return resolved
+      return displayNames(for: handles, region: defaultRegion)
     #else
       _ = handles
       return [:]
@@ -141,105 +164,10 @@ public final class ContactResolver: ContactResolving, @unchecked Sendable {
 
   public func searchByName(_ query: String) -> [ContactMatch] {
     #if os(macOS)
-      let normalizedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-      guard !normalizedQuery.isEmpty else { return [] }
-
-      var matches: [ContactMatch] = []
-      for contact in contacts where contact.name.lowercased().contains(normalizedQuery) {
-        if let phone = contact.phones.first {
-          matches.append(ContactMatch(name: contact.name, handle: phone))
-        } else if let email = contact.emails.first {
-          matches.append(ContactMatch(name: contact.name, handle: email))
-        }
-      }
-      return matches
+      return searchByName(query, region: defaultRegion)
     #else
       _ = query
       return []
     #endif
   }
-
-  #if os(macOS)
-    private static func requestAccess(store: CNContactStore) async -> Bool {
-      await withCheckedContinuation { continuation in
-        store.requestAccess(for: .contacts) { granted, _ in
-          continuation.resume(returning: granted)
-        }
-      }
-    }
-
-    private static func load(store: CNContactStore, region: String) -> any ContactResolving {
-      let keysToFetch: [CNKeyDescriptor] = [
-        CNContactGivenNameKey as CNKeyDescriptor,
-        CNContactFamilyNameKey as CNKeyDescriptor,
-        CNContactNicknameKey as CNKeyDescriptor,
-        CNContactPhoneNumbersKey as CNKeyDescriptor,
-        CNContactEmailAddressesKey as CNKeyDescriptor,
-      ]
-      let request = CNContactFetchRequest(keysToFetch: keysToFetch)
-      let normalizer = PhoneNumberNormalizer()
-      var phoneToName: [String: String] = [:]
-      var emailToName: [String: String] = [:]
-      var contacts: [ContactRecord] = []
-
-      do {
-        try store.enumerateContacts(with: request) { contact, _ in
-          guard let name = displayName(for: contact) else { return }
-          var phones: [String] = []
-          var emails: [String] = []
-
-          for number in contact.phoneNumbers {
-            let normalized = normalizer.normalize(number.value.stringValue, region: region)
-            phones.append(normalized)
-            phoneToName[normalized] = phoneToName[normalized] ?? name
-          }
-          for email in contact.emailAddresses {
-            let normalized = String(email.value).lowercased()
-            emails.append(normalized)
-            emailToName[normalized] = emailToName[normalized] ?? name
-          }
-
-          if !phones.isEmpty || !emails.isEmpty {
-            contacts.append(ContactRecord(name: name, phones: phones, emails: emails))
-          }
-        }
-      } catch {
-        return NoOpContactResolver(contactsUnavailable: true)
-      }
-
-      return ContactResolver(
-        phoneToName: phoneToName,
-        emailToName: emailToName,
-        contacts: contacts,
-        region: region
-      )
-    }
-
-    private static func displayName(for contact: CNContact) -> String? {
-      if !contact.nickname.isEmpty {
-        return contact.nickname
-      }
-      let name = [contact.givenName, contact.familyName]
-        .filter { !$0.isEmpty }
-        .joined(separator: " ")
-      return name.isEmpty ? nil : name
-    }
-
-    private func normalizedLookupHandle(_ handle: String) -> String {
-      let trimmed = handle.trimmingCharacters(in: .whitespacesAndNewlines)
-      for prefix in ["iMessage;-;", "iMessage;+;", "SMS;-;", "SMS;+;", "any;-;", "any;+;"]
-      where trimmed.hasPrefix(prefix) {
-        return String(trimmed.dropFirst(prefix.count))
-      }
-      return trimmed
-    }
-  #endif
 }
-
-#if os(macOS)
-  private struct ContactRecord: Sendable {
-    let name: String
-    let phones: [String]
-    let emails: [String]
-  }
-#endif

--- a/Sources/imsg/Commands/BridgeIntroCommands.swift
+++ b/Sources/imsg/Commands/BridgeIntroCommands.swift
@@ -47,11 +47,9 @@ enum SearchCommand {
     let contacts = await contactResolverFactory()
 
     if runtime.jsonOutput {
-      let cache = ChatCache(store: store)
       for message in messages {
-        let payload = try await buildMessagePayload(
+        let payload = try buildMessagePayload(
           store: store,
-          cache: cache,
           message: message,
           includeAttachments: false,
           includeReactions: false,

--- a/Sources/imsg/Commands/HistoryCommand.swift
+++ b/Sources/imsg/Commands/HistoryCommand.swift
@@ -66,16 +66,14 @@ enum HistoryCommand {
     let contacts = await contactResolverFactory()
 
     if runtime.jsonOutput {
-      let cache = ChatCache(store: store)
       let attachmentsByMessageID = try store.attachments(
         for: filtered.map(\.rowID),
         options: attachmentOptions
       )
       let reactionsByMessageID = try store.reactions(for: filtered)
       for message in filtered {
-        let payload = try await buildMessagePayload(
+        let payload = try buildMessagePayload(
           store: store,
-          cache: cache,
           message: message,
           includeAttachments: true,
           includeReactions: true,

--- a/Sources/imsg/Commands/WatchCommand.swift
+++ b/Sources/imsg/Commands/WatchCommand.swift
@@ -96,7 +96,6 @@ enum WatchCommand {
 
     let store = try storeFactory(dbPath)
     let watcher = MessageWatcher(store: store)
-    let cache = ChatCache(store: store)
     let contacts = await contactResolverFactory()
     let config = MessageWatcherConfiguration(
       debounceInterval: debounceInterval,
@@ -129,9 +128,8 @@ enum WatchCommand {
     let stream = streamProvider(watcher, chatID, sinceRowID, config, filter)
     for try await message in stream {
       if runtime.jsonOutput {
-        let payload = try await buildMessagePayload(
+        let payload = try buildMessagePayload(
           store: store,
-          cache: cache,
           message: message,
           includeAttachments: true,
           includeReactions: true,

--- a/Sources/imsg/RPCDatabaseResources.swift
+++ b/Sources/imsg/RPCDatabaseResources.swift
@@ -6,12 +6,10 @@ typealias RPCMessageStoreFactory = @Sendable (String) throws -> MessageStore
 struct RPCDatabaseResources: Sendable {
   let store: MessageStore
   let watcher: MessageWatcher
-  let cache: ChatCache
 
   init(store: MessageStore) {
     self.store = store
     self.watcher = MessageWatcher(store: store)
-    self.cache = ChatCache(store: store)
   }
 }
 

--- a/Sources/imsg/RPCServer+BridgeMessageHandlers.swift
+++ b/Sources/imsg/RPCServer+BridgeMessageHandlers.swift
@@ -159,7 +159,7 @@ extension RPCServer {
 
     let info: ChatInfo?
     if let chatID = target.chatID {
-      info = try await database.cache.info(chatID: chatID)
+      info = try database.store.chatInfo(chatID: chatID)
     } else if !target.chatIdentifier.isEmpty {
       info = try database.store.chatInfo(
         matchingExactIdentifier: target.chatIdentifier,

--- a/Sources/imsg/RPCServer+ChatHandlers.swift
+++ b/Sources/imsg/RPCServer+ChatHandlers.swift
@@ -158,7 +158,7 @@ extension RPCServer {
     }
     let resolved = try await ChatTargetResolver.resolveChatTarget(
       input: input,
-      lookupChat: { chatID in try await database?.cache.info(chatID: chatID) },
+      lookupChat: { chatID in try database?.store.chatInfo(chatID: chatID) },
       unknownChatError: { chatID in RPCError.invalidParams("unknown chat_id \(chatID)") }
     )
     if !resolved.chatGUID.isEmpty {

--- a/Sources/imsg/RPCServer+Handlers.swift
+++ b/Sources/imsg/RPCServer+Handlers.swift
@@ -26,7 +26,6 @@ extension RPCServer {
     let unreadOnly = try params.boolean("unread_only", aliases: ["unreadOnly"]) ?? false
     let database = try await databaseResources.require()
     let store = database.store
-    let cache = database.cache
     guard !unreadOnly || store.supportsUnreadState else {
       throw RPCError.invalidParams(
         "unread_only is unavailable because this Messages database has no read-state column")
@@ -36,8 +35,8 @@ extension RPCServer {
     payloads.reserveCapacity(chats.count)
 
     for chat in chats {
-      let info = try await cache.info(chatID: chat.id)
-      let participants = try await cache.participants(chatID: chat.id)
+      let info = try store.chatInfo(chatID: chat.id)
+      let participants = try store.participants(chatID: chat.id)
       let identifier = info?.identifier ?? chat.identifier
       let guid = info?.guid ?? ""
       let name = (info?.name.isEmpty == false ? info?.name : nil) ?? chat.name
@@ -86,7 +85,6 @@ extension RPCServer {
       convertUnsupported: try params.boolean("convert_attachments") ?? false)
     let database = try await databaseResources.require()
     let store = database.store
-    let cache = database.cache
     let filter = try MessageFilter.fromISO(
       participants: participants,
       startISO: startISO,
@@ -98,9 +96,8 @@ extension RPCServer {
     var payloads: [[String: Any]] = []
     payloads.reserveCapacity(filtered.count)
     for message in filtered {
-      let payload = try await buildMessagePayload(
+      let payload = try buildMessagePayload(
         store: store,
-        cache: cache,
         message: message,
         includeAttachments: includeAttachments,
         includeReactions: true,
@@ -138,6 +135,8 @@ extension RPCServer {
     }
     let transport = try RPCSendTransport.parse(try params.string("transport"))
     let region = try params.string("region") ?? "US"
+    let requestContacts =
+      (contactResolver as? ContactResolver)?.resolver(region: region) ?? contactResolver
     let selectedMessageGuid = try params.string(
       "reply_to", aliases: ["replyTo", "reply_to_guid", "message_guid"]
     ).flatMap { $0.isEmpty ? nil : $0 }
@@ -148,7 +147,7 @@ extension RPCServer {
       recipient =
         rawInput.hasChatTarget || rawRecipient.isEmpty
         ? rawRecipient
-        : try ChatTargetResolver.resolveRecipientName(rawRecipient, contacts: contactResolver)
+        : try ChatTargetResolver.resolveRecipientName(rawRecipient, contacts: requestContacts)
     } catch {
       throw RPCError.invalidParams(error.localizedDescription)
     }
@@ -172,7 +171,7 @@ extension RPCServer {
 
     let resolvedTarget = try await ChatTargetResolver.resolveChatTarget(
       input: input,
-      lookupChat: { chatID in try await database?.cache.info(chatID: chatID) },
+      lookupChat: { chatID in try database?.store.chatInfo(chatID: chatID) },
       unknownChatError: { chatID in
         RPCError.invalidParams("unknown chat_id \(chatID)")
       }
@@ -298,10 +297,10 @@ extension RPCServer {
     }
     var responseChatInfo: ChatInfo?
     if let sentMessage, let database {
-      responseChatInfo = try? await database.cache.info(chatID: sentMessage.chatID)
+      responseChatInfo = try? database.store.chatInfo(chatID: sentMessage.chatID)
     }
     if responseChatInfo == nil, let verificationChatID, let database {
-      responseChatInfo = try? await database.cache.info(chatID: verificationChatID)
+      responseChatInfo = try? database.store.chatInfo(chatID: verificationChatID)
     }
     if responseChatInfo == nil {
       responseChatInfo = directChatInfo
@@ -347,7 +346,7 @@ extension RPCServer {
     }
     let resolvedTarget = try await ChatTargetResolver.resolveChatTarget(
       input: input,
-      lookupChat: { chatID in try await database?.cache.info(chatID: chatID) },
+      lookupChat: { chatID in try database?.store.chatInfo(chatID: chatID) },
       unknownChatError: { chatID in
         RPCError.invalidParams("unknown chat_id \(chatID)")
       }
@@ -401,7 +400,7 @@ extension RPCServer {
     }
     let resolvedTarget = try await ChatTargetResolver.resolveChatTarget(
       input: input,
-      lookupChat: { chatID in try await database?.cache.info(chatID: chatID) },
+      lookupChat: { chatID in try database?.store.chatInfo(chatID: chatID) },
       unknownChatError: { chatID in
         RPCError.invalidParams("unknown chat_id \(chatID)")
       }
@@ -433,7 +432,6 @@ extension RPCServer {
 
 func buildMessagePayload(
   store: MessageStore,
-  cache: ChatCache,
   message: Message,
   includeAttachments: Bool,
   includeReactions: Bool,
@@ -441,9 +439,9 @@ func buildMessagePayload(
   prefetchedReactions: [Reaction]? = nil,
   attachmentOptions: AttachmentQueryOptions = .default,
   contactResolver: any ContactResolving = NoOpContactResolver()
-) async throws -> [String: Any] {
-  let chatInfo = try await cache.info(chatID: message.chatID)
-  let participants = try await cache.participants(chatID: message.chatID)
+) throws -> [String: Any] {
+  let chatInfo = try store.chatInfo(chatID: message.chatID)
+  let participants = try store.participants(chatID: message.chatID)
   let attachments: [AttachmentMeta]
   if includeAttachments {
     attachments =

--- a/Sources/imsg/RPCServer+MessagesAfterHandlers.swift
+++ b/Sources/imsg/RPCServer+MessagesAfterHandlers.swift
@@ -45,7 +45,6 @@ extension RPCServer {
       convertUnsupported: try params.boolean("convert_attachments") ?? false)
     let database = try await databaseResources.require()
     let store = database.store
-    let cache = database.cache
     let page = try store.messagesAfterPage(
       afterRowID: sinceRowID,
       chatID: chatID,
@@ -57,9 +56,8 @@ extension RPCServer {
     payloads.reserveCapacity(page.messages.count)
     for message in page.messages {
       payloads.append(
-        try await buildMessagePayload(
+        try buildMessagePayload(
           store: store,
-          cache: cache,
           message: message,
           includeAttachments: includeAttachments,
           includeReactions: true,

--- a/Sources/imsg/RPCServer+Support.swift
+++ b/Sources/imsg/RPCServer+Support.swift
@@ -301,32 +301,6 @@ actor SubscriptionStartGate {
   }
 }
 
-actor ChatCache {
-  private let store: MessageStore
-  private var infoCache: [Int64: ChatInfo] = [:]
-  private var participantsCache: [Int64: [String]] = [:]
-
-  init(store: MessageStore) {
-    self.store = store
-  }
-
-  func info(chatID: Int64) throws -> ChatInfo? {
-    if let cached = infoCache[chatID] { return cached }
-    if let info = try store.chatInfo(chatID: chatID) {
-      infoCache[chatID] = info
-      return info
-    }
-    return nil
-  }
-
-  func participants(chatID: Int64) throws -> [String] {
-    if let cached = participantsCache[chatID] { return cached }
-    let participants = try store.participants(chatID: chatID)
-    participantsCache[chatID] = participants
-    return participants
-  }
-}
-
 extension RPCServer {
   func sendViaBridge(
     chatGUID: String,

--- a/Sources/imsg/RPCServer+WatchHandlers.swift
+++ b/Sources/imsg/RPCServer+WatchHandlers.swift
@@ -53,7 +53,6 @@ extension RPCServer {
     // A live subscription keeps the exact recovered bundle it started with.
     let localStore = database.store
     let localWatcher = database.watcher
-    let localCache = database.cache
     let localWriter = output
     let localFilter = filter
     let localChatID = chatID
@@ -81,9 +80,8 @@ extension RPCServer {
           localFilter
         ) {
           try Task.checkCancellation()
-          let payload = try await buildMessagePayload(
+          let payload = try buildMessagePayload(
             store: localStore,
-            cache: localCache,
             message: message,
             includeAttachments: localIncludeAttachments,
             includeReactions: localIncludeReactions,

--- a/Sources/imsg/RPCServer.swift
+++ b/Sources/imsg/RPCServer.swift
@@ -40,8 +40,8 @@ typealias RPCWatchStreamProvider = (
   _ filter: MessageFilter
 ) -> AsyncThrowingStream<Message, Error>
 
-// MessageStore, stdout, and watcher state are serial-queue-owned; caches and subscriptions are
-// actors. Remaining production dependencies are immutable or internally synchronized.
+// MessageStore, stdout, and watcher state are serial-queue-owned; subscriptions are actors.
+// Remaining production dependencies are immutable or internally synchronized.
 final class RPCServer: @unchecked Sendable {
   let databaseResources: RPCDatabaseResourceOwner
   let output: RPCOutput

--- a/Tests/IMsgCoreTests/ContactResolverTests.swift
+++ b/Tests/IMsgCoreTests/ContactResolverTests.swift
@@ -62,4 +62,218 @@ func noOpContactResolverCanRepresentUnavailableContacts() {
     #expect(resolver.contactsUnavailable == true)
     #expect(await spy.count() == 1)
   }
+
+  private final class ContactTestClock: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value: TimeInterval = 0
+
+    func now() -> TimeInterval {
+      lock.withLock { value }
+    }
+
+    func advance(by interval: TimeInterval) {
+      lock.withLock { value += interval }
+    }
+  }
+
+  private final class ContactSourceHarness: @unchecked Sendable {
+    struct LoadFailure: Error {}
+
+    private let lock = NSLock()
+    private var authorizationValue: ContactCatalogAuthorization
+    private var recordsValue: [ContactCatalogRecord]
+    private var shouldFail = false
+    private var observer: (@Sendable () -> Void)?
+    private var loads = 0
+    private var loadStarted: DispatchSemaphore?
+    private var loadRelease: DispatchSemaphore?
+
+    init(
+      authorization: ContactCatalogAuthorization = .authorized,
+      records: [ContactCatalogRecord] = []
+    ) {
+      self.authorizationValue = authorization
+      self.recordsValue = records
+    }
+
+    var source: ContactCatalogSource {
+      ContactCatalogSource(
+        authorization: { [self] in authorization() },
+        load: { [self] in try load() },
+        observeChanges: { [self] observer in
+          lock.withLock { self.observer = observer }
+          return {}
+        }
+      )
+    }
+
+    var loadCount: Int { lock.withLock { loads } }
+
+    func setAuthorization(_ authorization: ContactCatalogAuthorization) {
+      lock.withLock { authorizationValue = authorization }
+    }
+
+    func setRecords(_ records: [ContactCatalogRecord]) {
+      lock.withLock { recordsValue = records }
+    }
+
+    func setFailure(_ value: Bool) {
+      lock.withLock { shouldFail = value }
+    }
+
+    func blockNextLoad(started: DispatchSemaphore, release: DispatchSemaphore) {
+      lock.withLock {
+        loadStarted = started
+        loadRelease = release
+      }
+    }
+
+    func notify() {
+      let callback = lock.withLock { observer }
+      callback?()
+    }
+
+    private func authorization() -> ContactCatalogAuthorization {
+      lock.withLock { authorizationValue }
+    }
+
+    private func load() throws -> [ContactCatalogRecord] {
+      let state = lock.withLock {
+        () -> (Bool, [ContactCatalogRecord], DispatchSemaphore?, DispatchSemaphore?) in
+        loads += 1
+        let state = (shouldFail, recordsValue, loadStarted, loadRelease)
+        loadStarted = nil
+        loadRelease = nil
+        return state
+      }
+      state.2?.signal()
+      state.3?.wait()
+      if state.0 { throw LoadFailure() }
+      return state.1
+    }
+  }
+
+  private func contactRecord(
+    name: String,
+    phone: String = "+15551234567"
+  ) -> ContactCatalogRecord {
+    ContactCatalogRecord(name: name, phones: [phone], emails: [])
+  }
+
+  @Test
+  func contactCatalogRefreshesAfterChangeNotification() {
+    let source = ContactSourceHarness(records: [contactRecord(name: "Alice")])
+    let resolver = ContactResolver(region: "US", source: source.source, refreshInterval: 60)
+
+    #expect(resolver.displayName(for: "+15551234567") == "Alice")
+    source.setRecords([contactRecord(name: "Bob")])
+    #expect(resolver.displayName(for: "+15551234567") == "Alice")
+
+    source.notify()
+    #expect(resolver.displayName(for: "+15551234567") == "Bob")
+    #expect(source.loadCount == 2)
+  }
+
+  @Test
+  func contactCatalogTTLRefreshesMissedChanges() {
+    let clock = ContactTestClock()
+    let source = ContactSourceHarness(records: [contactRecord(name: "Alice")])
+    let resolver = ContactResolver(
+      region: "US",
+      source: source.source,
+      refreshInterval: 10,
+      now: clock.now
+    )
+
+    #expect(resolver.displayName(for: "+15551234567") == "Alice")
+    source.setRecords([contactRecord(name: "Bob")])
+    clock.advance(by: 9)
+    #expect(resolver.displayName(for: "+15551234567") == "Alice")
+    clock.advance(by: 2)
+    #expect(resolver.displayName(for: "+15551234567") == "Bob")
+  }
+
+  @Test
+  func contactCatalogTracksAuthorizationAndClearsRevokedData() {
+    let clock = ContactTestClock()
+    let source = ContactSourceHarness(
+      authorization: .notDetermined,
+      records: [contactRecord(name: "Alice")]
+    )
+    let resolver = ContactResolver(
+      region: "US",
+      source: source.source,
+      refreshInterval: 10,
+      now: clock.now
+    )
+
+    #expect(resolver.contactsUnavailable)
+    source.setAuthorization(.authorized)
+    clock.advance(by: 11)
+    #expect(resolver.contactsUnavailable == false)
+    #expect(resolver.displayName(for: "+15551234567") == "Alice")
+
+    source.setAuthorization(.unavailable)
+    clock.advance(by: 11)
+    #expect(resolver.contactsUnavailable)
+    source.setAuthorization(.authorized)
+    source.setFailure(true)
+    clock.advance(by: 11)
+    #expect(resolver.displayName(for: "+15551234567") == nil)
+    #expect(resolver.contactsUnavailable)
+  }
+
+  @Test
+  func contactCatalogRetainsLastGoodDataOnTransientLoadFailure() {
+    let source = ContactSourceHarness(records: [contactRecord(name: "Alice")])
+    let resolver = ContactResolver(region: "US", source: source.source, refreshInterval: 60)
+
+    #expect(resolver.displayName(for: "+15551234567") == "Alice")
+    source.setFailure(true)
+    source.notify()
+    #expect(resolver.displayName(for: "+15551234567") == "Alice")
+    #expect(resolver.contactsUnavailable == false)
+  }
+
+  @Test
+  func contactCatalogCoalescesConcurrentRefreshes() {
+    let source = ContactSourceHarness(records: [contactRecord(name: "Alice")])
+    let started = DispatchSemaphore(value: 0)
+    let release = DispatchSemaphore(value: 0)
+    source.blockNextLoad(started: started, release: release)
+    let resolver = ContactResolver(region: "US", source: source.source, refreshInterval: 60)
+    let group = DispatchGroup()
+    let queue = DispatchQueue(label: "contact-refresh-test", attributes: .concurrent)
+
+    for _ in 0..<8 {
+      group.enter()
+      queue.async {
+        _ = resolver.displayName(for: "+15551234567")
+        group.leave()
+      }
+    }
+
+    #expect(started.wait(timeout: .now() + 1) == .success)
+    #expect(source.loadCount == 1)
+    release.signal()
+    #expect(group.wait(timeout: .now() + 1) == .success)
+    #expect(source.loadCount == 1)
+  }
+
+  @Test
+  func contactCatalogBoundsNormalizedRegionSnapshots() {
+    let source = ContactSourceHarness(records: [contactRecord(name: "Alice", phone: "07700900000")])
+    let resolver = ContactResolver(
+      region: "US",
+      source: source.source,
+      maximumRegionSnapshots: 2
+    )
+
+    _ = resolver.searchByName("Alice")
+    _ = resolver.resolver(region: "GB").searchByName("Alice")
+    _ = resolver.resolver(region: "FR").searchByName("Alice")
+
+    #expect(resolver.cachedRegionCount == 2)
+    #expect(source.loadCount == 1)
+  }
 #endif

--- a/Tests/IMsgCoreTests/ContactResolverTests.swift
+++ b/Tests/IMsgCoreTests/ContactResolverTests.swift
@@ -235,7 +235,7 @@ func noOpContactResolverCanRepresentUnavailableContacts() {
     #expect(resolver.contactsUnavailable == false)
   }
 
-  @Test
+  @Test(.timeLimit(.minutes(1)))
   func contactCatalogCoalescesConcurrentRefreshes() {
     let source = ContactSourceHarness(records: [contactRecord(name: "Alice")])
     let started = DispatchSemaphore(value: 0)
@@ -243,20 +243,21 @@ func noOpContactResolverCanRepresentUnavailableContacts() {
     source.blockNextLoad(started: started, release: release)
     let resolver = ContactResolver(region: "US", source: source.source, refreshInterval: 60)
     let group = DispatchGroup()
-    let queue = DispatchQueue(label: "contact-refresh-test", attributes: .concurrent)
-
-    for _ in 0..<8 {
+    let threads = (0..<8).map { _ in
       group.enter()
-      queue.async {
+      return Thread {
         _ = resolver.displayName(for: "+15551234567")
         group.leave()
       }
     }
+    for thread in threads {
+      thread.start()
+    }
 
-    #expect(started.wait(timeout: .now() + 1) == .success)
+    started.wait()
     #expect(source.loadCount == 1)
     release.signal()
-    #expect(group.wait(timeout: .now() + 1) == .success)
+    group.wait()
     #expect(source.loadCount == 1)
   }
 

--- a/Tests/imsgTests/RPCContactFreshnessTests.swift
+++ b/Tests/imsgTests/RPCContactFreshnessTests.swift
@@ -1,0 +1,116 @@
+import Foundation
+import Testing
+
+@testable import IMsgCore
+@testable import imsg
+
+#if os(macOS)
+  private final class RPCContactSource: @unchecked Sendable {
+    private let lock = NSLock()
+    private var authorizationValue: ContactCatalogAuthorization
+    private var recordsValue: [ContactCatalogRecord]
+
+    init(
+      authorization: ContactCatalogAuthorization,
+      records: [ContactCatalogRecord]
+    ) {
+      self.authorizationValue = authorization
+      self.recordsValue = records
+    }
+
+    var source: ContactCatalogSource {
+      ContactCatalogSource(
+        authorization: { [self] in lock.withLock { authorizationValue } },
+        load: { [self] in lock.withLock { recordsValue } },
+        observeChanges: { _ in {} }
+      )
+    }
+
+    func setAuthorization(_ authorization: ContactCatalogAuthorization) {
+      lock.withLock { authorizationValue = authorization }
+    }
+  }
+
+  private final class RPCContactClock: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value: TimeInterval = 0
+
+    func now() -> TimeInterval { lock.withLock { value } }
+    func advance() { lock.withLock { value += 11 } }
+  }
+
+  @Test
+  func rpcContactNameSendUsesRequestRegion() async throws {
+    let source = RPCContactSource(
+      authorization: .authorized,
+      records: [
+        ContactCatalogRecord(name: "Alice", phones: ["07700 900000"], emails: [])
+      ]
+    )
+    let contacts = ContactResolver(region: "US", source: source.source)
+    let store = try CommandTestDatabase.makeStoreForRPC()
+    let output = TestRPCOutput()
+    var sent: MessageSendOptions?
+    let server = RPCServer(
+      store: store,
+      verbose: false,
+      output: output,
+      sendMessage: { sent = $0 },
+      resolveSentMessage: resolvedSentMessageFixture,
+      isBridgeReady: { false },
+      contactResolver: contacts
+    )
+
+    await server.handleLineForTesting(
+      #"{"jsonrpc":"2.0","id":"gb","method":"send","params":{"to":"Alice","text":"hello","region":"GB"}}"#
+    )
+
+    #expect(sent?.recipient == "+447700900000")
+    #expect(sent?.region == "GB")
+    #expect(output.errors.isEmpty)
+  }
+
+  @Test
+  func rpcStatusTracksLiveContactOwnerHealth() async throws {
+    let clock = RPCContactClock()
+    let source = RPCContactSource(
+      authorization: .unavailable,
+      records: [
+        ContactCatalogRecord(name: "Alice", phones: ["+15551234567"], emails: [])
+      ]
+    )
+    let contacts = ContactResolver(
+      region: "US",
+      source: source.source,
+      refreshInterval: 10,
+      now: clock.now
+    )
+    let output = TestRPCOutput()
+    let server = RPCServer(
+      store: try CommandTestDatabase.makeStoreForRPC(),
+      verbose: false,
+      output: output,
+      isBridgeReady: { false },
+      contactResolver: contacts
+    )
+
+    await server.handleLineForTesting(
+      #"{"jsonrpc":"2.0","id":"before","method":"status","params":{}}"#)
+    source.setAuthorization(.authorized)
+    clock.advance()
+    await server.handleLineForTesting(
+      #"{"jsonrpc":"2.0","id":"after","method":"status","params":{}}"#)
+
+    let before = rpcContactsAvailable(output, id: "before")
+    let after = rpcContactsAvailable(output, id: "after")
+    #expect(before == false)
+    #expect(after == true)
+  }
+
+  private func rpcContactsAvailable(_ output: TestRPCOutput, id: String) -> Bool? {
+    let response = output.responses.first { $0["id"] as? String == id }
+    let result = response?["result"] as? [String: Any]
+    let contacts = result?["contacts"] as? [String: Any]
+    return contacts?["available"] as? Bool
+  }
+#endif

--- a/Tests/imsgTests/RPCFreshnessTests.swift
+++ b/Tests/imsgTests/RPCFreshnessTests.swift
@@ -1,0 +1,220 @@
+import Foundation
+import SQLite
+import Testing
+
+@testable import IMsgCore
+@testable import imsg
+
+private func makeWALFixture() throws -> (path: String, writer: Connection, store: MessageStore) {
+  let path = try CommandTestDatabase.makePath()
+  let writer = try Connection(path)
+  _ = try writer.scalar("PRAGMA journal_mode=WAL")
+  let reader = try Connection(path)
+  let store = try MessageStore(
+    connection: reader,
+    path: path,
+    hasAttributedBody: false,
+    hasReactionColumns: false
+  )
+  return (path, writer, store)
+}
+
+private func rpcResult(_ output: TestRPCOutput, id: String) -> [String: Any]? {
+  output.responses.first { $0["id"] as? String == id }?["result"] as? [String: Any]
+}
+
+private func rpcMessages(_ output: TestRPCOutput, id: String) -> [[String: Any]] {
+  rpcResult(output, id: id)?["messages"] as? [[String: Any]] ?? []
+}
+
+@Test
+func rpcFiniteRequestsAndRoutingReadFreshWALMetadata() async throws {
+  let fixture = try makeWALFixture()
+  defer {
+    try? FileManager.default.removeItem(
+      at: URL(fileURLWithPath: fixture.path).deletingLastPathComponent())
+  }
+  let output = TestRPCOutput()
+  var routedGUID: String?
+  let server = RPCServer(
+    store: fixture.store,
+    verbose: false,
+    output: output,
+    invokeBridge: { action, params in
+      if action == .sendMessage {
+        routedGUID = params["chatGuid"] as? String
+      }
+      return [:]
+    },
+    isBridgeReady: { true }
+  )
+
+  await server.handleLineForTesting(
+    #"{"jsonrpc":"2.0","id":"warm-list","method":"chats.list","params":{"limit":10}}"#)
+  await server.handleLineForTesting(
+    #"{"jsonrpc":"2.0","id":"warm-history","method":"messages.history","params":{"chat_id":1}}"#)
+
+  try fixture.writer.run(
+    "UPDATE chat SET chat_identifier = ?, guid = ?, display_name = ? WHERE ROWID = 1",
+    "fresh-chat",
+    "iMessage;+;fresh-chat",
+    "Fresh Name"
+  )
+  try fixture.writer.run("INSERT INTO handle(ROWID, id) VALUES (2, '+999')")
+  try fixture.writer.run("DELETE FROM chat_handle_join WHERE chat_id = 1")
+  try fixture.writer.run("INSERT INTO chat_handle_join(chat_id, handle_id) VALUES (1, 2)")
+
+  await server.handleLineForTesting(
+    #"{"jsonrpc":"2.0","id":"fresh-list","method":"chats.list","params":{"limit":10}}"#)
+  await server.handleLineForTesting(
+    #"{"jsonrpc":"2.0","id":"fresh-history","method":"messages.history","params":{"chat_id":1}}"#)
+  await server.handleLineForTesting(
+    #"{"jsonrpc":"2.0","id":"fresh-after","method":"messages.after","params":{"since_rowid":0,"chat_id":1}}"#
+  )
+  await server.handleLineForTesting(
+    #"{"jsonrpc":"2.0","id":"fresh-route","method":"send","params":{"chat_id":1,"text":"hello","transport":"bridge"}}"#
+  )
+
+  let chats = rpcResult(output, id: "fresh-list")?["chats"] as? [[String: Any]] ?? []
+  #expect(chats.first?["guid"] as? String == "iMessage;+;fresh-chat")
+  #expect(chats.first?["name"] as? String == "Fresh Name")
+  #expect(chats.first?["participants"] as? [String] == ["+999"])
+  for id in ["fresh-history", "fresh-after"] {
+    let message = rpcMessages(output, id: id).first
+    #expect(message?["chat_guid"] as? String == "iMessage;+;fresh-chat")
+    #expect(message?["chat_name"] as? String == "Fresh Name")
+    #expect(message?["participants"] as? [String] == ["+999"])
+  }
+  #expect(routedGUID == "iMessage;+;fresh-chat")
+}
+
+@Test
+func deletedWarmChatIDRejectsBeforeSendOrBridgeDispatch() async throws {
+  let fixture = try makeWALFixture()
+  defer {
+    try? FileManager.default.removeItem(
+      at: URL(fileURLWithPath: fixture.path).deletingLastPathComponent())
+  }
+  let output = TestRPCOutput()
+  var sendCount = 0
+  var bridgeCount = 0
+  let server = RPCServer(
+    store: fixture.store,
+    verbose: false,
+    output: output,
+    sendMessage: { _ in sendCount += 1 },
+    invokeBridge: { _, _ in
+      bridgeCount += 1
+      return [:]
+    },
+    isBridgeReady: { true }
+  )
+
+  await server.handleLineForTesting(
+    #"{"jsonrpc":"2.0","id":"warm","method":"messages.history","params":{"chat_id":1}}"#)
+  try fixture.writer.run("DELETE FROM chat WHERE ROWID = 1")
+
+  await server.handleLineForTesting(
+    #"{"jsonrpc":"2.0","id":"send-deleted","method":"send","params":{"chat_id":1,"text":"no"}}"#)
+  await server.handleLineForTesting(
+    #"{"jsonrpc":"2.0","id":"rename-deleted","method":"group.rename","params":{"chat_id":1,"name":"No"}}"#
+  )
+
+  #expect(output.errors.count == 2)
+  #expect(sendCount == 0)
+  #expect(bridgeCount == 0)
+}
+
+private final class RPCWatchStreamHarness: @unchecked Sendable {
+  private let lock = NSLock()
+  private let ready = DispatchSemaphore(value: 0)
+  private var continuation: AsyncThrowingStream<Message, Error>.Continuation?
+
+  func stream() -> AsyncThrowingStream<Message, Error> {
+    AsyncThrowingStream { continuation in
+      lock.withLock { self.continuation = continuation }
+      ready.signal()
+    }
+  }
+
+  func waitUntilReady() -> Bool {
+    ready.wait(timeout: .now() + 1) == .success
+  }
+
+  func yield(_ message: Message) {
+    lock.withLock { continuation }?.yield(message)
+  }
+
+  func finish() {
+    lock.withLock { continuation }?.finish()
+  }
+}
+
+@Test(.timeLimit(.minutes(1)))
+func rpcWatchReadsMetadataAndParticipantsForEveryEmission() async throws {
+  let fixture = try makeWALFixture()
+  defer {
+    try? FileManager.default.removeItem(
+      at: URL(fileURLWithPath: fixture.path).deletingLastPathComponent())
+  }
+  let output = TestRPCOutput()
+  let stream = RPCWatchStreamHarness()
+  let server = RPCServer(
+    store: fixture.store,
+    verbose: false,
+    output: output,
+    watchStreamProvider: { _, _, _, _, _ in stream.stream() }
+  )
+  let first = Message(
+    rowID: 10,
+    chatID: 1,
+    sender: "+123",
+    text: "first",
+    date: Date(),
+    isFromMe: false,
+    service: "iMessage",
+    handleID: 1,
+    attachmentsCount: 0
+  )
+  let second = Message(
+    rowID: 11,
+    chatID: 1,
+    sender: "+999",
+    text: "second",
+    date: Date(),
+    isFromMe: false,
+    service: "iMessage",
+    handleID: 2,
+    attachmentsCount: 0
+  )
+
+  await server.handleLineForTesting(
+    #"{"jsonrpc":"2.0","id":"watch","method":"watch.subscribe","params":{}}"#)
+  #expect(stream.waitUntilReady())
+  stream.yield(first)
+  await output.waitForOutputCount(2)
+
+  try fixture.writer.run(
+    "UPDATE chat SET guid = ?, display_name = ? WHERE ROWID = 1",
+    "iMessage;+;fresh-watch",
+    "Fresh Watch"
+  )
+  try fixture.writer.run("INSERT INTO handle(ROWID, id) VALUES (2, '+999')")
+  try fixture.writer.run("DELETE FROM chat_handle_join WHERE chat_id = 1")
+  try fixture.writer.run("INSERT INTO chat_handle_join(chat_id, handle_id) VALUES (1, 2)")
+  stream.yield(second)
+  stream.finish()
+  await output.waitForOutputCount(3)
+  await server.subscriptions.waitUntilEmpty()
+
+  let messages = output.notifications.compactMap { notification -> [String: Any]? in
+    let params = notification["params"] as? [String: Any]
+    return params?["message"] as? [String: Any]
+  }
+  #expect(messages.count == 2)
+  #expect(messages[0]["chat_name"] as? String == "Test Chat")
+  #expect(messages[0]["participants"] as? [String] == ["+123"])
+  #expect(messages[1]["chat_guid"] as? String == "iMessage;+;fresh-watch")
+  #expect(messages[1]["chat_name"] as? String == "Fresh Watch")
+  #expect(messages[1]["participants"] as? [String] == ["+999"])
+}

--- a/Tests/imsgTests/WatchCommandTests.swift
+++ b/Tests/imsgTests/WatchCommandTests.swift
@@ -228,6 +228,91 @@ func watchCommandFlushesJsonOutput() async throws {
   #expect(output.contains("\"text\":\"hello\""))
 }
 
+private final class WatchFreshnessSequence: @unchecked Sendable {
+  private let lock = NSLock()
+  private let writer: Connection
+  private var index = 0
+
+  init(writer: Connection) {
+    self.writer = writer
+  }
+
+  func next() throws -> Message? {
+    try lock.withLock {
+      index += 1
+      if index == 2 {
+        try writer.run(
+          "UPDATE chat SET guid = ?, display_name = ? WHERE ROWID = 1",
+          "iMessage;+;cli-fresh",
+          "CLI Fresh"
+        )
+        try writer.run("INSERT INTO handle(ROWID, id) VALUES (2, '+999')")
+        try writer.run("DELETE FROM chat_handle_join WHERE chat_id = 1")
+        try writer.run("INSERT INTO chat_handle_join(chat_id, handle_id) VALUES (1, 2)")
+      }
+      guard index <= 2 else { return nil }
+      return Message(
+        rowID: Int64(index),
+        chatID: 1,
+        sender: index == 1 ? "+123" : "+999",
+        text: "message-\(index)",
+        date: Date(),
+        isFromMe: false,
+        service: "iMessage",
+        handleID: Int64(index),
+        attachmentsCount: 0
+      )
+    }
+  }
+}
+
+@Test
+func watchCommandReadsFreshMetadataForEveryJSONEmission() async throws {
+  let path = try CommandTestDatabase.makePath()
+  defer {
+    try? FileManager.default.removeItem(at: URL(fileURLWithPath: path).deletingLastPathComponent())
+  }
+  let writer = try Connection(path)
+  _ = try writer.scalar("PRAGMA journal_mode=WAL")
+  let reader = try Connection(path)
+  let store = try MessageStore(
+    connection: reader,
+    path: path,
+    hasAttributedBody: false,
+    hasReactionColumns: false
+  )
+  let sequence = WatchFreshnessSequence(writer: writer)
+  let values = ParsedValues(
+    positional: [],
+    options: ["db": [path], "debounce": ["1ms"]],
+    flags: ["jsonOutput"]
+  )
+
+  let (output, _) = try await StdoutCapture.capture {
+    try await WatchCommand.run(
+      values: values,
+      runtime: RuntimeOptions(parsedValues: values),
+      storeFactory: { _ in store },
+      contactResolverFactory: { NoOpContactResolver() },
+      streamProvider: { _, _, _, _, _ in
+        AsyncThrowingStream(unfolding: { try sequence.next() })
+      }
+    )
+  }
+
+  let payloads = try output.split(separator: "\n").map { line in
+    try #require(
+      JSONSerialization.jsonObject(with: Data(line.utf8)) as? [String: Any]
+    )
+  }
+  #expect(payloads.count == 2)
+  #expect(payloads[0]["chat_name"] as? String == "Test Chat")
+  #expect(payloads[0]["participants"] as? [String] == ["+123"])
+  #expect(payloads[1]["chat_guid"] as? String == "iMessage;+;cli-fresh")
+  #expect(payloads[1]["chat_name"] as? String == "CLI Fresh")
+  #expect(payloads[1]["participants"] as? [String] == ["+999"])
+}
+
 private func jsonObject(from output: String) throws -> [String: Any] {
   let line = output.split(separator: "\n").first.map(String.init) ?? ""
   let data = Data(line.utf8)

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -52,7 +52,7 @@ When granted, `imsg` resolves names from your Address Book and includes them as 
 
 Grant it under **System Settings → Privacy & Security → Contacts**.
 
-If you skip this, JSON output simply leaves the resolved name fields empty. Nothing else changes.
+If you skip this, JSON output simply leaves the resolved name fields empty. Nothing else changes. A long-running `imsg rpc` child observes Contacts changes and periodically rechecks authorization, so grants and contact edits become visible without restarting. Revocation clears cached names; a transient Contacts read failure retains the last successful catalog until the next refresh.
 
 On Macs with CardDAV accounts such as Google or Yahoo, Apple's Contacts framework may periodically write `Could not fetch group … :ABGroup` reconciliation messages to stderr. These messages are benign and do not come from `imsg`; a parent process that captures `imsg rpc --json` stderr should not report this specific framework message as an `imsg` error.
 

--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -73,9 +73,11 @@ same time.
 The configured database is an optional, retryable RPC resource. Startup does
 not open it. `initialize`, `status`, and every database-required request retry
 after an earlier open failure; the first successful open is cached for the
-life of the child. A watch subscription keeps the exact database/watcher/cache
+life of the child. A watch subscription keeps the exact database and watcher
 bundle it started with. Recovery affects new requests and does not swap a live
-subscription underneath its stream.
+subscription underneath its stream. Chat metadata and participants are read
+from the live SQLite connection for each request or watch emission, so Messages
+sync and other writers do not leave a long-running child with stale routing.
 
 `initialize`, `status`, and bridge capability probes never launch, kill, or
 relaunch Messages.app. Bridge-only RPC methods first check the existing ready
@@ -185,8 +187,12 @@ union for protocol negotiation and does not claim current readiness.
 
 When the database is ready, `database.features` exposes feature-level booleans,
 not raw SQLite column names. When it is down, `database.error` is redacted and
-actionable. A successful bridge probe additionally reports `bridge_version`,
-`v2_ready`, `registry_available`, and `selectors` supplied by the helper.
+actionable. `contacts.available` is refreshed during the child lifetime; a
+permission grant can become usable without restarting, while revocation clears
+cached contact data. Contact-backed sends normalize phone numbers using that
+request's `region`. A successful bridge probe additionally reports
+`bridge_version`, `v2_ready`, `registry_available`, and `selectors` supplied by
+the helper.
 
 ### `chats.list`
 


### PR DESCRIPTION
## What Problem This Solves

Long-lived RPC children froze Contacts data at startup and kept process-lifetime chat metadata caches. Contact edits, permission changes, Messages sync, and other SQLite writers could therefore leave name resolution, chat output, participants, and send routing stale until restart.

## Why This Change Was Made

This gives Contacts one synchronized process-owned catalog. It refreshes from `CNContactStoreDidChange`, falls back to a bounded 30-second authorization/data check, coalesces concurrent refreshes, and keeps at most eight region-normalized snapshots. Transient Contacts failures retain the last successful catalog, while permission revocation immediately clears cached names for privacy. Contact-backed sends resolve and normalize using the request's `region`.

For chat state, this removes the process-lifetime `ChatCache`. Finite RPC requests, CLI watch output, RPC watch emissions, and routing now read chat metadata and participants from the live SQLite connection at the point of use.

## User Impact

Long-running `imsg rpc` processes now observe contact grants, revocations, and edits without a restart, and current Messages database metadata is reflected in listing, history, watch output, and routing. Revoked Contacts access cannot continue serving names from memory.

This deliberately does not add parity methods or bridge events, deduplicate URL previews, or handle Messages database inode replacement. Those remain separate follow-ups.

## Evidence

- `make test`: 609 tests passed
- `make lint`: green, with only pre-existing warnings
- Universal `make build`: green
- Linux parse validation: green
- Final diff check and autoreview: clean
- Live macOS same-child validation used an online copied database with a concurrent WAL writer: after warming chat state, an external copy-only mutation was visible to the next `chats.list` and history requests, including fresh routing metadata. Contacts correctly reported unavailable in the headless context, the Messages process was unchanged, EOF/stderr were clean, and temporary data was removed.
- CI must include both `linux-read-core` and the macOS job on `macos-26`.
