### PR TITLE
feat(rpc): complete message contract parity

### DIFF
--- a/Sources/IMsgHelper/IMsgInjected.m
+++ b/Sources/IMsgHelper/IMsgInjected.m
@@ -1085,6 +1085,7 @@ static NSDictionary* handleStatus(NSInteger requestId, NSDictionary *params) {
         @"sendMessageReason": @(gHasSendMessageReason),
         @"sendMessage": @(chatSend),
         @"sendAttachment": @(attachmentSend),
+        @"sendMultipart": @(chatSend),
         @"sendReaction": @(reactionSend),
         @"pollPayloadMessage": @(
             [chatClass instancesRespondToSelector:@selector(sendMessage:)]

--- a/Sources/imsg/Commands/ChatsCommand.swift
+++ b/Sources/imsg/Commands/ChatsCommand.swift
@@ -77,21 +77,4 @@ enum ChatsCommand {
     }
   }
 
-  private static func contactNameForChat(
-    chat: Chat,
-    chatInfo: ChatInfo?,
-    participants: [String],
-    contacts: any ContactResolving
-  ) -> String? {
-    let identifier = chatInfo?.identifier ?? chat.identifier
-    let guid = chatInfo?.guid ?? ""
-    guard !isGroupHandle(identifier: identifier, guid: guid) else { return nil }
-    if let name = contacts.displayName(for: identifier) {
-      return name
-    }
-    if participants.count == 1 {
-      return contacts.displayName(for: participants[0])
-    }
-    return nil
-  }
 }

--- a/Sources/imsg/Commands/SendRichCommand+Support.swift
+++ b/Sources/imsg/Commands/SendRichCommand+Support.swift
@@ -46,17 +46,61 @@ extension SendRichCommand {
         Int64?,
         Date
       ) async throws -> Message?,
-    storeFactory: (String) throws -> MessageStore
+    storeFactory: (String) throws -> MessageStore,
+    resolveRow: Bool = false
   ) async throws -> [String: Any] {
+    let store = try? storeFactory(dbPath)
+    let chatInfo = try? store?.chatInfo(matchingTarget: chat)
+    return await enrichedSentMessageResponse(
+      data,
+      chat: chat,
+      text: text,
+      sentAt: sentAt,
+      store: store,
+      chatInfo: chatInfo,
+      resolveSentMessage: resolveSentMessage,
+      resolveRow: resolveRow
+    )
+  }
+
+  static func enrichedSentMessageResponse(
+    _ data: [String: Any],
+    chat: String,
+    text: String,
+    sentAt: Date,
+    store: MessageStore?,
+    chatInfo: ChatInfo?,
+    resolveSentMessage:
+      @escaping (
+        MessageStore,
+        MessageSendOptions,
+        Int64?,
+        Date
+      ) async throws -> Message?,
+    resolveRow: Bool = false
+  ) async -> [String: Any] {
     var enriched = data
-    guard !text.isEmpty, data["queued"] as? Bool == true else {
+    let bridgeGUID = (data["messageGuid"] as? String) ?? ""
+    let resolvedChatGUID = chatInfo?.guid ?? ""
+    let responseChatGUID =
+      ((data["chatGuid"] as? String).flatMap { $0.isEmpty ? nil : $0 })
+      ?? (!resolvedChatGUID.isEmpty ? resolvedChatGUID : chat)
+    if !responseChatGUID.isEmpty {
+      enriched["chat_guid"] = responseChatGUID
+    }
+
+    let queued = data["queued"] as? Bool == true
+    guard !text.isEmpty, queued || resolveRow, let store else {
+      if queued {
+        enriched.removeValue(forKey: "messageGuid")
+      } else if !bridgeGUID.isEmpty {
+        enriched["guid"] = bridgeGUID
+        enriched["message_id"] = bridgeGUID
+      }
       return enriched
     }
 
     do {
-      let store = try storeFactory(dbPath)
-      let chatInfo = try store.chatInfo(matchingTarget: chat)
-      let resolvedChatGUID = chatInfo?.guid ?? ""
       let options = MessageSendOptions(
         recipient: "",
         text: text,
@@ -71,13 +115,17 @@ extension SendRichCommand {
           enriched["message_id"] = sentMessage.guid
           enriched["messageGuid"] = sentMessage.guid
         }
-      } else if data["queued"] as? Bool == true {
+      } else if queued {
         enriched.removeValue(forKey: "messageGuid")
       }
     } catch {
-      if data["queued"] as? Bool == true {
+      if queued {
         enriched.removeValue(forKey: "messageGuid")
       }
+    }
+    if enriched["guid"] == nil, !queued, !bridgeGUID.isEmpty {
+      enriched["guid"] = bridgeGUID
+      enriched["message_id"] = bridgeGUID
     }
     return enriched
   }

--- a/Sources/imsg/OutputModels.swift
+++ b/Sources/imsg/OutputModels.swift
@@ -56,6 +56,38 @@ struct ChatPayload: Codable {
   }
 }
 
+extension ChatPayload {
+  func asDictionary() throws -> [String: Any] {
+    let data = try JSONEncoder().encode(self)
+    let object = try JSONSerialization.jsonObject(with: data)
+    guard let dictionary = object as? [String: Any] else {
+      throw EncodingError.invalidValue(
+        self,
+        EncodingError.Context(
+          codingPath: [], debugDescription: "Chat payload encoding did not produce an object"))
+    }
+    return dictionary
+  }
+}
+
+func contactNameForChat(
+  chat: Chat,
+  chatInfo: ChatInfo?,
+  participants: [String],
+  contacts: any ContactResolving
+) -> String? {
+  let identifier = chatInfo?.identifier ?? chat.identifier
+  let guid = chatInfo?.guid ?? ""
+  guard !isGroupHandle(identifier: identifier, guid: guid) else { return nil }
+  if let name = contacts.displayName(for: identifier) {
+    return name
+  }
+  if participants.count == 1 {
+    return contacts.displayName(for: participants[0])
+  }
+  return nil
+}
+
 struct MessagePayload: Codable {
   struct URLPreviewPayload: Codable {
     let id: Int64

--- a/Sources/imsg/RPCMethodDescriptors.swift
+++ b/Sources/imsg/RPCMethodDescriptors.swift
@@ -36,8 +36,19 @@ struct RPCBridgeRequirement: Sendable, Equatable {
   }
 }
 
+enum RPCDispatchRoute: Sendable, Equatable {
+  case initialize, status, chatsList, messagesStats, messagesHistory, messagesSearch
+  case messagesAfter, watchSubscribe, watchUnsubscribe, send, sendRich, sendAttachment
+  case sendMultipart, sendSticker, messagesScheduled, pollSend, pollVote, pollUnvote
+  case tapback, typing, read, messageEdit, messageUnsend, messageDelete
+  case messageNotifyAnyways, messageSendStatus, chatsCreate, chatsDelete, chatsMarkUnread
+  case groupRename, groupSetIcon, groupAddParticipant, groupRemoveParticipant, groupLeave
+  case contactsShouldShare, contactsShare, handlesCheck
+}
+
 struct RPCMethodDescriptor: Sendable, Equatable {
   let names: [String]
+  let route: RPCDispatchRoute
   let lane: RPCRequestLane
   let database: [RPCDatabaseRequirement]
   let bridge: RPCBridgeRequirement
@@ -53,12 +64,14 @@ struct RPCMethodDescriptor: Sendable, Equatable {
 
   init(
     _ names: String...,
+    route: RPCDispatchRoute,
     lane: RPCRequestLane,
     database: [RPCDatabaseRequirement] = [],
     bridge: RPCBridgeRequirement = .none,
     macOSOnly: Bool = false
   ) {
     self.names = names
+    self.route = route
     self.lane = lane
     self.database = database
     self.bridge = bridge
@@ -85,80 +98,100 @@ struct RPCMethodDescriptor: Sendable, Equatable {
 }
 
 let rpcMethodDescriptors: [RPCMethodDescriptor] = [
-  RPCMethodDescriptor("initialize", lane: .control),
-  RPCMethodDescriptor("status", lane: .read),
-  RPCMethodDescriptor("watch.unsubscribe", lane: .control),
-  RPCMethodDescriptor("chats.list", lane: .read, database: [.ready]),
-  RPCMethodDescriptor("messages.stats", lane: .read, database: [.ready]),
-  RPCMethodDescriptor("messages.history", lane: .read, database: [.ready]),
-  RPCMethodDescriptor("messages.after", lane: .read, database: [.ready]),
-  RPCMethodDescriptor("messages.scheduled", lane: .read, database: [.scheduledMessages]),
-  RPCMethodDescriptor("watch.subscribe", lane: .control, database: [.ready]),
-  RPCMethodDescriptor("message.send_status", lane: .read, database: [.ready]),
-  RPCMethodDescriptor("send", lane: .mutation, macOSOnly: true),
+  RPCMethodDescriptor("initialize", route: .initialize, lane: .control),
+  RPCMethodDescriptor("status", route: .status, lane: .read),
+  RPCMethodDescriptor("watch.unsubscribe", route: .watchUnsubscribe, lane: .control),
+  RPCMethodDescriptor("chats.list", route: .chatsList, lane: .read, database: [.ready]),
   RPCMethodDescriptor(
-    "chats.create", lane: .mutation, bridge: .selector("createChat"), macOSOnly: true),
+    "messages.stats", route: .messagesStats, lane: .read, database: [.ready]),
   RPCMethodDescriptor(
-    "chats.delete", lane: .mutation, bridge: .anySelector("deleteChat", "removeChat"),
+    "messages.history", route: .messagesHistory, lane: .read, database: [.ready]),
+  RPCMethodDescriptor(
+    "messages.search", route: .messagesSearch, lane: .read, database: [.ready]),
+  RPCMethodDescriptor(
+    "messages.after", route: .messagesAfter, lane: .read, database: [.ready]),
+  RPCMethodDescriptor(
+    "messages.scheduled", route: .messagesScheduled, lane: .read,
+    database: [.scheduledMessages]),
+  RPCMethodDescriptor(
+    "watch.subscribe", route: .watchSubscribe, lane: .control, database: [.ready]),
+  RPCMethodDescriptor(
+    "message.send_status", route: .messageSendStatus, lane: .read, database: [.ready]),
+  RPCMethodDescriptor("send", route: .send, lane: .mutation, macOSOnly: true),
+  RPCMethodDescriptor(
+    "chats.create", route: .chatsCreate, lane: .mutation, bridge: .selector("createChat"),
     macOSOnly: true),
   RPCMethodDescriptor(
-    "chats.markUnread", lane: .mutation, bridge: .selector("markChatUnread"),
+    "chats.delete", route: .chatsDelete, lane: .mutation,
+    bridge: .anySelector("deleteChat", "removeChat"), macOSOnly: true),
+  RPCMethodDescriptor(
+    "chats.markUnread", route: .chatsMarkUnread, lane: .mutation,
+    bridge: .selector("markChatUnread"), macOSOnly: true),
+  RPCMethodDescriptor(
+    "send.rich", route: .sendRich, lane: .mutation, bridge: .selector("sendMessage"),
     macOSOnly: true),
   RPCMethodDescriptor(
-    "send.rich", lane: .mutation, bridge: .selector("sendMessage"), macOSOnly: true),
+    "send.attachment", route: .sendAttachment, lane: .mutation,
+    bridge: .selector("sendAttachment"), macOSOnly: true),
   RPCMethodDescriptor(
-    "send.attachment", lane: .mutation, bridge: .selector("sendAttachment"),
-    macOSOnly: true),
+    "send.multipart", route: .sendMultipart, lane: .mutation,
+    bridge: .selector("sendMultipart"), macOSOnly: true),
   RPCMethodDescriptor(
-    "send.sticker", lane: .mutation, database: [.ready], bridge: .selector("stickerSend"),
-    macOSOnly: true),
+    "send.sticker", route: .sendSticker, lane: .mutation, database: [.ready],
+    bridge: .selector("stickerSend"), macOSOnly: true),
   RPCMethodDescriptor(
-    "poll.send", "messages.poll.send", lane: .mutation,
+    "poll.send", "messages.poll.send", route: .pollSend, lane: .mutation,
     bridge: .selector("pollPayloadMessage"), macOSOnly: true),
   RPCMethodDescriptor(
-    "poll.vote", "messages.poll.vote", lane: .mutation,
+    "poll.vote", "messages.poll.vote", route: .pollVote, lane: .mutation,
     database: [.ready, .balloonPayloads], bridge: .selector("pollVoteMessage"),
     macOSOnly: true),
   RPCMethodDescriptor(
-    "poll.unvote", "polls.unvote", "messages.poll.unvote", lane: .mutation,
+    "poll.unvote", "polls.unvote", "messages.poll.unvote", route: .pollUnvote,
+    lane: .mutation,
     database: [.ready, .balloonPayloads, .reactions],
     bridge: .selector("pollVoteMessage"), macOSOnly: true),
   RPCMethodDescriptor(
-    "tapback", lane: .mutation, bridge: .selector("sendReaction"), macOSOnly: true),
-  RPCMethodDescriptor("typing", lane: .mutation, macOSOnly: true),
-  RPCMethodDescriptor("read", lane: .mutation, macOSOnly: true),
+    "tapback", route: .tapback, lane: .mutation, bridge: .selector("sendReaction"),
+    macOSOnly: true),
+  RPCMethodDescriptor("typing", route: .typing, lane: .mutation, macOSOnly: true),
+  RPCMethodDescriptor("read", route: .read, lane: .mutation, macOSOnly: true),
   RPCMethodDescriptor(
-    "message.edit", lane: .mutation,
+    "message.edit", route: .messageEdit, lane: .mutation,
     bridge: .anySelector("editMessageItemTranslation", "editMessageItem", "editMessage"),
     macOSOnly: true),
   RPCMethodDescriptor(
-    "message.unsend", lane: .mutation, bridge: .selector("retractMessagePart"),
+    "message.unsend", route: .messageUnsend, lane: .mutation,
+    bridge: .selector("retractMessagePart"), macOSOnly: true),
+  RPCMethodDescriptor(
+    "message.delete", route: .messageDelete, lane: .mutation,
+    bridge: .selector("deleteMessage"), macOSOnly: true),
+  RPCMethodDescriptor(
+    "message.notifyAnyways", route: .messageNotifyAnyways, lane: .mutation,
+    bridge: .selector("notifyAnyways"), macOSOnly: true),
+  RPCMethodDescriptor(
+    "group.rename", route: .groupRename, lane: .mutation,
+    bridge: .selector("setDisplayName"), macOSOnly: true),
+  RPCMethodDescriptor(
+    "group.setIcon", route: .groupSetIcon, lane: .mutation,
+    bridge: .selector("updateGroupPhoto"), macOSOnly: true),
+  RPCMethodDescriptor(
+    "group.addParticipant", route: .groupAddParticipant, lane: .mutation,
+    bridge: .selector("addParticipant"), macOSOnly: true),
+  RPCMethodDescriptor(
+    "group.removeParticipant", route: .groupRemoveParticipant, lane: .mutation,
+    bridge: .selector("removeParticipant"), macOSOnly: true),
+  RPCMethodDescriptor(
+    "group.leave", route: .groupLeave, lane: .mutation, bridge: .selector("leaveChat"),
     macOSOnly: true),
   RPCMethodDescriptor(
-    "message.delete", lane: .mutation, bridge: .selector("deleteMessage"), macOSOnly: true),
+    "contacts.shouldShareContact", route: .contactsShouldShare, lane: .read,
+    bridge: .selector("namePhotoShouldOffer"), macOSOnly: true),
   RPCMethodDescriptor(
-    "message.notifyAnyways", lane: .mutation, bridge: .selector("notifyAnyways"),
-    macOSOnly: true),
+    "contacts.shareContactCard", route: .contactsShare, lane: .mutation,
+    bridge: .selector("namePhotoShare"), macOSOnly: true),
   RPCMethodDescriptor(
-    "group.rename", lane: .mutation, bridge: .selector("setDisplayName"), macOSOnly: true),
-  RPCMethodDescriptor(
-    "group.setIcon", lane: .mutation, bridge: .selector("updateGroupPhoto"), macOSOnly: true),
-  RPCMethodDescriptor(
-    "group.addParticipant", lane: .mutation, bridge: .selector("addParticipant"),
-    macOSOnly: true),
-  RPCMethodDescriptor(
-    "group.removeParticipant", lane: .mutation, bridge: .selector("removeParticipant"),
-    macOSOnly: true),
-  RPCMethodDescriptor(
-    "group.leave", lane: .mutation, bridge: .selector("leaveChat"), macOSOnly: true),
-  RPCMethodDescriptor(
-    "contacts.shouldShareContact", lane: .read, bridge: .selector("namePhotoShouldOffer"),
-    macOSOnly: true),
-  RPCMethodDescriptor(
-    "contacts.shareContactCard", lane: .mutation, bridge: .selector("namePhotoShare"),
-    macOSOnly: true),
-  RPCMethodDescriptor(
-    "handles.check", lane: .read,
+    "handles.check", route: .handlesCheck, lane: .read,
     bridge: .selector("checkIMessageAvailability", requiresRegistry: false),
     macOSOnly: true),
 ]
@@ -191,3 +224,11 @@ func rpcUsableMethods(
     .filter { $0.isUsable(database: database, bridge: bridge) }
     .flatMap(\.names)
 }
+
+let rpcDispatchRoutes: [String: RPCDispatchRoute] = {
+  var result: [String: RPCDispatchRoute] = [:]
+  for descriptor in rpcMethodDescriptors {
+    for name in descriptor.names { result[name] = descriptor.route }
+  }
+  return result
+}()

--- a/Sources/imsg/RPCMethodDescriptors.swift
+++ b/Sources/imsg/RPCMethodDescriptors.swift
@@ -135,7 +135,7 @@ let rpcMethodDescriptors: [RPCMethodDescriptor] = [
     bridge: .selector("sendAttachment"), macOSOnly: true),
   RPCMethodDescriptor(
     "send.multipart", route: .sendMultipart, lane: .mutation,
-    bridge: .selector("sendMultipart"), macOSOnly: true),
+    database: [.ready], bridge: .selector("sendMultipart"), macOSOnly: true),
   RPCMethodDescriptor(
     "send.sticker", route: .sendSticker, lane: .mutation, database: [.ready],
     bridge: .selector("stickerSend"), macOSOnly: true),

--- a/Sources/imsg/RPCPayloads.swift
+++ b/Sources/imsg/RPCPayloads.swift
@@ -1,36 +1,6 @@
 import Foundation
 import IMsgCore
 
-func chatPayload(
-  id: Int64,
-  identifier: String,
-  guid: String,
-  name: String,
-  service: String,
-  lastMessageAt: Date,
-  participants: [String],
-  contactName: String? = nil,
-  unreadCount: Int? = nil
-) -> [String: Any] {
-  var payload: [String: Any] = [
-    "id": id,
-    "identifier": identifier,
-    "guid": guid,
-    "name": name,
-    "service": service,
-    "last_message_at": CLIISO8601.format(lastMessageAt),
-    "participants": participants,
-    "is_group": isGroupHandle(identifier: identifier, guid: guid),
-  ]
-  if let unreadCount {
-    payload["unread_count"] = unreadCount
-  }
-  if let contactName {
-    payload["contact_name"] = contactName
-  }
-  return payload
-}
-
 func messagePayload(
   message: Message,
   chatInfo: ChatInfo?,

--- a/Sources/imsg/RPCServer+BridgeMessageHandlers.swift
+++ b/Sources/imsg/RPCServer+BridgeMessageHandlers.swift
@@ -8,8 +8,8 @@ extension RPCServer {
       RPCParameterKeys.replyTarget,
       RPCParameterKeys.partIndex,
       [
-        "text", "message", "url", "dd_scan", "ddScan", "effect_id", "effectId", "effect",
-        "subject", "text_formatting", "textFormatting",
+        "text", "message", "file", "path", "url", "dd_scan", "ddScan", "effect_id",
+        "effectId", "effect", "subject", "text_formatting", "textFormatting",
       ]
     )
     let params = try RPCParameters(params, method: "send.rich", supportedKeys: supportedKeys)
@@ -18,6 +18,12 @@ extension RPCServer {
       return
     }
     let text = try params.string("text", aliases: ["message"]) ?? ""
+    let file = try params.string("file", aliases: ["path"]) ?? ""
+    if params.contains("file") || params.contains("path") {
+      guard !file.isEmpty else {
+        throw RPCError.invalidParams("file must be a non-empty string")
+      }
+    }
     let partIndex = try params.integer("part_index", aliases: ["partIndex"]) ?? 0
     let ddScan = try params.boolean("dd_scan", aliases: ["ddScan"]) ?? true
     let effect = try params.string("effect_id", aliases: ["effectId", "effect"])
@@ -46,35 +52,56 @@ extension RPCServer {
     }
 
     let sentAt = Date()
-    let data = try await invokeBridge(action: .sendMessage, params: bridgeParams)
-    var result: [String: Any] = ["ok": true]
-    if let queued = data["queued"] as? Bool {
-      result["queued"] = queued
+    let action: BridgeAction
+    if file.isEmpty {
+      action = .sendMessage
+    } else {
+      try await requireRichAttachmentCapability(
+        requiresMetadata: !text.isEmpty || effect?.isEmpty == false || subject?.isEmpty == false
+          || reply?.isEmpty == false || partIndex != 0 || formatting != nil
+      )
+      do {
+        bridgeParams["filePath"] = try stageAttachment((file as NSString).expandingTildeInPath)
+      } catch {
+        throw DeliveryFailure(
+          disposition: .notStarted,
+          transport: .bridgeV2,
+          operation: BridgeAction.sendAttachment.rawValue,
+          detail: "The attachment could not be staged before bridge dispatch."
+        )
+      }
+      bridgeParams["isAudioMessage"] = false
+      action = .sendAttachment
     }
-    let database = await databaseResources.available()
-    let chatID =
-      (try params.int64("chat_id"))
-      ?? (try? database?.store.chatInfo(matchingTarget: chatGUID)?.id)
-    let options = MessageSendOptions(
-      recipient: "",
-      text: text,
-      service: .auto,
-      chatGUID: chatGUID
-    )
-    if data["queued"] as? Bool == true,
-      !text.isEmpty,
-      let database,
-      let sentMessage = try? await resolveSentMessage(database.store, options, chatID, sentAt),
-      !sentMessage.guid.isEmpty
-    {
-      result["guid"] = sentMessage.guid
-      result["message_id"] = sentMessage.guid
-    } else if data["queued"] as? Bool != true,
-      let guid = data["messageGuid"] as? String, !guid.isEmpty
-    {
-      result["guid"] = guid
-      result["message_id"] = guid
+    let emptyTextBaselineRowID = await bridgeSendVerificationBaseline(
+      requiresGUIDVerification: !file.isEmpty && text.isEmpty)
+    let data = try await invokeBridge(action: action, params: bridgeParams)
+    var result: [String: Any]
+    if file.isEmpty {
+      let database = await databaseResources.available()
+      let chatInfo = try bridgeResponseChatInfo(
+        params: params, chatGUID: chatGUID, database: database)
+      result = await SendRichCommand.enrichedSentMessageResponse(
+        data,
+        chat: chatGUID,
+        text: text,
+        sentAt: sentAt,
+        store: database?.store,
+        chatInfo: chatInfo,
+        resolveSentMessage: resolveSentMessage
+      )
+    } else {
+      result = try await verifiedBridgeSendResponse(
+        data,
+        params: params,
+        chatGUID: chatGUID,
+        text: text,
+        sentAt: sentAt,
+        action: action,
+        emptyTextBaselineRowID: emptyTextBaselineRowID
+      )
     }
+    result["ok"] = true
     respond(id: id, result: result)
   }
 
@@ -82,7 +109,7 @@ extension RPCServer {
     let incompatibleKeys = [
       "text", "message", "dd_scan", "ddScan", "effect_id", "effectId", "effect", "subject",
       "reply_to", "replyTo", "reply_to_guid", "message_guid", "part_index", "partIndex",
-      "text_formatting", "textFormatting",
+      "text_formatting", "textFormatting", "file", "path",
     ]
     if let unsupported = incompatibleKeys.first(where: params.contains) {
       throw RPCError.invalidParams("\(unsupported) is not supported with url")
@@ -125,58 +152,17 @@ extension RPCServer {
     } catch {
       throw error
     }
-    var result: [String: Any] = ["ok": true]
-    if let queued = data["queued"] as? Bool {
-      result["queued"] = queued
-    }
-    let options = MessageSendOptions(
-      recipient: "",
+    var result = await SendRichCommand.enrichedSentMessageResponse(
+      data,
+      chat: chatGUID,
       text: prepared.originalURL,
-      service: .imessage,
-      chatGUID: chatGUID
+      sentAt: sentAt,
+      store: database.store,
+      chatInfo: chatInfo,
+      resolveSentMessage: resolveSentMessage
     )
-    if data["queued"] as? Bool == true,
-      let sentMessage = try? await resolveSentMessage(
-        database.store, options, chatInfo.id, sentAt),
-      !sentMessage.guid.isEmpty
-    {
-      result["guid"] = sentMessage.guid
-      result["message_id"] = sentMessage.guid
-    } else if data["queued"] as? Bool != true,
-      let guid = data["messageGuid"] as? String, !guid.isEmpty
-    {
-      result["guid"] = guid
-      result["message_id"] = guid
-    }
+    result["ok"] = true
     respond(id: id, result: result)
-  }
-
-  private func strictRichLinkChatInfo(
-    _ params: RPCParameters,
-    database: RPCDatabaseResources
-  ) async throws -> ChatInfo {
-    let target = try params.chatTarget()
-
-    let info: ChatInfo?
-    if let chatID = target.chatID {
-      info = try database.store.chatInfo(chatID: chatID)
-    } else if !target.chatIdentifier.isEmpty {
-      info = try database.store.chatInfo(
-        matchingExactIdentifier: target.chatIdentifier,
-        preferredServices: ["iMessage", "iMessageLite"]
-      )
-    } else {
-      info = try database.store.chatInfo(matchingExactGUID: target.chatGUID)
-    }
-
-    guard let info, !info.guid.isEmpty else {
-      throw RPCError.invalidParams("rich links require an existing chat")
-    }
-    let service = info.service.lowercased()
-    guard service == "imessage" || service == "imessagelite" else {
-      throw RPCError.invalidParams("rich links require an iMessage chat")
-    }
-    return info
   }
 
   func handleSendAttachment(params: [String: Any], id: Any?) async throws {
@@ -216,11 +202,19 @@ extension RPCServer {
       bridgeParams["partIndex"] = partIndex
     }
     let data = try await invokeBridge(action: .sendAttachment, params: bridgeParams)
-    var result: [String: Any] = ["ok": true]
-    if let guid = data["messageGuid"] as? String, !guid.isEmpty {
-      result["guid"] = guid
-      result["message_id"] = guid
-    }
+    let database = await databaseResources.available()
+    let chatInfo = try bridgeResponseChatInfo(
+      params: params, chatGUID: chatGUID, database: database)
+    var result = await SendRichCommand.enrichedSentMessageResponse(
+      data,
+      chat: chatGUID,
+      text: "",
+      sentAt: Date(),
+      store: database?.store,
+      chatInfo: chatInfo,
+      resolveSentMessage: resolveSentMessage
+    )
+    result["ok"] = true
     respond(id: id, result: result)
   }
 
@@ -244,6 +238,9 @@ extension RPCServer {
     let commentValue = try params.string("comment")
     let suppressComment =
       try params.boolean("suppress_comment", aliases: ["suppressComment"]) ?? false
+    if commentValue != nil, suppressComment {
+      throw RPCError.invalidParams("comment cannot be combined with suppress_comment: true")
+    }
     let chatGUID = try await resolveChatGUIDParam(params)
     var bridgeParams: [String: Any] = [
       "chatGuid": chatGUID,

--- a/Sources/imsg/RPCServer+BridgeMessageHandlers.swift
+++ b/Sources/imsg/RPCServer+BridgeMessageHandlers.swift
@@ -51,37 +51,13 @@ extension RPCServer {
       bridgeParams["textFormatting"] = formatting
     }
 
-    let sentAt = Date()
-    let action: BridgeAction
     if file.isEmpty {
-      action = .sendMessage
-    } else {
-      try await requireRichAttachmentCapability(
-        requiresMetadata: !text.isEmpty || effect?.isEmpty == false || subject?.isEmpty == false
-          || reply?.isEmpty == false || partIndex != 0 || formatting != nil
-      )
-      do {
-        bridgeParams["filePath"] = try stageAttachment((file as NSString).expandingTildeInPath)
-      } catch {
-        throw DeliveryFailure(
-          disposition: .notStarted,
-          transport: .bridgeV2,
-          operation: BridgeAction.sendAttachment.rawValue,
-          detail: "The attachment could not be staged before bridge dispatch."
-        )
-      }
-      bridgeParams["isAudioMessage"] = false
-      action = .sendAttachment
-    }
-    let emptyTextBaselineRowID = await bridgeSendVerificationBaseline(
-      requiresGUIDVerification: !file.isEmpty && text.isEmpty)
-    let data = try await invokeBridge(action: action, params: bridgeParams)
-    var result: [String: Any]
-    if file.isEmpty {
+      let sentAt = Date()
+      let data = try await invokeBridge(action: .sendMessage, params: bridgeParams)
       let database = await databaseResources.available()
       let chatInfo = try bridgeResponseChatInfo(
         params: params, chatGUID: chatGUID, database: database)
-      result = await SendRichCommand.enrichedSentMessageResponse(
+      var result = await SendRichCommand.enrichedSentMessageResponse(
         data,
         chat: chatGUID,
         text: text,
@@ -90,17 +66,36 @@ extension RPCServer {
         chatInfo: chatInfo,
         resolveSentMessage: resolveSentMessage
       )
-    } else {
-      result = try await verifiedBridgeSendResponse(
-        data,
-        params: params,
-        chatGUID: chatGUID,
-        text: text,
-        sentAt: sentAt,
-        action: action,
-        emptyTextBaselineRowID: emptyTextBaselineRowID
+      result["ok"] = true
+      respond(id: id, result: result)
+      return
+    }
+
+    let verification = try await bridgeSendVerificationBaseline()
+    try await requireRichAttachmentCapability(
+      requiresMetadata: !text.isEmpty || effect?.isEmpty == false || subject?.isEmpty == false
+        || reply?.isEmpty == false || partIndex != 0 || formatting != nil
+    )
+    do {
+      bridgeParams["filePath"] = try stageAttachment((file as NSString).expandingTildeInPath)
+    } catch {
+      throw DeliveryFailure(
+        disposition: .notStarted,
+        transport: .bridgeV2,
+        operation: BridgeAction.sendAttachment.rawValue,
+        detail: "The attachment could not be staged before bridge dispatch."
       )
     }
+    bridgeParams["isAudioMessage"] = false
+    let data = try await invokeBridge(action: .sendAttachment, params: bridgeParams)
+    var result = try await verifiedBridgeSendResponse(
+      data,
+      params: params,
+      chatGUID: chatGUID,
+      action: .sendAttachment,
+      database: verification.database,
+      baselineRowID: verification.rowID
+    )
     result["ok"] = true
     respond(id: id, result: result)
   }

--- a/Sources/imsg/RPCServer+BridgeMessageSupport.swift
+++ b/Sources/imsg/RPCServer+BridgeMessageSupport.swift
@@ -1,6 +1,18 @@
 import Foundation
 import IMsgCore
 
+private func bridgeDeliveryVerificationFailure(
+  action: BridgeAction,
+  detail: String
+) -> DeliveryFailure {
+  DeliveryFailure(
+    disposition: .mayHaveCompleted,
+    transport: .bridgeV2,
+    operation: action.rawValue,
+    detail: detail
+  )
+}
+
 func rpcPollOptionsParam(_ params: RPCParameters) throws -> [String] {
   guard let values = try params.stringArray("options", aliases: ["option"]) else {
     throw RPCError.invalidParams("options is required")
@@ -57,4 +69,177 @@ func normalizeBridgeReactionType(_ raw: String, remove: Bool = false) throws -> 
     throw RPCError.invalidParams("unsupported tapback reaction \(raw)")
   }
   return result
+}
+
+extension RPCServer {
+  func bridgeSendVerificationBaseline(requiresGUIDVerification: Bool) async -> Int64? {
+    guard requiresGUIDVerification, let database = await databaseResources.available() else {
+      return nil
+    }
+    return try? database.store.maxRowID()
+  }
+
+  func verifiedBridgeSendResponse(
+    _ data: [String: Any],
+    params: RPCParameters,
+    chatGUID: String,
+    text: String,
+    sentAt: Date,
+    action: BridgeAction,
+    emptyTextBaselineRowID: Int64?
+  ) async throws -> [String: Any] {
+    guard let database = await databaseResources.available() else {
+      throw bridgeDeliveryVerificationFailure(
+        action: action,
+        detail: "The Messages database was unavailable after bridge publication."
+      )
+    }
+
+    let chatInfo: ChatInfo?
+    do {
+      chatInfo = try bridgeResponseChatInfo(
+        params: params,
+        chatGUID: chatGUID,
+        database: database
+      )
+    } catch {
+      throw bridgeDeliveryVerificationFailure(
+        action: action,
+        detail: "The resolved chat could not be read after bridge publication."
+      )
+    }
+
+    let sentMessage: Message?
+    if text.isEmpty {
+      guard
+        let chatInfo,
+        let emptyTextBaselineRowID,
+        let bridgeGUID = data["messageGuid"] as? String,
+        !bridgeGUID.isEmpty
+      else {
+        throw bridgeDeliveryVerificationFailure(
+          action: action,
+          detail: "The bridge completed, but the attachment had no verifiable text or new row GUID."
+        )
+      }
+      do {
+        sentMessage = try await SentMessageVerifier.resolveSentMessage(
+          store: database.store,
+          messageGUID: bridgeGUID,
+          chatInfo: chatInfo,
+          afterRowID: emptyTextBaselineRowID
+        )
+      } catch {
+        throw bridgeDeliveryVerificationFailure(
+          action: action,
+          detail: "The Messages database could not verify the published bridge operation."
+        )
+      }
+    } else {
+      do {
+        let resolvedChatGUID = chatInfo?.guid ?? ""
+        let options = MessageSendOptions(
+          recipient: "",
+          text: text,
+          service: .auto,
+          chatIdentifier: chatInfo?.identifier ?? "",
+          chatGUID: resolvedChatGUID.isEmpty ? chatGUID : resolvedChatGUID
+        )
+        sentMessage = try await resolveSentMessage(
+          database.store, options, chatInfo?.id, sentAt)
+      } catch {
+        throw bridgeDeliveryVerificationFailure(
+          action: action,
+          detail: "The Messages database could not verify the published bridge operation."
+        )
+      }
+    }
+
+    guard let sentMessage, !sentMessage.guid.isEmpty else {
+      throw bridgeDeliveryVerificationFailure(
+        action: action,
+        detail: "The bridge completed, but no matching outgoing row was observed within 8 seconds."
+      )
+    }
+
+    var enriched = data
+    let responseChatGUID =
+      ((data["chatGuid"] as? String).flatMap { $0.isEmpty ? nil : $0 })
+      ?? chatInfo?.guid
+      ?? chatGUID
+    if !responseChatGUID.isEmpty {
+      enriched["chat_guid"] = responseChatGUID
+    }
+    enriched["id"] = sentMessage.rowID
+    enriched["guid"] = sentMessage.guid
+    enriched["message_id"] = sentMessage.guid
+    enriched["messageGuid"] = sentMessage.guid
+    return enriched
+  }
+
+  func requireRichAttachmentCapability(requiresMetadata: Bool) async throws {
+    let status: [String: Any]
+    do {
+      status = try await invokeBridge(action: .status, params: [:])
+    } catch {
+      throw DeliveryFailure(
+        disposition: .notStarted,
+        transport: .bridgeV2,
+        operation: BridgeAction.sendAttachment.rawValue,
+        detail: "Bridge capability inspection failed before the send was published."
+      )
+    }
+    let selectors = status["selectors"] as? [String: Any]
+    guard selectors?["sendAttachment"] as? Bool == true else {
+      throw RPCError.internalError(
+        "running bridge does not support attachments; restart Messages with the current imsg bridge"
+      )
+    }
+    if requiresMetadata, status["attachment_metadata"] as? Bool != true {
+      throw RPCError.internalError(
+        "running bridge does not support rich attachment metadata; "
+          + "restart Messages with the current imsg bridge"
+      )
+    }
+  }
+
+  func bridgeResponseChatInfo(
+    params: RPCParameters,
+    chatGUID: String,
+    database: RPCDatabaseResources?
+  ) throws -> ChatInfo? {
+    guard let database else { return nil }
+    if let chatID = try params.int64("chat_id") {
+      return try database.store.chatInfo(chatID: chatID)
+    }
+    return try database.store.chatInfo(matchingTarget: chatGUID)
+  }
+
+  func strictRichLinkChatInfo(
+    _ params: RPCParameters,
+    database: RPCDatabaseResources
+  ) async throws -> ChatInfo {
+    let target = try params.chatTarget()
+
+    let info: ChatInfo?
+    if let chatID = target.chatID {
+      info = try database.store.chatInfo(chatID: chatID)
+    } else if !target.chatIdentifier.isEmpty {
+      info = try database.store.chatInfo(
+        matchingExactIdentifier: target.chatIdentifier,
+        preferredServices: ["iMessage", "iMessageLite"]
+      )
+    } else {
+      info = try database.store.chatInfo(matchingExactGUID: target.chatGUID)
+    }
+
+    guard let info, !info.guid.isEmpty else {
+      throw RPCError.invalidParams("rich links require an existing chat")
+    }
+    let service = info.service.lowercased()
+    guard service == "imessage" || service == "imessagelite" else {
+      throw RPCError.invalidParams("rich links require an iMessage chat")
+    }
+    return info
+  }
 }

--- a/Sources/imsg/RPCServer+BridgeMessageSupport.swift
+++ b/Sources/imsg/RPCServer+BridgeMessageSupport.swift
@@ -72,100 +72,66 @@ func normalizeBridgeReactionType(_ raw: String, remove: Bool = false) throws -> 
 }
 
 extension RPCServer {
-  func bridgeSendVerificationBaseline(requiresGUIDVerification: Bool) async -> Int64? {
-    guard requiresGUIDVerification, let database = await databaseResources.available() else {
-      return nil
-    }
-    return try? database.store.maxRowID()
+  func bridgeSendVerificationBaseline() async throws -> (
+    database: RPCDatabaseResources, rowID: Int64
+  ) {
+    let database = try await databaseResources.require()
+    return (database, try database.store.maxRowID())
   }
 
   func verifiedBridgeSendResponse(
     _ data: [String: Any],
     params: RPCParameters,
     chatGUID: String,
-    text: String,
-    sentAt: Date,
     action: BridgeAction,
-    emptyTextBaselineRowID: Int64?
+    database: RPCDatabaseResources,
+    baselineRowID: Int64
   ) async throws -> [String: Any] {
-    guard let database = await databaseResources.available() else {
+    guard let bridgeGUID = data["messageGuid"] as? String, !bridgeGUID.isEmpty else {
       throw bridgeDeliveryVerificationFailure(
         action: action,
-        detail: "The Messages database was unavailable after bridge publication."
-      )
-    }
-
-    let chatInfo: ChatInfo?
-    do {
-      chatInfo = try bridgeResponseChatInfo(
-        params: params,
-        chatGUID: chatGUID,
-        database: database
-      )
-    } catch {
-      throw bridgeDeliveryVerificationFailure(
-        action: action,
-        detail: "The resolved chat could not be read after bridge publication."
+        detail: "The bridge completed, but returned no message GUID to verify."
       )
     }
 
     let sentMessage: Message?
-    if text.isEmpty {
+    do {
       guard
-        let chatInfo,
-        let emptyTextBaselineRowID,
-        let bridgeGUID = data["messageGuid"] as? String,
-        !bridgeGUID.isEmpty
+        let chatInfo = try bridgeResponseChatInfo(
+          params: params,
+          chatGUID: chatGUID,
+          database: database
+        )
       else {
         throw bridgeDeliveryVerificationFailure(
-          action: action,
-          detail: "The bridge completed, but the attachment had no verifiable text or new row GUID."
+          action: action, detail: "The target chat could not be resolved after bridge publication."
         )
       }
-      do {
-        sentMessage = try await SentMessageVerifier.resolveSentMessage(
-          store: database.store,
-          messageGUID: bridgeGUID,
-          chatInfo: chatInfo,
-          afterRowID: emptyTextBaselineRowID
-        )
-      } catch {
-        throw bridgeDeliveryVerificationFailure(
-          action: action,
-          detail: "The Messages database could not verify the published bridge operation."
-        )
-      }
-    } else {
-      do {
-        let resolvedChatGUID = chatInfo?.guid ?? ""
-        let options = MessageSendOptions(
-          recipient: "",
-          text: text,
-          service: .auto,
-          chatIdentifier: chatInfo?.identifier ?? "",
-          chatGUID: resolvedChatGUID.isEmpty ? chatGUID : resolvedChatGUID
-        )
-        sentMessage = try await resolveSentMessage(
-          database.store, options, chatInfo?.id, sentAt)
-      } catch {
-        throw bridgeDeliveryVerificationFailure(
-          action: action,
-          detail: "The Messages database could not verify the published bridge operation."
-        )
-      }
+      sentMessage = try await SentMessageVerifier.resolveSentMessage(
+        store: database.store,
+        messageGUID: bridgeGUID,
+        chatInfo: chatInfo,
+        afterRowID: baselineRowID
+      )
+    } catch let failure as DeliveryFailure {
+      throw failure
+    } catch {
+      throw bridgeDeliveryVerificationFailure(
+        action: action,
+        detail: "The Messages database could not verify the published bridge operation."
+      )
     }
 
     guard let sentMessage, !sentMessage.guid.isEmpty else {
       throw bridgeDeliveryVerificationFailure(
         action: action,
-        detail: "The bridge completed, but no matching outgoing row was observed within 8 seconds."
+        detail: "The bridge completed, but its message GUID was not a new row in the target chat."
       )
     }
 
     var enriched = data
     let responseChatGUID =
       ((data["chatGuid"] as? String).flatMap { $0.isEmpty ? nil : $0 })
-      ?? chatInfo?.guid
       ?? chatGUID
     if !responseChatGUID.isEmpty {
       enriched["chat_guid"] = responseChatGUID

--- a/Sources/imsg/RPCServer+Handlers.swift
+++ b/Sources/imsg/RPCServer+Handlers.swift
@@ -23,6 +23,9 @@ extension RPCServer {
       supportedKeys: ["limit", "unread_only", "unreadOnly"]
     )
     let limit = try params.integer("limit") ?? 20
+    guard limit > 0 else {
+      throw RPCError.invalidParams("limit must be a positive integer")
+    }
     let unreadOnly = try params.boolean("unread_only", aliases: ["unreadOnly"]) ?? false
     let database = try await databaseResources.require()
     let store = database.store
@@ -30,32 +33,26 @@ extension RPCServer {
       throw RPCError.invalidParams(
         "unread_only is unavailable because this Messages database has no read-state column")
     }
-    let chats = try store.listChats(limit: max(limit, 1), unreadOnly: unreadOnly)
+    let chats = try store.listChats(limit: limit, unreadOnly: unreadOnly)
     var payloads: [[String: Any]] = []
     payloads.reserveCapacity(chats.count)
 
     for chat in chats {
       let info = try store.chatInfo(chatID: chat.id)
       let participants = try store.participants(chatID: chat.id)
-      let identifier = info?.identifier ?? chat.identifier
-      let guid = info?.guid ?? ""
-      let name = (info?.name.isEmpty == false ? info?.name : nil) ?? chat.name
-      let service = info?.service ?? chat.service
-      let contactName =
-        isGroupHandle(identifier: identifier, guid: guid)
-        ? nil : contactResolver.displayName(for: identifier)
+      let contactName = contactNameForChat(
+        chat: chat,
+        chatInfo: info,
+        participants: participants,
+        contacts: contactResolver
+      )
       payloads.append(
-        chatPayload(
-          id: chat.id,
-          identifier: identifier,
-          guid: guid,
-          name: name,
-          service: service,
-          lastMessageAt: chat.lastMessageAt,
+        try ChatPayload(
+          chat: chat,
+          chatInfo: info,
           participants: participants,
-          contactName: contactName,
-          unreadCount: chat.unreadCount
-        ))
+          contactName: contactName
+        ).asDictionary())
     }
 
     respond(id: id, result: ["chats": payloads])
@@ -77,6 +74,9 @@ extension RPCServer {
       throw RPCError.invalidParams("chat_id must be a positive integer")
     }
     let limit = try params.integer("limit") ?? 50
+    guard limit > 0 else {
+      throw RPCError.invalidParams("limit must be a positive integer")
+    }
     let participants = try params.stringArray("participants") ?? []
     let startISO = try params.string("start")
     let endISO = try params.string("end")
@@ -90,7 +90,7 @@ extension RPCServer {
       startISO: startISO,
       endISO: endISO
     )
-    let filtered = try store.messages(chatID: chatID, limit: max(limit, 1), filter: filter)
+    let filtered = try store.messages(chatID: chatID, limit: limit, filter: filter)
     let reactionsByMessageID = try store.reactions(for: filtered)
 
     var payloads: [[String: Any]] = []
@@ -117,7 +117,7 @@ extension RPCServer {
       RPCParameterKeys.replyTarget,
       [
         "to", "text", "file", "text_formatting", "textFormatting", "formatting", "service",
-        "transport", "region",
+        "transport", "region", "allow_sms_fallback", "allowSMSFallback",
       ]
     )
     let params = try RPCParameters(params, method: "send", supportedKeys: supportedKeys)
@@ -135,6 +135,8 @@ extension RPCServer {
     }
     let transport = try RPCSendTransport.parse(try params.string("transport"))
     let region = try params.string("region") ?? "US"
+    let requestedSMSFallback =
+      try params.boolean("allow_sms_fallback", aliases: ["allowSMSFallback"]) ?? true
     let requestContacts =
       (contactResolver as? ContactResolver)?.resolver(region: region) ?? contactResolver
     let selectedMessageGuid = try params.string(
@@ -204,7 +206,8 @@ extension RPCServer {
       } ?? nil
 
     let allowSMSFallback =
-      service == .auto
+      requestedSMSFallback
+      && service == .auto
       && !input.hasChatTarget
       && !input.recipient.isEmpty
       && !text.isEmpty

--- a/Sources/imsg/RPCServer+MultipartHandler.swift
+++ b/Sources/imsg/RPCServer+MultipartHandler.swift
@@ -52,17 +52,15 @@ extension RPCServer {
       bridgeParams["subject"] = subject
     }
 
-    let sentAt = Date()
+    let verification = try await bridgeSendVerificationBaseline()
     let data = try await invokeBridge(action: .sendMultipart, params: bridgeParams)
-    let combinedText = parts.compactMap { $0["text"] as? String }.joined()
     var result = try await verifiedBridgeSendResponse(
       data,
       params: params,
       chatGUID: chatGUID,
-      text: combinedText,
-      sentAt: sentAt,
       action: .sendMultipart,
-      emptyTextBaselineRowID: nil
+      database: verification.database,
+      baselineRowID: verification.rowID
     )
     result["ok"] = true
     result["parts_count"] = parts.count

--- a/Sources/imsg/RPCServer+MultipartHandler.swift
+++ b/Sources/imsg/RPCServer+MultipartHandler.swift
@@ -1,0 +1,71 @@
+import Foundation
+import IMsgCore
+
+extension RPCServer {
+  func handleSendMultipart(params: [String: Any], id: Any?) async throws {
+    let supportedKeys = RPCParameterKeys.combining(
+      RPCParameterKeys.chatTarget,
+      ["parts", "effect_id", "effectId", "effect", "subject"]
+    )
+    let params = try RPCParameters(
+      params, method: "send.multipart", supportedKeys: supportedKeys)
+    guard let rawParts = try params.objectArray("parts") else {
+      throw RPCError.invalidParams("parts is required")
+    }
+    guard !rawParts.isEmpty, rawParts.count <= 20 else {
+      throw RPCError.invalidParams("parts must contain between 1 and 20 text parts")
+    }
+
+    var parts: [[String: Any]] = []
+    parts.reserveCapacity(rawParts.count)
+    for (index, rawPart) in rawParts.enumerated() {
+      if let key = rawPart.keys.sorted().first(where: {
+        ["file", "attachment", "mention", "mentions"].contains($0)
+      }) {
+        throw RPCError.invalidParams("\(key) parts are not supported")
+      }
+      let part = try RPCParameters(
+        rawPart,
+        method: "send.multipart parts[\(index)]",
+        supportedKeys: ["text", "text_formatting", "textFormatting"]
+      )
+      guard let text = try part.string("text"), !text.isEmpty else {
+        throw RPCError.invalidParams("parts[\(index)].text must be a non-empty string")
+      }
+      var bridgePart: [String: Any] = ["text": text]
+      if let formatting = try part.objectArray(
+        "text_formatting", aliases: ["textFormatting"])
+      {
+        bridgePart["textFormatting"] = formatting
+      }
+      parts.append(bridgePart)
+    }
+
+    let effect = try params.string("effect_id", aliases: ["effectId", "effect"])
+    let subject = try params.string("subject")
+    let chatGUID = try await resolveChatGUIDParam(params)
+    var bridgeParams: [String: Any] = ["chatGuid": chatGUID, "parts": parts]
+    if let effect, !effect.isEmpty {
+      bridgeParams["effectId"] = ExpressiveSendEffect.expand(effect)
+    }
+    if let subject, !subject.isEmpty {
+      bridgeParams["subject"] = subject
+    }
+
+    let sentAt = Date()
+    let data = try await invokeBridge(action: .sendMultipart, params: bridgeParams)
+    let combinedText = parts.compactMap { $0["text"] as? String }.joined()
+    var result = try await verifiedBridgeSendResponse(
+      data,
+      params: params,
+      chatGUID: chatGUID,
+      text: combinedText,
+      sentAt: sentAt,
+      action: .sendMultipart,
+      emptyTextBaselineRowID: nil
+    )
+    result["ok"] = true
+    result["parts_count"] = parts.count
+    respond(id: id, result: result)
+  }
+}

--- a/Sources/imsg/RPCServer+SearchHandler.swift
+++ b/Sources/imsg/RPCServer+SearchHandler.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+extension RPCServer {
+  func handleMessagesSearch(id: Any?, params: [String: Any]) async throws {
+    let params = try RPCParameters(
+      params,
+      method: "messages.search",
+      supportedKeys: ["query", "match", "limit"]
+    )
+    guard
+      let query = try params.string("query")?.trimmingCharacters(in: .whitespacesAndNewlines),
+      !query.isEmpty
+    else {
+      throw RPCError.invalidParams("query must be a non-empty string")
+    }
+    let match = try params.string("match") ?? "contains"
+    guard match == "contains" || match == "exact" else {
+      throw RPCError.invalidParams("match must be contains or exact")
+    }
+    let limit = try params.integer("limit") ?? 50
+    guard limit > 0, limit <= 100 else {
+      throw RPCError.invalidParams("limit must be between 1 and 100")
+    }
+
+    let database = try await databaseResources.require()
+    let messages = try database.store.searchMessages(query: query, match: match, limit: limit)
+    let payloads = try messages.map {
+      try buildMessagePayload(
+        store: database.store,
+        message: $0,
+        includeAttachments: false,
+        includeReactions: false,
+        contactResolver: contactResolver
+      )
+    }
+    respond(id: id, result: ["messages": payloads])
+  }
+}

--- a/Sources/imsg/RPCServer.swift
+++ b/Sources/imsg/RPCServer.swift
@@ -240,81 +240,87 @@ final class RPCServer: @unchecked Sendable {
     let id = request.id
 
     do {
-      switch method {
-      case "initialize":
-        try await handleInitialize(id: id, params: params)
-      case "status":
-        try await handleStatus(id: id, params: params)
-      case "chats.list":
-        try await handleChatsList(id: id, params: params)
-      case "messages.stats":
-        try await handleMessagesStats(id: id, params: params)
-      case "messages.history":
-        try await handleMessagesHistory(id: id, params: params)
-      case "messages.after":
-        try await handleMessagesAfter(id: id, params: params)
-      case "watch.subscribe":
-        try await handleWatchSubscribe(id: id, params: params)
-      case "watch.unsubscribe":
-        try await handleWatchUnsubscribe(id: id, params: params)
-      case "send":
-        try await handleSend(params: params, id: id)
-      case "send.rich":
-        try await handleSendRich(params: params, id: id)
-      case "send.attachment":
-        try await handleSendAttachment(params: params, id: id)
-      case "send.sticker":
-        try await handleSendSticker(params: params, id: id)
-      case "messages.scheduled":
-        try await handleMessagesScheduled(params: params, id: id)
-      case "poll.send", "messages.poll.send":
-        try await handlePollSend(params: params, id: id)
-      case "poll.vote", "messages.poll.vote":
-        try await handlePollVote(params: params, id: id)
-      case "poll.unvote", "polls.unvote", "messages.poll.unvote":
-        try await handlePollUnvote(params: params, id: id)
-      case "tapback":
-        try await handleTapback(params: params, id: id)
-      case "typing":
-        try await handleTyping(params: params, id: id)
-      case "read":
-        try await handleRead(params: params, id: id)
-      case "message.edit":
-        try await handleMessageEdit(params: params, id: id)
-      case "message.unsend":
-        try await handleMessageUnsend(params: params, id: id)
-      case "message.delete":
-        try await handleMessageDelete(params: params, id: id)
-      case "message.notifyAnyways":
-        try await handleMessageNotifyAnyways(params: params, id: id)
-      case "message.send_status":
-        try await handleMessageSendStatus(params: params, id: id)
-      case "chats.create":
-        try await handleChatsCreate(id: id, params: params)
-      case "chats.delete":
-        try await handleChatsDelete(id: id, params: params)
-      case "chats.markUnread":
-        try await handleChatsMarkUnread(id: id, params: params)
-      case "group.rename":
-        try await handleGroupRename(id: id, params: params)
-      case "group.setIcon":
-        try await handleGroupSetIcon(id: id, params: params)
-      case "group.addParticipant":
-        try await handleGroupAddParticipant(id: id, params: params)
-      case "group.removeParticipant":
-        try await handleGroupRemoveParticipant(id: id, params: params)
-      case "group.leave":
-        try await handleGroupLeave(id: id, params: params)
-      case "contacts.shouldShareContact":
-        try await handleNamePhotoStatus(params: params, id: id)
-      case "contacts.shareContactCard":
-        try await handleNamePhotoShare(params: params, id: id)
-      case "handles.check":
-        try await handleHandlesCheck(params: params, id: id)
-      default:
+      guard let route = rpcDispatchRoutes[method] else {
         if !request.isNotification {
           output.sendError(id: id, error: RPCError.methodNotFound(method))
         }
+        return .completed
+      }
+      switch route {
+      case .initialize:
+        try await handleInitialize(id: id, params: params)
+      case .status:
+        try await handleStatus(id: id, params: params)
+      case .chatsList:
+        try await handleChatsList(id: id, params: params)
+      case .messagesStats:
+        try await handleMessagesStats(id: id, params: params)
+      case .messagesHistory:
+        try await handleMessagesHistory(id: id, params: params)
+      case .messagesSearch:
+        try await handleMessagesSearch(id: id, params: params)
+      case .messagesAfter:
+        try await handleMessagesAfter(id: id, params: params)
+      case .watchSubscribe:
+        try await handleWatchSubscribe(id: id, params: params)
+      case .watchUnsubscribe:
+        try await handleWatchUnsubscribe(id: id, params: params)
+      case .send:
+        try await handleSend(params: params, id: id)
+      case .sendRich:
+        try await handleSendRich(params: params, id: id)
+      case .sendAttachment:
+        try await handleSendAttachment(params: params, id: id)
+      case .sendMultipart:
+        try await handleSendMultipart(params: params, id: id)
+      case .sendSticker:
+        try await handleSendSticker(params: params, id: id)
+      case .messagesScheduled:
+        try await handleMessagesScheduled(params: params, id: id)
+      case .pollSend:
+        try await handlePollSend(params: params, id: id)
+      case .pollVote:
+        try await handlePollVote(params: params, id: id)
+      case .pollUnvote:
+        try await handlePollUnvote(params: params, id: id)
+      case .tapback:
+        try await handleTapback(params: params, id: id)
+      case .typing:
+        try await handleTyping(params: params, id: id)
+      case .read:
+        try await handleRead(params: params, id: id)
+      case .messageEdit:
+        try await handleMessageEdit(params: params, id: id)
+      case .messageUnsend:
+        try await handleMessageUnsend(params: params, id: id)
+      case .messageDelete:
+        try await handleMessageDelete(params: params, id: id)
+      case .messageNotifyAnyways:
+        try await handleMessageNotifyAnyways(params: params, id: id)
+      case .messageSendStatus:
+        try await handleMessageSendStatus(params: params, id: id)
+      case .chatsCreate:
+        try await handleChatsCreate(id: id, params: params)
+      case .chatsDelete:
+        try await handleChatsDelete(id: id, params: params)
+      case .chatsMarkUnread:
+        try await handleChatsMarkUnread(id: id, params: params)
+      case .groupRename:
+        try await handleGroupRename(id: id, params: params)
+      case .groupSetIcon:
+        try await handleGroupSetIcon(id: id, params: params)
+      case .groupAddParticipant:
+        try await handleGroupAddParticipant(id: id, params: params)
+      case .groupRemoveParticipant:
+        try await handleGroupRemoveParticipant(id: id, params: params)
+      case .groupLeave:
+        try await handleGroupLeave(id: id, params: params)
+      case .contactsShouldShare:
+        try await handleNamePhotoStatus(params: params, id: id)
+      case .contactsShare:
+        try await handleNamePhotoShare(params: params, id: id)
+      case .handlesCheck:
+        try await handleHandlesCheck(params: params, id: id)
       }
     } catch is CancellationError {
       return .completed

--- a/Sources/imsg/SentMessageVerifier.swift
+++ b/Sources/imsg/SentMessageVerifier.swift
@@ -34,6 +34,39 @@ enum SentMessageVerifier {
     return nil
   }
 
+  static func resolveSentMessage(
+    store: MessageStore,
+    messageGUID: String,
+    chatInfo: ChatInfo,
+    afterRowID: Int64
+  ) async throws -> Message? {
+    guard !messageGUID.isEmpty, !chatInfo.guid.isEmpty else { return nil }
+
+    let deadline = Date().addingTimeInterval(8)
+    repeat {
+      if Task.isCancelled { return nil }
+      if let status = try store.messageSendStatus(guid: messageGUID),
+        status.rowID > afterRowID,
+        try store.messageBelongsToChat(messageGUID: messageGUID, chatGUID: chatInfo.guid)
+      {
+        return Message(
+          rowID: status.rowID,
+          chatID: chatInfo.id,
+          sender: "",
+          text: "",
+          date: Date(),
+          isFromMe: true,
+          service: status.service,
+          handleID: nil,
+          attachmentsCount: 1,
+          guid: status.guid
+        )
+      }
+      try await Task.sleep(nanoseconds: 100_000_000)
+    } while Date() < deadline
+    return nil
+  }
+
   static func resolveSentMessageCandidate(
     store: MessageStore,
     options: MessageSendOptions,

--- a/Tests/imsgTests/BridgeCommandRegistrationTests.swift
+++ b/Tests/imsgTests/BridgeCommandRegistrationTests.swift
@@ -27,6 +27,21 @@ func commandRouterIncludesAllBridgeCommands() {
 }
 
 @Test
+func injectedHelperReportsAuthoritativeMultipartCapability() throws {
+  let testFile = URL(fileURLWithPath: #filePath)
+  let repoRoot =
+    testFile
+    .deletingLastPathComponent()
+    .deletingLastPathComponent()
+    .deletingLastPathComponent()
+  let helper = repoRoot.appendingPathComponent("Sources/IMsgHelper/IMsgInjected.m")
+  let source = stripObjectiveCComments(try String(contentsOf: helper, encoding: .utf8))
+  let statusBody = try #require(functionBody(named: "handleStatus", in: source))
+
+  #expect(statusBody.contains(#"@"sendMultipart": @(chatSend)"#))
+}
+
+@Test
 func bridgeMessagingCommandsExposeChatRequirement() async {
   // Each new bridge messaging command requires a `--chat` option (the chat
   // guid is the universal addressing key in v2). Ensure missing args bubble

--- a/Tests/imsgTests/RPCBridgeMessageHandlersTests.swift
+++ b/Tests/imsgTests/RPCBridgeMessageHandlersTests.swift
@@ -27,6 +27,7 @@ func rpcStatusAdvertisesBridgeMessageMethods() {
   for method in [
     "send.rich",
     "send.attachment",
+    "send.multipart",
     "send.sticker",
     "poll.send",
     "messages.poll.send",
@@ -419,6 +420,7 @@ func rpcSendAttachmentStagesFileBeforeBridgeSend() async throws {
   #expect(capturedParams["partIndex"] as? Int == 2)
   let result = output.responses.first?["result"] as? [String: Any]
   #expect(result?["message_id"] as? String == "attachment-guid")
+  #expect(result?["chat_guid"] as? String == "iMessage;+;chat123")
 }
 
 @Test

--- a/Tests/imsgTests/RPCContractValidationTests.swift
+++ b/Tests/imsgTests/RPCContractValidationTests.swift
@@ -168,6 +168,7 @@ func rpcRejectsCoercedNumericAndBooleanValues() async throws {
     #"{"jsonrpc":"2.0","id":"bool-chat","method":"messages.history","params":{"chat_id":true}}"#,
     #"{"jsonrpc":"2.0","id":"bool-limit","method":"chats.list","params":{"limit":false}}"#,
     #"{"jsonrpc":"2.0","id":"number-bool","method":"chats.list","params":{"unread_only":1}}"#,
+    #"{"jsonrpc":"2.0","id":"sms-fallback","method":"send","params":{"to":"+123","text":"hi","allow_sms_fallback":1}}"#,
   ]
 
   for request in requests {
@@ -200,6 +201,11 @@ func rpcRejectsDocumentedInvalidSemanticValuesBeforeSideEffects() async throws {
   )
   let requests = [
     #"{"jsonrpc":"2.0","id":"history-id","method":"messages.history","params":{"chat_id":0}}"#,
+    #"{"jsonrpc":"2.0","id":"history-limit","method":"messages.history","params":{"chat_id":1,"limit":0}}"#,
+    #"{"jsonrpc":"2.0","id":"chats-limit","method":"chats.list","params":{"limit":-1}}"#,
+    #"{"jsonrpc":"2.0","id":"search-empty","method":"messages.search","params":{"query":"   "}}"#,
+    #"{"jsonrpc":"2.0","id":"search-match","method":"messages.search","params":{"query":"hello","match":"prefix"}}"#,
+    #"{"jsonrpc":"2.0","id":"search-limit","method":"messages.search","params":{"query":"hello","limit":101}}"#,
     #"{"jsonrpc":"2.0","id":"watch-id","method":"watch.subscribe","params":{"chat_id":-1}}"#,
     #"{"jsonrpc":"2.0","id":"send-id","method":"send","params":{"chat_id":0,"text":"hi"}}"#,
     #"{"jsonrpc":"2.0","id":"subscription","method":"watch.unsubscribe","params":{"subscription":0}}"#,
@@ -208,6 +214,9 @@ func rpcRejectsDocumentedInvalidSemanticValuesBeforeSideEffects() async throws {
     #"{"jsonrpc":"2.0","id":"empty-address","method":"group.addParticipant","params":{"chat_id":1,"address":""}}"#,
     #"{"jsonrpc":"2.0","id":"negative-part","method":"send.sticker","params":{"#
       + #""chat_id":1,"file":"sticker.png","attach_to":"parent-guid","part_index":-1}}"#,
+    #"{"jsonrpc":"2.0","id":"poll-comment","method":"poll.send","params":{"#
+      + #""chat_id":1,"question":"Q","options":["A","B"],"comment":"caption","#
+      + #""suppress_comment":true}}"#,
   ]
 
   for request in requests {
@@ -219,6 +228,49 @@ func rpcRejectsDocumentedInvalidSemanticValuesBeforeSideEffects() async throws {
   #expect(output.errors.allSatisfy { rpcErrorCode($0) == -32602 })
   #expect(bridgeCalls == 0)
   #expect(stageCalls == 0)
+}
+
+@Test
+func rpcMultipartRejectsInvalidPartsBeforeBridgeDispatch() async throws {
+  let store = try CommandTestDatabase.makeStoreForRPC()
+  let output = TestRPCOutput()
+  var bridgeCalls = 0
+  let server = RPCServer(
+    store: store,
+    verbose: false,
+    output: output,
+    invokeBridge: { _, _ in
+      bridgeCalls += 1
+      return [:]
+    }
+  )
+  let tooMany = Array(repeating: #"{"text":"x"}"#, count: 21).joined(separator: ",")
+  let params = [
+    #"{}"#,
+    #"{"parts":[]}"#,
+    #"{"parts":["text"]}"#,
+    #"{"parts":[{"text":""}]}"#,
+    #"{"parts":[{"text":1}]}"#,
+    #"{"parts":[{"text":"hi","extra":true}]}"#,
+    #"{"parts":[{"text":"hi","file":"photo.jpg"}]}"#,
+    #"{"parts":[{"text":"hi","attachment":{}}]}"#,
+    #"{"parts":[{"text":"hi","mention":"+123"}]}"#,
+    #"{"parts":[{"text":"hi","text_formatting":[]}],"effect":1}"#,
+    #"{"chat_id":1,"parts":[{"text":"hi","textFormatting":[],"text_formatting":[]}]}"#,
+    "{\"chat_id\":1,\"parts\":[\(tooMany)]}",
+  ]
+
+  for (index, value) in params.enumerated() {
+    await server.handleLineForTesting(
+      "{\"jsonrpc\":\"2.0\",\"id\":\"multipart-\(index)\","
+        + "\"method\":\"send.multipart\",\"params\":\(value)}"
+    )
+  }
+
+  #expect(output.responses.isEmpty)
+  #expect(output.errors.count == params.count)
+  #expect(output.errors.allSatisfy { rpcErrorCode($0) == -32602 })
+  #expect(bridgeCalls == 0)
 }
 
 @Test
@@ -242,6 +294,8 @@ func rpcRejectsConflictingAliasesBeforeSideEffects() async throws {
     #"{"jsonrpc":"2.0","id":"watch","method":"watch.subscribe","params":{"debounce_ms":1,"debounceMs":1}}"#,
     #"{"jsonrpc":"2.0","id":"send-format","method":"send","params":{"to":"+123","text":"hi","formatting":[],"textFormatting":[]}}"#,
     #"{"jsonrpc":"2.0","id":"send-reply","method":"send","params":{"to":"+123","text":"hi","reply_to":"a","replyTo":"a"}}"#,
+    #"{"jsonrpc":"2.0","id":"send-fallback","method":"send","params":{"#
+      + #""to":"+123","text":"hi","allow_sms_fallback":true,"allowSMSFallback":true}}"#,
     #"{"jsonrpc":"2.0","id":"rich","method":"send.rich","params":{"chat_id":1,"text":"hi","message":"hi"}}"#,
     #"{"jsonrpc":"2.0","id":"attachment","method":"send.attachment","params":{"chat_id":1,"file":"a","path":"a"}}"#,
     #"{"jsonrpc":"2.0","id":"attachment-audio","method":"send.attachment","params":{"#

--- a/Tests/imsgTests/RPCPayloadsTests.swift
+++ b/Tests/imsgTests/RPCPayloadsTests.swift
@@ -12,35 +12,46 @@ func isGroupHandleFlagsGroup() {
 }
 
 @Test
-func chatPayloadIncludesParticipantsAndGroupFlag() {
+func canonicalChatPayloadIncludesParticipantsAndGroupFlag() throws {
   let date = Date(timeIntervalSince1970: 0)
-  let payload = chatPayload(
+  let chat = Chat(
+    id: 1,
+    identifier: "iMessage;+;chat123",
+    name: "Group",
+    service: "iMessage",
+    lastMessageAt: date
+  )
+  let info = ChatInfo(
     id: 1,
     identifier: "iMessage;+;chat123",
     guid: "iMessage;+;chat123",
-    name: "Group",
-    service: "iMessage",
-    lastMessageAt: date,
-    participants: ["+111", "+222"]
+    name: "Group title",
+    service: "iMessage"
   )
-  #expect(payload["id"] as? Int64 == 1)
+  let payload = try ChatPayload(
+    chat: chat, chatInfo: info, participants: ["+111", "+222"]
+  ).asDictionary()
+  #expect((payload["id"] as? NSNumber)?.int64Value == 1)
   #expect(payload["identifier"] as? String == "iMessage;+;chat123")
+  #expect(payload["display_name"] as? String == "Group title")
   #expect(payload["is_group"] as? Bool == true)
   #expect((payload["participants"] as? [String])?.count == 2)
 }
 
 @Test
-func chatPayloadIncludesContactName() {
-  let payload = chatPayload(
+func canonicalChatPayloadIncludesContactName() throws {
+  let chat = Chat(
     id: 2,
     identifier: "+15551234567",
-    guid: "iMessage;-;+15551234567",
     name: "+15551234567",
     service: "iMessage",
-    lastMessageAt: Date(timeIntervalSince1970: 0),
+    lastMessageAt: Date(timeIntervalSince1970: 0)
+  )
+  let payload = try ChatPayload(
+    chat: chat,
     participants: ["+15551234567"],
     contactName: "Alice"
-  )
+  ).asDictionary()
   #expect(payload["contact_name"] as? String == "Alice")
 }
 
@@ -106,9 +117,16 @@ func messagePayloadIncludesChatFields() throws {
   #expect(payload["chat_name"] as? String == "Group")
   #expect(payload["is_group"] as? Bool == true)
   #expect((payload["attachments"] as? [[String: Any]])?.count == 1)
-  let attachmentPayload = (payload["attachments"] as? [[String: Any]])?.first
-  #expect(attachmentPayload?["converted_path"] as? String == "/tmp/file.png")
-  #expect(attachmentPayload?["converted_mime_type"] as? String == "image/png")
+  let attachmentPayload = try #require((payload["attachments"] as? [[String: Any]])?.first)
+  #expect(
+    Set(attachmentPayload.keys) == [
+      "filename", "transfer_name", "uti", "mime_type", "total_bytes", "is_sticker",
+      "original_path", "converted_path", "converted_mime_type", "missing",
+    ])
+  #expect((attachmentPayload["total_bytes"] as? NSNumber)?.int64Value == 12)
+  #expect(attachmentPayload["original_path"] as? String == "/tmp/file.dat")
+  #expect(attachmentPayload["converted_path"] as? String == "/tmp/file.png")
+  #expect(attachmentPayload["converted_mime_type"] as? String == "image/png")
   #expect(
     (payload["reactions"] as? [[String: Any]])?.first?["emoji"] as? String
       == ReactionType.like.emoji)

--- a/Tests/imsgTests/RPCReadParityTests.swift
+++ b/Tests/imsgTests/RPCReadParityTests.swift
@@ -1,0 +1,49 @@
+import Foundation
+import Testing
+
+@testable import IMsgCore
+@testable import imsg
+
+@Test
+func rpcChatsListUsesCanonicalSingleParticipantContactFallback() async throws {
+  let store = try CommandTestDatabase.makeStoreForRPCDirectChat()
+  _ = try store.withConnection { db in
+    try db.run("DELETE FROM chat_handle_join WHERE handle_id = 2")
+  }
+  let output = TestRPCOutput()
+  let resolver = MockContactResolver(names: ["+123": "Alice"])
+  let server = RPCServer(store: store, verbose: false, output: output, contactResolver: resolver)
+
+  await server.handleLineForTesting(
+    #"{"jsonrpc":"2.0","id":"direct","method":"chats.list","params":{"limit":1}}"#)
+
+  let result = try #require(output.responses.first?["result"] as? [String: Any])
+  let chat = try #require((result["chats"] as? [[String: Any]])?.first)
+  #expect(chat["contact_name"] as? String == "Alice")
+  #expect(chat["display_name"] as? String == "Direct Chat")
+  #expect(chat["is_group"] as? Bool == false)
+  #expect(chat["account_id"] as? String == "iMessage;+;me@icloud.com")
+  #expect(chat["account_login"] as? String == "me@icloud.com")
+  #expect(chat["last_addressed_handle"] as? String == "me@icloud.com")
+}
+
+@Test
+func rpcMessagesSearchUsesDatabaseAndCanonicalMessagePayload() async throws {
+  let store = try CommandTestDatabase.makeStoreForRPC()
+  let output = TestRPCOutput()
+  let resolver = MockContactResolver(names: ["+123": "Alice"])
+  let server = RPCServer(store: store, verbose: false, output: output, contactResolver: resolver)
+
+  await server.handleLineForTesting(
+    #"{"jsonrpc":"2.0","id":"search","method":"messages.search","params":{"query":"HELLO","match":"exact","limit":1}}"#
+  )
+
+  let result = try #require(output.responses.first?["result"] as? [String: Any])
+  let message = try #require((result["messages"] as? [[String: Any]])?.first)
+  #expect((message["id"] as? NSNumber)?.int64Value == 5)
+  #expect(message["text"] as? String == "hello")
+  #expect(message["sender_name"] as? String == "Alice")
+  #expect(message["chat_guid"] as? String == "iMessage;+;chat123")
+  #expect((message["attachments"] as? [[String: Any]])?.isEmpty == true)
+  #expect((message["reactions"] as? [[String: Any]])?.isEmpty == true)
+}

--- a/Tests/imsgTests/RPCSendParityTests.swift
+++ b/Tests/imsgTests/RPCSendParityTests.swift
@@ -1,0 +1,339 @@
+import Foundation
+import Testing
+
+@testable import IMsgCore
+@testable import imsg
+
+private struct SendVerificationTestError: Error {}
+
+@Test
+func rpcSendRichFileUsesAttachmentCapabilityAndSharedResponseEnrichment() async throws {
+  let store = try CommandTestDatabase.makeStoreForRPC()
+  let output = TestRPCOutput()
+  var calls: [(BridgeAction, [String: Any])] = []
+  var staged = ""
+  let server = RPCServer(
+    store: store,
+    verbose: false,
+    output: output,
+    resolveSentMessage: { _, options, chatID, _ in
+      #expect(options.text == "caption")
+      #expect(chatID == 1)
+      return Message(
+        rowID: 88,
+        chatID: 1,
+        sender: "",
+        text: "caption",
+        date: Date(),
+        isFromMe: true,
+        service: "iMessage",
+        handleID: nil,
+        attachmentsCount: 1,
+        guid: "resolved-attachment-guid"
+      )
+    },
+    invokeBridge: { action, params in
+      calls.append((action, params))
+      if action == .status {
+        return [
+          "attachment_metadata": true,
+          "selectors": ["sendAttachment": true] as [String: Any],
+        ]
+      }
+      return ["chatGuid": "iMessage;+;chat123", "messageGuid": "bridge-guid"]
+    },
+    stageAttachment: {
+      staged = $0
+      return "/staged/photo.jpg"
+    }
+  )
+
+  let request =
+    #"{"jsonrpc":"2.0","id":"rich-file","method":"send.rich","params":{"#
+    + #""chat_id":1,"path":"~/photo.jpg","text":"caption","effect":"impact","#
+    + #""subject":"Subject","reply_to":"parent-guid","part_index":2,"dd_scan":false,"#
+    + #""text_formatting":[{"start":0,"length":7,"styles":["bold"]}]}}"#
+  await server.handleLineForTesting(request)
+
+  #expect(calls.map(\.0) == [.status, .sendAttachment])
+  #expect(staged.hasSuffix("/photo.jpg"))
+  let sent = try #require(calls.last?.1)
+  #expect(sent["filePath"] as? String == "/staged/photo.jpg")
+  #expect(sent["message"] as? String == "caption")
+  #expect(sent["effectId"] as? String == "com.apple.MobileSMS.expressivesend.impact")
+  #expect(sent["subject"] as? String == "Subject")
+  #expect(sent["selectedMessageGuid"] as? String == "parent-guid")
+  #expect(sent["partIndex"] as? Int == 2)
+  #expect(sent["ddScan"] as? Bool == false)
+  #expect((sent["textFormatting"] as? [[String: Any]])?.count == 1)
+  let result = try #require(output.responses.first?["result"] as? [String: Any])
+  #expect(result["ok"] as? Bool == true)
+  #expect((result["id"] as? NSNumber)?.int64Value == 88)
+  #expect(result["guid"] as? String == "resolved-attachment-guid")
+  #expect(result["message_id"] as? String == "resolved-attachment-guid")
+  #expect(result["chat_guid"] as? String == "iMessage;+;chat123")
+}
+
+@Test
+func rpcSendRichFileWithoutCaptionVerifiesNewBridgeGUIDRow() async throws {
+  let store = try CommandTestDatabase.makeStoreForRPC()
+  _ = try store.withConnection { db in
+    try db.run("ALTER TABLE message ADD COLUMN guid TEXT")
+  }
+  let output = TestRPCOutput()
+  var actions: [BridgeAction] = []
+  let server = RPCServer(
+    store: store,
+    verbose: false,
+    output: output,
+    resolveSentMessage: { _, _, _, _ in
+      Issue.record("empty-caption rich file should use canonical GUID verification")
+      return nil
+    },
+    invokeBridge: { action, _ in
+      actions.append(action)
+      if action == .status {
+        return ["selectors": ["sendAttachment": true] as [String: Any]]
+      }
+      try store.withConnection { db in
+        try db.run(
+          "INSERT INTO message(ROWID, handle_id, text, date, is_from_me, service, guid) "
+            + "VALUES (6, 1, '', ?, 1, 'iMessage', 'new-attachment-guid')",
+          CommandTestDatabase.appleEpoch(Date())
+        )
+        try db.run("INSERT INTO chat_message_join(chat_id, message_id) VALUES (1, 6)")
+      }
+      return ["messageGuid": "new-attachment-guid"]
+    },
+    stageAttachment: { _ in "/staged/photo.jpg" }
+  )
+
+  await server.handleLineForTesting(
+    #"{"jsonrpc":"2.0","id":"rich-file","method":"send.rich","params":{"chat_id":1,"file":"photo.jpg"}}"#
+  )
+
+  #expect(actions == [.status, .sendAttachment])
+  #expect(output.errors.isEmpty)
+  let result = try #require(output.responses.first?["result"] as? [String: Any])
+  #expect((result["id"] as? NSNumber)?.int64Value == 6)
+  #expect(result["guid"] as? String == "new-attachment-guid")
+  #expect(result["message_id"] as? String == "new-attachment-guid")
+}
+
+@Test
+func rpcSendRichFileRejectsMissingAttachmentCapabilityBeforeStaging() async throws {
+  let store = try CommandTestDatabase.makeStoreForRPC()
+  let output = TestRPCOutput()
+  var actions: [BridgeAction] = []
+  var stageCalls = 0
+  let server = RPCServer(
+    store: store,
+    verbose: false,
+    output: output,
+    invokeBridge: { action, _ in
+      actions.append(action)
+      return ["selectors": ["sendAttachment": false] as [String: Any]]
+    },
+    stageAttachment: { _ in
+      stageCalls += 1
+      return "/must-not-stage"
+    }
+  )
+
+  await server.handleLineForTesting(
+    #"{"jsonrpc":"2.0","id":"rich-file","method":"send.rich","params":{"chat_id":1,"file":"photo.jpg"}}"#
+  )
+
+  #expect(actions == [.status])
+  #expect(stageCalls == 0)
+  #expect(output.responses.isEmpty)
+  #expect((output.errors.first?["error"] as? [String: Any])?["code"] as? Int == -32603)
+}
+
+@Test
+func rpcSendMultipartValidatesTextPartsAndNormalizesResponse() async throws {
+  let store = try CommandTestDatabase.makeStoreForRPC()
+  let output = TestRPCOutput()
+  var action: BridgeAction?
+  var bridgeParams: [String: Any] = [:]
+  let server = RPCServer(
+    store: store,
+    verbose: false,
+    output: output,
+    resolveSentMessage: { _, options, chatID, _ in
+      #expect(options.text == "hello world")
+      #expect(chatID == 1)
+      return Message(
+        rowID: 99,
+        chatID: 1,
+        sender: "",
+        text: options.text,
+        date: Date(),
+        isFromMe: true,
+        service: "iMessage",
+        handleID: nil,
+        attachmentsCount: 0,
+        guid: "multipart-resolved-guid"
+      )
+    },
+    invokeBridge: { sentAction, params in
+      action = sentAction
+      bridgeParams = params
+      return [
+        "chatGuid": "iMessage;+;chat123",
+        "messageGuid": "multipart-bridge-guid",
+        "parts_count": 2,
+      ]
+    }
+  )
+
+  let request =
+    #"{"jsonrpc":"2.0","id":"multipart","method":"send.multipart","params":{"#
+    + #""chat_id":1,"parts":[{"text":"hello ","text_formatting":[{"start":0,"#
+    + #""length":5,"styles":["bold"]}]},{"text":"world"}],"effect":"confetti","#
+    + #""subject":"Greeting"}}"#
+  await server.handleLineForTesting(request)
+
+  #expect(action == .sendMultipart)
+  #expect(bridgeParams["effectId"] as? String == "com.apple.messages.effect.CKConfettiEffect")
+  #expect(bridgeParams["subject"] as? String == "Greeting")
+  let parts = try #require(bridgeParams["parts"] as? [[String: Any]])
+  #expect(parts.map { $0["text"] as? String } == ["hello ", "world"])
+  #expect((parts.first?["textFormatting"] as? [[String: Any]])?.count == 1)
+  let result = try #require(output.responses.first?["result"] as? [String: Any])
+  #expect(result["ok"] as? Bool == true)
+  #expect((result["id"] as? NSNumber)?.int64Value == 99)
+  #expect(result["guid"] as? String == "multipart-resolved-guid")
+  #expect(result["message_id"] as? String == "multipart-resolved-guid")
+  #expect(result["chat_guid"] as? String == "iMessage;+;chat123")
+  #expect(result["parts_count"] as? Int == 2)
+}
+
+@Test
+func rpcSendMultipartRejectsUnobservedDeliveryWithoutRetry() async throws {
+  let store = try CommandTestDatabase.makeStoreForRPC()
+  let output = TestRPCOutput()
+  var bridgeCalls = 0
+  let server = RPCServer(
+    store: store,
+    verbose: false,
+    output: output,
+    resolveSentMessage: { _, _, _, _ in nil },
+    invokeBridge: { action, _ in
+      #expect(action == .sendMultipart)
+      bridgeCalls += 1
+      return ["messageGuid": "unobserved-guid"]
+    },
+    isBridgeReady: { true }
+  )
+
+  await server.handleLineForTesting(
+    #"{"jsonrpc":"2.0","id":"multipart","method":"send.multipart","params":{"chat_id":1,"parts":[{"text":"unique nonce"}]}}"#
+  )
+
+  #expect(bridgeCalls == 1)
+  #expect(output.responses.isEmpty)
+  let error = try #require(output.errors.first?["error"] as? [String: Any])
+  let data = try #require(error["data"] as? [String: Any])
+  #expect(error["code"] as? Int == -32001)
+  #expect(data["disposition"] as? String == "may_have_completed")
+  #expect(data["transport"] as? String == "bridge_v2")
+  #expect(data["operation"] as? String == "send-multipart")
+  #expect(data["retry_safe"] as? Bool == false)
+}
+
+@Test
+func rpcSendRichFileMapsResolverErrorWithoutRetry() async throws {
+  let store = try CommandTestDatabase.makeStoreForRPC()
+  let output = TestRPCOutput()
+  var actions: [BridgeAction] = []
+  let server = RPCServer(
+    store: store,
+    verbose: false,
+    output: output,
+    resolveSentMessage: { _, _, _, _ in throw SendVerificationTestError() },
+    invokeBridge: { action, _ in
+      actions.append(action)
+      if action == .status {
+        return [
+          "attachment_metadata": true,
+          "selectors": ["sendAttachment": true] as [String: Any],
+        ]
+      }
+      return ["messageGuid": "unobserved-guid"]
+    },
+    stageAttachment: { _ in "/staged/photo.jpg" }
+  )
+
+  await server.handleLineForTesting(
+    #"{"jsonrpc":"2.0","id":"rich-file","method":"send.rich","params":{"chat_id":1,"file":"photo.jpg","text":"unique caption"}}"#
+  )
+
+  #expect(actions == [.status, .sendAttachment])
+  #expect(output.responses.isEmpty)
+  let error = try #require(output.errors.first?["error"] as? [String: Any])
+  let data = try #require(error["data"] as? [String: Any])
+  #expect(error["code"] as? Int == -32001)
+  #expect(data["disposition"] as? String == "may_have_completed")
+  #expect(data["transport"] as? String == "bridge_v2")
+  #expect(data["operation"] as? String == "send-attachment")
+}
+
+@Test
+func rpcSendMultipartRejectsSuccessWhenDatabaseUnavailable() async throws {
+  let output = TestRPCOutput()
+  var bridgeCalls = 0
+  let server = RPCServer(
+    databasePath: "/unavailable/chat.db",
+    verbose: false,
+    output: output,
+    storeFactory: { _ in throw SendVerificationTestError() },
+    invokeBridge: { action, _ in
+      #expect(action == .sendMultipart)
+      bridgeCalls += 1
+      return ["messageGuid": "unobserved-guid"]
+    },
+    isBridgeReady: { true }
+  )
+
+  let request =
+    #"{"jsonrpc":"2.0","id":"multipart","method":"send.multipart","params":{"#
+    + #""chat_guid":"iMessage;+;chat123","parts":[{"text":"unique nonce"}]}}"#
+  await server.handleLineForTesting(
+    request
+  )
+
+  #expect(bridgeCalls == 1)
+  #expect(output.responses.isEmpty)
+  let error = try #require(output.errors.first?["error"] as? [String: Any])
+  let data = try #require(error["data"] as? [String: Any])
+  #expect(error["code"] as? Int == -32001)
+  #expect(data["disposition"] as? String == "may_have_completed")
+  #expect(data["transport"] as? String == "bridge_v2")
+  #expect(data["operation"] as? String == "send-multipart")
+}
+
+@Test
+func rpcUnobservedSendNotificationRemainsSilent() async throws {
+  let store = try CommandTestDatabase.makeStoreForRPC()
+  let output = TestRPCOutput()
+  var bridgeCalls = 0
+  let server = RPCServer(
+    store: store,
+    verbose: false,
+    output: output,
+    resolveSentMessage: { _, _, _, _ in nil },
+    invokeBridge: { action, _ in
+      #expect(action == .sendMultipart)
+      bridgeCalls += 1
+      return ["messageGuid": "unobserved-guid"]
+    }
+  )
+
+  await server.handleLineForTesting(
+    #"{"jsonrpc":"2.0","method":"send.multipart","params":{"chat_id":1,"parts":[{"text":"unique nonce"}]}}"#
+  )
+
+  #expect(bridgeCalls == 1)
+  #expect(output.outputs.isEmpty)
+}

--- a/Tests/imsgTests/RPCSendParityTests.swift
+++ b/Tests/imsgTests/RPCSendParityTests.swift
@@ -6,118 +6,373 @@ import Testing
 
 private struct SendVerificationTestError: Error {}
 
-@Test
-func rpcSendRichFileUsesAttachmentCapabilityAndSharedResponseEnrichment() async throws {
-  let store = try CommandTestDatabase.makeStoreForRPC()
-  let output = TestRPCOutput()
-  var calls: [(BridgeAction, [String: Any])] = []
-  var staged = ""
-  let server = RPCServer(
-    store: store,
-    verbose: false,
-    output: output,
-    resolveSentMessage: { _, options, chatID, _ in
-      #expect(options.text == "caption")
-      #expect(chatID == 1)
-      return Message(
-        rowID: 88,
-        chatID: 1,
-        sender: "",
-        text: "caption",
-        date: Date(),
-        isFromMe: true,
-        service: "iMessage",
-        handleID: nil,
-        attachmentsCount: 1,
-        guid: "resolved-attachment-guid"
-      )
-    },
-    invokeBridge: { action, params in
-      calls.append((action, params))
-      if action == .status {
-        return [
-          "attachment_metadata": true,
-          "selectors": ["sendAttachment": true] as [String: Any],
-        ]
-      }
-      return ["chatGuid": "iMessage;+;chat123", "messageGuid": "bridge-guid"]
-    },
-    stageAttachment: {
-      staged = $0
-      return "/staged/photo.jpg"
-    }
-  )
+private struct PublicationSignal {
+  private let stream: AsyncStream<Void>
+  private let continuation: AsyncStream<Void>.Continuation
 
-  let request =
-    #"{"jsonrpc":"2.0","id":"rich-file","method":"send.rich","params":{"#
-    + #""chat_id":1,"path":"~/photo.jpg","text":"caption","effect":"impact","#
-    + #""subject":"Subject","reply_to":"parent-guid","part_index":2,"dd_scan":false,"#
-    + #""text_formatting":[{"start":0,"length":7,"styles":["bold"]}]}}"#
-  await server.handleLineForTesting(request)
+  init() {
+    (self.stream, self.continuation) = AsyncStream.makeStream()
+  }
 
-  #expect(calls.map(\.0) == [.status, .sendAttachment])
-  #expect(staged.hasSuffix("/photo.jpg"))
-  let sent = try #require(calls.last?.1)
-  #expect(sent["filePath"] as? String == "/staged/photo.jpg")
-  #expect(sent["message"] as? String == "caption")
-  #expect(sent["effectId"] as? String == "com.apple.MobileSMS.expressivesend.impact")
-  #expect(sent["subject"] as? String == "Subject")
-  #expect(sent["selectedMessageGuid"] as? String == "parent-guid")
-  #expect(sent["partIndex"] as? Int == 2)
-  #expect(sent["ddScan"] as? Bool == false)
-  #expect((sent["textFormatting"] as? [[String: Any]])?.count == 1)
-  let result = try #require(output.responses.first?["result"] as? [String: Any])
-  #expect(result["ok"] as? Bool == true)
-  #expect((result["id"] as? NSNumber)?.int64Value == 88)
-  #expect(result["guid"] as? String == "resolved-attachment-guid")
-  #expect(result["message_id"] as? String == "resolved-attachment-guid")
-  #expect(result["chat_guid"] as? String == "iMessage;+;chat123")
+  func publish() {
+    self.continuation.yield(())
+  }
+
+  func wait() async {
+    var iterator = self.stream.makeAsyncIterator()
+    _ = await iterator.next()
+  }
 }
 
-@Test
-func rpcSendRichFileWithoutCaptionVerifiesNewBridgeGUIDRow() async throws {
+private enum StrictSendSurface: CaseIterable, CustomStringConvertible {
+  case richFile
+  case multipart
+
+  var description: String {
+    switch self {
+    case .richFile: "send.rich file"
+    case .multipart: "send.multipart"
+    }
+  }
+
+  var publication: BridgeAction {
+    switch self {
+    case .richFile: .sendAttachment
+    case .multipart: .sendMultipart
+    }
+  }
+
+  func request(id: Bool = true) -> String {
+    let idField = id ? #""id":"strict","# : ""
+    switch self {
+    case .richFile:
+      return
+        #"{"jsonrpc":"2.0","# + idField
+        + #""method":"send.rich","params":{"chat_id":1,"file":"photo.jpg","text":"same text"}}"#
+    case .multipart:
+      return
+        #"{"jsonrpc":"2.0","# + idField
+        + #""method":"send.multipart","params":{"chat_id":1,"parts":[{"text":"same text"}]}}"#
+    }
+  }
+
+  func bridgeResponse(for action: BridgeAction, messageGUID: String) -> [String: Any] {
+    if action == .status {
+      return [
+        "attachment_metadata": true,
+        "selectors": ["sendAttachment": true] as [String: Any],
+      ]
+    }
+    return ["chatGuid": "iMessage;+;chat123", "messageGuid": messageGUID]
+  }
+}
+
+private func makeGUIDVerificationStore() throws -> MessageStore {
   let store = try CommandTestDatabase.makeStoreForRPC()
   _ = try store.withConnection { db in
     try db.run("ALTER TABLE message ADD COLUMN guid TEXT")
   }
+  return store
+}
+
+private func addOtherChat(to store: MessageStore) throws {
+  _ = try store.withConnection { db in
+    try db.run(
+      "INSERT INTO chat(ROWID, chat_identifier, guid, display_name, service_name) "
+        + "VALUES (2, 'other', 'iMessage;+;other', 'Other', 'iMessage')"
+    )
+  }
+}
+
+private func insertOutgoing(
+  into store: MessageStore,
+  rowID: Int64 = 6,
+  chatID: Int64 = 1,
+  guid: String,
+  text: String = "same text"
+) throws {
+  _ = try store.withConnection { db in
+    try db.run(
+      "INSERT INTO message(ROWID, handle_id, text, date, is_from_me, service, guid) "
+        + "VALUES (?, 1, ?, ?, 1, 'iMessage', ?)",
+      rowID,
+      text,
+      CommandTestDatabase.appleEpoch(Date()),
+      guid
+    )
+    try db.run("INSERT INTO chat_message_join(chat_id, message_id) VALUES (?, ?)", chatID, rowID)
+  }
+}
+
+private func handleAndCancelVerification(
+  _ server: RPCServer,
+  request: String,
+  publication: PublicationSignal
+) async {
+  let task = Task { await server.handleLineForTesting(request) }
+  await publication.wait()
+  task.cancel()
+  await task.value
+}
+
+private func assertUnknownDelivery(
+  _ output: TestRPCOutput,
+  operation: String,
+  sourceLocation: SourceLocation = #_sourceLocation
+) throws {
+  #expect(output.responses.isEmpty, sourceLocation: sourceLocation)
+  let error = try #require(
+    output.errors.first?["error"] as? [String: Any], sourceLocation: sourceLocation)
+  let data = try #require(error["data"] as? [String: Any], sourceLocation: sourceLocation)
+  #expect(error["code"] as? Int == -32001, sourceLocation: sourceLocation)
+  #expect(data["disposition"] as? String == "may_have_completed", sourceLocation: sourceLocation)
+  #expect(data["transport"] as? String == "bridge_v2", sourceLocation: sourceLocation)
+  #expect(data["operation"] as? String == operation, sourceLocation: sourceLocation)
+  #expect(data["retry_safe"] as? Bool == false, sourceLocation: sourceLocation)
+}
+
+@Test
+func rpcStrictSendSurfacesRequireDatabaseBeforePublication() async throws {
+  for surface in StrictSendSurface.allCases {
+    let output = TestRPCOutput()
+    var actions: [BridgeAction] = []
+    let server = RPCServer(
+      databasePath: "/unavailable/chat.db",
+      verbose: false,
+      output: output,
+      storeFactory: { _ in throw SendVerificationTestError() },
+      invokeBridge: { action, _ in
+        actions.append(action)
+        return surface.bridgeResponse(for: action, messageGUID: "must-not-send")
+      },
+      stageAttachment: { _ in "/staged/photo.jpg" },
+      isBridgeReady: { true }
+    )
+
+    await server.handleLineForTesting(surface.request())
+
+    #expect(actions.isEmpty, "\(surface)")
+    #expect(output.responses.isEmpty, "\(surface)")
+    #expect(
+      (output.errors.first?["error"] as? [String: Any])?["code"] as? Int == -32002,
+      "\(surface)"
+    )
+  }
+}
+
+@Test
+func rpcStrictSendBaselineFailureIsPreDispatchInternalError() async throws {
+  let store = try makeGUIDVerificationStore()
+  _ = try store.withConnection { db in try db.run("DROP TABLE message") }
   let output = TestRPCOutput()
-  var actions: [BridgeAction] = []
+  var bridgeCalls = 0
   let server = RPCServer(
     store: store,
     verbose: false,
     output: output,
-    resolveSentMessage: { _, _, _, _ in
-      Issue.record("empty-caption rich file should use canonical GUID verification")
-      return nil
-    },
-    invokeBridge: { action, _ in
-      actions.append(action)
-      if action == .status {
-        return ["selectors": ["sendAttachment": true] as [String: Any]]
-      }
-      try store.withConnection { db in
-        try db.run(
-          "INSERT INTO message(ROWID, handle_id, text, date, is_from_me, service, guid) "
-            + "VALUES (6, 1, '', ?, 1, 'iMessage', 'new-attachment-guid')",
-          CommandTestDatabase.appleEpoch(Date())
-        )
-        try db.run("INSERT INTO chat_message_join(chat_id, message_id) VALUES (1, 6)")
-      }
-      return ["messageGuid": "new-attachment-guid"]
-    },
-    stageAttachment: { _ in "/staged/photo.jpg" }
+    invokeBridge: { _, _ in
+      bridgeCalls += 1
+      return [:]
+    }
   )
 
   await server.handleLineForTesting(
-    #"{"jsonrpc":"2.0","id":"rich-file","method":"send.rich","params":{"chat_id":1,"file":"photo.jpg"}}"#
+    #"{"jsonrpc":"2.0","id":"strict","method":"send.multipart","params":{"chat_guid":"iMessage;+;chat123","parts":[{"text":"same text"}]}}"#
   )
 
-  #expect(actions == [.status, .sendAttachment])
-  #expect(output.errors.isEmpty)
-  let result = try #require(output.responses.first?["result"] as? [String: Any])
-  #expect((result["id"] as? NSNumber)?.int64Value == 6)
-  #expect(result["guid"] as? String == "new-attachment-guid")
-  #expect(result["message_id"] as? String == "new-attachment-guid")
+  #expect(bridgeCalls == 0)
+  #expect((output.errors.first?["error"] as? [String: Any])?["code"] as? Int == -32603)
+}
+
+@Test
+func rpcStrictSendSurfacesAcceptOnlyNewHelperGUIDInTargetChat() async throws {
+  for surface in StrictSendSurface.allCases {
+    let store = try makeGUIDVerificationStore()
+    let output = TestRPCOutput()
+    var actions: [BridgeAction] = []
+    let server = RPCServer(
+      store: store,
+      verbose: false,
+      output: output,
+      invokeBridge: { action, _ in
+        actions.append(action)
+        if action == surface.publication {
+          try insertOutgoing(into: store, guid: "new-helper-guid")
+        }
+        return surface.bridgeResponse(for: action, messageGUID: "new-helper-guid")
+      },
+      stageAttachment: { _ in "/staged/photo.jpg" }
+    )
+
+    await server.handleLineForTesting(surface.request())
+
+    #expect(actions.filter { $0 == surface.publication }.count == 1, "\(surface)")
+    #expect(output.errors.isEmpty, "\(surface)")
+    let result = try #require(output.responses.first?["result"] as? [String: Any])
+    #expect((result["id"] as? NSNumber)?.int64Value == 6, "\(surface)")
+    #expect(result["guid"] as? String == "new-helper-guid", "\(surface)")
+    #expect(result["message_id"] as? String == "new-helper-guid", "\(surface)")
+    #expect(result["chat_guid"] as? String == "iMessage;+;chat123", "\(surface)")
+    if surface == .multipart {
+      #expect(result["parts_count"] as? Int == 1)
+    }
+  }
+}
+
+@Test
+func rpcStrictSendRejectsConcurrentIdenticalTextWithoutMatchingHelperGUID() async throws {
+  for surface in StrictSendSurface.allCases {
+    for bridgeGUID in ["", "different-helper-guid"] {
+      let store = try makeGUIDVerificationStore()
+      let output = TestRPCOutput()
+      var publications = 0
+      let publication = PublicationSignal()
+      let server = RPCServer(
+        store: store,
+        verbose: false,
+        output: output,
+        invokeBridge: { action, _ in
+          if action == surface.publication {
+            publications += 1
+            publication.publish()
+            try insertOutgoing(into: store, guid: "unrelated-guid")
+          }
+          return surface.bridgeResponse(for: action, messageGUID: bridgeGUID)
+        },
+        stageAttachment: { _ in "/staged/photo.jpg" }
+      )
+
+      if bridgeGUID.isEmpty {
+        await server.handleLineForTesting(surface.request())
+      } else {
+        await handleAndCancelVerification(
+          server,
+          request: surface.request(),
+          publication: publication
+        )
+      }
+
+      #expect(publications == 1, "\(surface), GUID: \(bridgeGUID)")
+      try assertUnknownDelivery(output, operation: surface.publication.rawValue)
+    }
+  }
+}
+
+@Test
+func rpcStrictSendRejectsOldHelperGUIDBelowBaseline() async throws {
+  for surface in StrictSendSurface.allCases {
+    let store = try makeGUIDVerificationStore()
+    _ = try store.withConnection { db in
+      try db.run("UPDATE message SET guid = 'old-helper-guid' WHERE ROWID = 5")
+    }
+    let output = TestRPCOutput()
+    var publications = 0
+    let publication = PublicationSignal()
+    let server = RPCServer(
+      store: store,
+      verbose: false,
+      output: output,
+      invokeBridge: { action, _ in
+        if action == surface.publication {
+          publications += 1
+          publication.publish()
+        }
+        return surface.bridgeResponse(for: action, messageGUID: "old-helper-guid")
+      },
+      stageAttachment: { _ in "/staged/photo.jpg" }
+    )
+
+    await handleAndCancelVerification(
+      server,
+      request: surface.request(),
+      publication: publication
+    )
+
+    #expect(publications == 1, "\(surface)")
+    try assertUnknownDelivery(output, operation: surface.publication.rawValue)
+  }
+}
+
+@Test
+func rpcStrictSendRejectsNewHelperGUIDInWrongChat() async throws {
+  for surface in StrictSendSurface.allCases {
+    let store = try makeGUIDVerificationStore()
+    try addOtherChat(to: store)
+    let output = TestRPCOutput()
+    var publications = 0
+    let publication = PublicationSignal()
+    let server = RPCServer(
+      store: store,
+      verbose: false,
+      output: output,
+      invokeBridge: { action, _ in
+        if action == surface.publication {
+          publications += 1
+          publication.publish()
+          try insertOutgoing(into: store, chatID: 2, guid: "wrong-chat-guid")
+        }
+        return surface.bridgeResponse(for: action, messageGUID: "wrong-chat-guid")
+      },
+      stageAttachment: { _ in "/staged/photo.jpg" }
+    )
+
+    await handleAndCancelVerification(
+      server,
+      request: surface.request(),
+      publication: publication
+    )
+
+    #expect(publications == 1, "\(surface)")
+    try assertUnknownDelivery(output, operation: surface.publication.rawValue)
+  }
+}
+
+@Test
+func rpcStrictSendMapsPostPublicationDatabaseErrorsToUnknownDelivery() async throws {
+  let store = try makeGUIDVerificationStore()
+  let output = TestRPCOutput()
+  var publications = 0
+  let server = RPCServer(
+    store: store,
+    verbose: false,
+    output: output,
+    invokeBridge: { action, _ in
+      if action == .sendMultipart {
+        publications += 1
+        _ = try store.withConnection { db in try db.run("DROP TABLE message") }
+      }
+      return ["messageGuid": "new-helper-guid"]
+    }
+  )
+
+  await server.handleLineForTesting(StrictSendSurface.multipart.request())
+
+  #expect(publications == 1)
+  try assertUnknownDelivery(output, operation: BridgeAction.sendMultipart.rawValue)
+}
+
+@Test
+func rpcStrictSendNotificationsRemainSilentAndPublishOnce() async throws {
+  for surface in StrictSendSurface.allCases {
+    let store = try makeGUIDVerificationStore()
+    let output = TestRPCOutput()
+    var publications = 0
+    let server = RPCServer(
+      store: store,
+      verbose: false,
+      output: output,
+      invokeBridge: { action, _ in
+        if action == surface.publication { publications += 1 }
+        return surface.bridgeResponse(for: action, messageGUID: "")
+      },
+      stageAttachment: { _ in "/staged/photo.jpg" }
+    )
+
+    await server.handleLineForTesting(surface.request(id: false))
+
+    #expect(publications == 1, "\(surface)")
+    #expect(output.outputs.isEmpty, "\(surface)")
+  }
 }
 
 @Test
@@ -140,200 +395,10 @@ func rpcSendRichFileRejectsMissingAttachmentCapabilityBeforeStaging() async thro
     }
   )
 
-  await server.handleLineForTesting(
-    #"{"jsonrpc":"2.0","id":"rich-file","method":"send.rich","params":{"chat_id":1,"file":"photo.jpg"}}"#
-  )
+  await server.handleLineForTesting(StrictSendSurface.richFile.request())
 
   #expect(actions == [.status])
   #expect(stageCalls == 0)
   #expect(output.responses.isEmpty)
   #expect((output.errors.first?["error"] as? [String: Any])?["code"] as? Int == -32603)
-}
-
-@Test
-func rpcSendMultipartValidatesTextPartsAndNormalizesResponse() async throws {
-  let store = try CommandTestDatabase.makeStoreForRPC()
-  let output = TestRPCOutput()
-  var action: BridgeAction?
-  var bridgeParams: [String: Any] = [:]
-  let server = RPCServer(
-    store: store,
-    verbose: false,
-    output: output,
-    resolveSentMessage: { _, options, chatID, _ in
-      #expect(options.text == "hello world")
-      #expect(chatID == 1)
-      return Message(
-        rowID: 99,
-        chatID: 1,
-        sender: "",
-        text: options.text,
-        date: Date(),
-        isFromMe: true,
-        service: "iMessage",
-        handleID: nil,
-        attachmentsCount: 0,
-        guid: "multipart-resolved-guid"
-      )
-    },
-    invokeBridge: { sentAction, params in
-      action = sentAction
-      bridgeParams = params
-      return [
-        "chatGuid": "iMessage;+;chat123",
-        "messageGuid": "multipart-bridge-guid",
-        "parts_count": 2,
-      ]
-    }
-  )
-
-  let request =
-    #"{"jsonrpc":"2.0","id":"multipart","method":"send.multipart","params":{"#
-    + #""chat_id":1,"parts":[{"text":"hello ","text_formatting":[{"start":0,"#
-    + #""length":5,"styles":["bold"]}]},{"text":"world"}],"effect":"confetti","#
-    + #""subject":"Greeting"}}"#
-  await server.handleLineForTesting(request)
-
-  #expect(action == .sendMultipart)
-  #expect(bridgeParams["effectId"] as? String == "com.apple.messages.effect.CKConfettiEffect")
-  #expect(bridgeParams["subject"] as? String == "Greeting")
-  let parts = try #require(bridgeParams["parts"] as? [[String: Any]])
-  #expect(parts.map { $0["text"] as? String } == ["hello ", "world"])
-  #expect((parts.first?["textFormatting"] as? [[String: Any]])?.count == 1)
-  let result = try #require(output.responses.first?["result"] as? [String: Any])
-  #expect(result["ok"] as? Bool == true)
-  #expect((result["id"] as? NSNumber)?.int64Value == 99)
-  #expect(result["guid"] as? String == "multipart-resolved-guid")
-  #expect(result["message_id"] as? String == "multipart-resolved-guid")
-  #expect(result["chat_guid"] as? String == "iMessage;+;chat123")
-  #expect(result["parts_count"] as? Int == 2)
-}
-
-@Test
-func rpcSendMultipartRejectsUnobservedDeliveryWithoutRetry() async throws {
-  let store = try CommandTestDatabase.makeStoreForRPC()
-  let output = TestRPCOutput()
-  var bridgeCalls = 0
-  let server = RPCServer(
-    store: store,
-    verbose: false,
-    output: output,
-    resolveSentMessage: { _, _, _, _ in nil },
-    invokeBridge: { action, _ in
-      #expect(action == .sendMultipart)
-      bridgeCalls += 1
-      return ["messageGuid": "unobserved-guid"]
-    },
-    isBridgeReady: { true }
-  )
-
-  await server.handleLineForTesting(
-    #"{"jsonrpc":"2.0","id":"multipart","method":"send.multipart","params":{"chat_id":1,"parts":[{"text":"unique nonce"}]}}"#
-  )
-
-  #expect(bridgeCalls == 1)
-  #expect(output.responses.isEmpty)
-  let error = try #require(output.errors.first?["error"] as? [String: Any])
-  let data = try #require(error["data"] as? [String: Any])
-  #expect(error["code"] as? Int == -32001)
-  #expect(data["disposition"] as? String == "may_have_completed")
-  #expect(data["transport"] as? String == "bridge_v2")
-  #expect(data["operation"] as? String == "send-multipart")
-  #expect(data["retry_safe"] as? Bool == false)
-}
-
-@Test
-func rpcSendRichFileMapsResolverErrorWithoutRetry() async throws {
-  let store = try CommandTestDatabase.makeStoreForRPC()
-  let output = TestRPCOutput()
-  var actions: [BridgeAction] = []
-  let server = RPCServer(
-    store: store,
-    verbose: false,
-    output: output,
-    resolveSentMessage: { _, _, _, _ in throw SendVerificationTestError() },
-    invokeBridge: { action, _ in
-      actions.append(action)
-      if action == .status {
-        return [
-          "attachment_metadata": true,
-          "selectors": ["sendAttachment": true] as [String: Any],
-        ]
-      }
-      return ["messageGuid": "unobserved-guid"]
-    },
-    stageAttachment: { _ in "/staged/photo.jpg" }
-  )
-
-  await server.handleLineForTesting(
-    #"{"jsonrpc":"2.0","id":"rich-file","method":"send.rich","params":{"chat_id":1,"file":"photo.jpg","text":"unique caption"}}"#
-  )
-
-  #expect(actions == [.status, .sendAttachment])
-  #expect(output.responses.isEmpty)
-  let error = try #require(output.errors.first?["error"] as? [String: Any])
-  let data = try #require(error["data"] as? [String: Any])
-  #expect(error["code"] as? Int == -32001)
-  #expect(data["disposition"] as? String == "may_have_completed")
-  #expect(data["transport"] as? String == "bridge_v2")
-  #expect(data["operation"] as? String == "send-attachment")
-}
-
-@Test
-func rpcSendMultipartRejectsSuccessWhenDatabaseUnavailable() async throws {
-  let output = TestRPCOutput()
-  var bridgeCalls = 0
-  let server = RPCServer(
-    databasePath: "/unavailable/chat.db",
-    verbose: false,
-    output: output,
-    storeFactory: { _ in throw SendVerificationTestError() },
-    invokeBridge: { action, _ in
-      #expect(action == .sendMultipart)
-      bridgeCalls += 1
-      return ["messageGuid": "unobserved-guid"]
-    },
-    isBridgeReady: { true }
-  )
-
-  let request =
-    #"{"jsonrpc":"2.0","id":"multipart","method":"send.multipart","params":{"#
-    + #""chat_guid":"iMessage;+;chat123","parts":[{"text":"unique nonce"}]}}"#
-  await server.handleLineForTesting(
-    request
-  )
-
-  #expect(bridgeCalls == 1)
-  #expect(output.responses.isEmpty)
-  let error = try #require(output.errors.first?["error"] as? [String: Any])
-  let data = try #require(error["data"] as? [String: Any])
-  #expect(error["code"] as? Int == -32001)
-  #expect(data["disposition"] as? String == "may_have_completed")
-  #expect(data["transport"] as? String == "bridge_v2")
-  #expect(data["operation"] as? String == "send-multipart")
-}
-
-@Test
-func rpcUnobservedSendNotificationRemainsSilent() async throws {
-  let store = try CommandTestDatabase.makeStoreForRPC()
-  let output = TestRPCOutput()
-  var bridgeCalls = 0
-  let server = RPCServer(
-    store: store,
-    verbose: false,
-    output: output,
-    resolveSentMessage: { _, _, _, _ in nil },
-    invokeBridge: { action, _ in
-      #expect(action == .sendMultipart)
-      bridgeCalls += 1
-      return ["messageGuid": "unobserved-guid"]
-    }
-  )
-
-  await server.handleLineForTesting(
-    #"{"jsonrpc":"2.0","method":"send.multipart","params":{"chat_id":1,"parts":[{"text":"unique nonce"}]}}"#
-  )
-
-  #expect(bridgeCalls == 1)
-  #expect(output.outputs.isEmpty)
 }

--- a/Tests/imsgTests/RPCServerSendFallbackTests.swift
+++ b/Tests/imsgTests/RPCServerSendFallbackTests.swift
@@ -27,6 +27,31 @@ func rpcSendEnablesSMSFallbackForAutoTextDirectSend() async throws {
 }
 
 @Test
+func rpcSendCanDisableOtherwiseEligibleSMSFallbackWithoutChangingAutoService() async throws {
+  for key in ["allow_sms_fallback", "allowSMSFallback"] {
+    let store = try CommandTestDatabase.makeStoreForRPC()
+    let output = TestRPCOutput()
+    var captured: MessageSendOptions?
+    let server = RPCServer(
+      store: store,
+      verbose: false,
+      output: output,
+      sendMessage: { captured = $0 },
+      resolveSentMessage: resolvedSentMessageFixture
+    )
+
+    await server.handleLineForTesting(
+      "{\"jsonrpc\":\"2.0\",\"id\":\"no-fallback\",\"method\":\"send\","
+        + "\"params\":{\"to\":\"+15551234567\",\"text\":\"yo\",\"\(key)\":false}}"
+    )
+
+    #expect(captured?.service == .auto)
+    #expect(captured?.allowSMSFallback == false)
+    #expect(output.errors.isEmpty)
+  }
+}
+
+@Test
 func rpcSendAutoUsesLocalSMSHistoryForAttachmentSend() async throws {
   let store = try CommandTestDatabase.makeStoreForRPC()
   try store.withConnection { db in

--- a/Tests/imsgTests/RPCServerTests.swift
+++ b/Tests/imsgTests/RPCServerTests.swift
@@ -27,7 +27,15 @@ func rpcChatsListReturnsChatPayload() async throws {
   let chats = result?["chats"] as? [[String: Any]] ?? []
   #expect(chats.count == 1)
   let chat = chats[0]
+  #expect(
+    Set(chat.keys) == [
+      "id", "name", "identifier", "service", "last_message_at", "guid", "display_name",
+      "is_group", "participants", "account_id", "account_login", "last_addressed_handle",
+    ])
   #expect(int64Value(chat["id"]) == 1)
+  #expect(chat["name"] as? String == "Group Chat")
+  #expect(chat["display_name"] as? String == "Group Chat")
+  #expect(chat["guid"] as? String == "iMessage;+;chat123")
   #expect(chat["identifier"] as? String == "iMessage;+;chat123")
   #expect(chat["is_group"] as? Bool == true)
   #expect(chat["contact_name"] == nil)

--- a/Tests/imsgTests/RPCStatusCapabilityTests.swift
+++ b/Tests/imsgTests/RPCStatusCapabilityTests.swift
@@ -68,6 +68,7 @@ func rpcStatusCalculatesDynamicMethodsAcrossResourceStates() async throws {
   #expect(bridgeOnlyMethods.contains("group.rename"))
   #expect(bridgeOnlyMethods.contains("poll.send"))
   #expect(!bridgeOnlyMethods.contains("chats.list"))
+  #expect(!bridgeOnlyMethods.contains("send.multipart"))
   #expect(!bridgeOnlyMethods.contains("send.sticker"))
   #expect(!bridgeOnlyMethods.contains("poll.vote"))
 

--- a/Tests/imsgTests/RPCStatusCapabilityTests.swift
+++ b/Tests/imsgTests/RPCStatusCapabilityTests.swift
@@ -21,7 +21,7 @@ func rpcStatusCalculatesDynamicMethodsAcrossResourceStates() async throws {
   let bothMethods = rpcStatusMethods(both)
   #expect(
     bothMethods.isSuperset(of: [
-      "chats.list", "send.sticker", "poll.send", "poll.vote",
+      "chats.list", "messages.search", "send.multipart", "send.sticker", "poll.send", "poll.vote",
       "typing", "read", "message.edit", "message.unsend", "group.rename",
     ]))
   let readyBridge = try #require(both["bridge"] as? [String: Any])
@@ -74,6 +74,7 @@ func rpcStatusCalculatesDynamicMethodsAcrossResourceStates() async throws {
   var limitedSelectors = fullRPCStatusBridgeSelectors()
   limitedSelectors["stickerSend"] = false
   limitedSelectors["editMessageItem"] = false
+  limitedSelectors["sendMultipart"] = false
   let limitedOutput = TestRPCOutput()
   let limitedServer = RPCServer(
     store: store,
@@ -89,6 +90,7 @@ func rpcStatusCalculatesDynamicMethodsAcrossResourceStates() async throws {
   let limitedMethods = rpcStatusMethods(try rpcStatusResult(limitedOutput))
   #expect(!limitedMethods.contains("send.sticker"))
   #expect(!limitedMethods.contains("message.edit"))
+  #expect(!limitedMethods.contains("send.multipart"))
   #expect(limitedMethods.contains("poll.send"))
 
   let ignoredAllowlistOutput = TestRPCOutput()

--- a/Tests/imsgTests/RPCStatusTestSupport.swift
+++ b/Tests/imsgTests/RPCStatusTestSupport.swift
@@ -38,6 +38,7 @@ func fullRPCStatusBridgeSelectors() -> [String: Bool] {
   [
     "sendMessage": true,
     "sendAttachment": true,
+    "sendMultipart": true,
     "sendReaction": true,
     "stickerSend": true,
     "pollPayloadMessage": true,

--- a/Tests/imsgTests/RPCStatusTests.swift
+++ b/Tests/imsgTests/RPCStatusTests.swift
@@ -327,6 +327,15 @@ func rpcInitializeAndStatusUseControlAndReadSchedulerLanes() {
   #expect(kSupportedRPCMethods.prefix(3) == ["initialize", "status", "watch.unsubscribe"])
 }
 
+@Test
+func everyRPCMethodDescriptorNameIsDispatchable() {
+  for descriptor in rpcMethodDescriptors {
+    for name in descriptor.names {
+      #expect(rpcDispatchRoutes[name] == descriptor.route)
+    }
+  }
+}
+
 @Test(.timeLimit(.minutes(1)))
 func rpcDegradedStartupWritesOnlyJSONLinesToStdout() async throws {
   let server = RPCServer(

--- a/docs/attachments.md
+++ b/docs/attachments.md
@@ -12,7 +12,11 @@ imsg history --chat-id 42 --attachments --json
 imsg watch   --chat-id 42 --attachments --json
 ```
 
-Each message gains an `attachments` array. Per-attachment fields:
+Every message JSON object contains an `attachments` array. CLI `history` and
+`watch` JSON preserve their historical behavior of populating attachment
+metadata even without `--attachments`; that flag controls human-readable
+display. RPC read methods populate the array only when their documented
+`attachments` flag is true. Otherwise it is empty. Per-attachment fields:
 
 | Field | Type | Notes |
 |-------|------|-------|
@@ -20,14 +24,14 @@ Each message gains an `attachments` array. Per-attachment fields:
 | `transfer_name` | string | Original filename as sent. |
 | `uti` | string | Apple Uniform Type Identifier. |
 | `mime_type` | string | Best-effort MIME from UTI. |
-| `byte_size` | int | Size in bytes. |
+| `total_bytes` | int | Size in bytes. |
 | `is_sticker` | bool | True for sticker-pack attachments. |
 | `missing` | bool | True when the file couldn't be located on disk. |
-| `path` | string | Resolved absolute path under `~/Library/Messages/Attachments/`. |
+| `original_path` | string | Resolved absolute path under `~/Library/Messages/Attachments/`. |
 | `converted_path` | string | Set only with `--convert-attachments`; see below. |
 | `converted_mime_type` | string | Set only with `--convert-attachments`. |
 
-When an attachment is referenced in `chat.db` but the underlying file has been pruned (Messages can age out big files), `missing` is `true` and `path` may be empty.
+When an attachment is referenced in `chat.db` but the underlying file has been pruned (Messages can age out big files), `missing` is `true` and `original_path` may be empty.
 
 ## Converted variants
 

--- a/docs/json.md
+++ b/docs/json.md
@@ -36,7 +36,8 @@ Returned by `imsg chats --json` and JSON-RPC `chats.list`.
 
 ## Message
 
-Returned by `imsg history`, `imsg search`, `imsg watch`, and the JSON-RPC `messages.history` and `watch.subscribe` notifications.
+Returned by `imsg history`, `imsg search`, `imsg watch`, and the JSON-RPC
+`messages.history`, `messages.search`, and `watch.subscribe` surfaces.
 
 | Field | Type | Notes |
 |-------|------|-------|
@@ -57,7 +58,7 @@ Returned by `imsg history`, `imsg search`, `imsg watch`, and the JSON-RPC `messa
 | `is_from_me` | bool | True for outbound. |
 | `text` | string | Plain text. Recovered from `attributedBody` when `text` column is empty. |
 | `created_at` | ISO8601 | Message timestamp. |
-| `attachments` | array | Present when `--attachments` is set. See below. |
+| `attachments` | array | Always present. CLI history/watch JSON keeps its historical populated metadata; RPC read methods populate it only when their `attachments` flag is true. See below. |
 | `thread_originator_guid` | string | For inline-reply threads. |
 | `poll` | object | Present for native Apple Messages Polls creation and vote rows. See below. |
 | `is_read` | bool | Inbound only — omitted when `is_from_me` is true. |
@@ -108,7 +109,7 @@ Returned by `imsg chat-background status --chat-id <id> --json`. This surface is
 
 ### URL preview coalescing
 
-Messages may store a link send as two rows: the user's text row and a later `com.apple.messages.URLBalloonProvider` preview row. `history`, `search`, `watch`, `messages.history`, and `watch.subscribe` coalesce those rows into one logical message when the preview immediately follows a same-chat/same-sender text row containing the preview URL. In batch reads the coalesced message includes:
+Messages may store a link send as two rows: the user's text row and a later `com.apple.messages.URLBalloonProvider` preview row. `history`, `search`, `watch`, `messages.history`, `messages.search`, and `watch.subscribe` coalesce those rows into one logical message when the preview immediately follows a same-chat/same-sender text row containing the preview URL. In batch reads the coalesced message includes:
 
 | Field | Type | Notes |
 |-------|------|-------|
@@ -183,10 +184,10 @@ Inside the `attachments` array on a message:
 | `transfer_name` | string | Original filename as sent. |
 | `uti` | string | Apple UTI. |
 | `mime_type` | string | Best-effort MIME. |
-| `byte_size` | int | Size in bytes. |
+| `total_bytes` | int | Size in bytes. |
 | `is_sticker` | bool | Sticker-pack attachments. |
 | `missing` | bool | Underlying file not on disk. |
-| `path` | string | Resolved absolute path. |
+| `original_path` | string | Resolved absolute path. |
 | `converted_path` | string | Present with `--convert-attachments`. |
 | `converted_mime_type` | string | Present with `--convert-attachments`. |
 
@@ -210,7 +211,7 @@ See [Statistics](stats.md) for filtering, ordering, and timezone behavior.
 
 ## Conventions
 
-- Every numeric field is a JSON number. `id`, `chat_id`, and `byte_size` are integers; nothing requires 64-bit JSON-string encoding.
+- Every numeric field is a JSON number. `id`, `chat_id`, and `total_bytes` are integers; nothing requires 64-bit JSON-string encoding.
 - Times are ISO 8601 with explicit timezone (typically `Z`).
 - Strings that aren't applicable are omitted, not set to `null`. Test with `field in obj`, not `obj.field === null`.
 - Booleans are explicit `true` / `false`, never 0/1.

--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -30,7 +30,8 @@ Supported compatibility aliases are explicit and method-specific:
 - `chats.list`: `unreadOnly` for `unread_only`.
 - `watch.subscribe`: `debounceMs` for `debounce_ms`.
 - `send`: `textFormatting` or `formatting` for `text_formatting`; `replyTo`,
-  `reply_to_guid`, or `message_guid` for `reply_to`.
+  `reply_to_guid`, or `message_guid` for `reply_to`; and `allowSMSFallback` for
+  `allow_sms_fallback`.
 - `send.rich`: `message` for `text`; camelCase forms for `part_index`,
   `dd_scan`, `effect_id`, and `text_formatting`; `effect` for `effect_id`; and
   the same reply aliases as `send`.
@@ -41,6 +42,8 @@ Supported compatibility aliases are explicit and method-specific:
   `optionId`, `optionIdentifier`, `optionIndex`, and `suppressComment`.
 - Message mutations accept the existing `messageId`, `messageGuid`, and
   `message` target aliases, plus their documented text and part-index aliases.
+- `send.multipart`: camelCase forms for `effect_id` and per-part
+  `text_formatting`; `effect` is also accepted for `effect_id`.
 
 Other spellings, including `chatId`, are not aliases and are rejected.
 
@@ -198,7 +201,7 @@ the helper.
 
 Params:
 
-- `limit` (int, default 20)
+- `limit` (positive int, default 20)
 - `unread_only` (bool, default `false`) — when true, return only chats with `unread_count > 0`; unavailable database schemas return an invalid-params error rather than an empty list
 
 Result:
@@ -251,7 +254,7 @@ UTI/MIME and chat. Otherwise the `media` key is omitted. Invalid, non-positive, 
 Params:
 
 - `chat_id` (int, required) — preferred identifier.
-- `limit` (int, default 50)
+- `limit` (positive int, default 50)
 - `participants` (array of handle strings, optional)
 - `start` / `end` (ISO 8601, optional)
 - `attachments` (bool, default `false`)
@@ -261,6 +264,28 @@ Result:
 ```json
 { "messages": [Message] }
 ```
+
+The `attachments` array remains present on every message and is populated only
+when `attachments` is true.
+
+### `messages.search`
+
+Searches local `chat.db` through the same logical-message and JSON payload
+pipeline as `imsg search`; it never invokes the bridge.
+
+Params:
+
+- `query` (non-empty string, required)
+- `match` (`contains` | `exact`, default `contains`)
+- `limit` (positive int, default 50, maximum 100)
+
+Result:
+
+```json
+{ "messages": [Message] }
+```
+
+Search results always contain an empty `attachments` array.
 
 ### `messages.after`
 
@@ -414,6 +439,9 @@ Params (direct send):
 - `file` (string, optional)
 - `service` (`imessage` | `sms` | `auto`, optional)
 - `region` (string, optional)
+- `allow_sms_fallback` (bool, default `true`) — gates only the narrow
+  `service: auto`, direct-recipient, text-only retry described below; false
+  leaves service selection on `auto` but disables that retry
 
 Params (chat target):
 
@@ -485,8 +513,9 @@ membership or payload state—poll vote/unvote and stickers—still require the
 database even with an explicit GUID. Rich-link mode also requires a stored
 existing iMessage chat; ordinary `send.rich` text does not.
 
-- `send.rich` sends text with optional `effect`, `subject`, `reply_to`, `part_index`, `dd_scan`, and `text_formatting`. Alternatively, pass only one chat target plus an HTTP(S) `url` to send an Apple URL-preview balloon. URL mode is iMessage-only and rejects text/send modifiers; metadata or image lookup failure falls back to a metadata-only card, never a plain-message send.
+- `send.rich` sends text with optional `effect`, `subject`, `reply_to`, `part_index`, `dd_scan`, and `text_formatting`. It also accepts `file` or `path` and securely stages the file before sending it through the attachment bridge while preserving those same caption/effect/subject/reply/part/formatting semantics. Attachment capability is checked before staging or publishing the send. Alternatively, pass only one chat target plus an HTTP(S) `url` to send an Apple URL-preview balloon. URL mode is iMessage-only and rejects text, file, and other send modifiers; metadata or image lookup failure falls back to a metadata-only card, never a plain-message send.
 - `send.attachment` sends `file` or `path`, with optional `audio` / `is_audio` / `as_voice`. Pass `reply_to` (or `replyTo`, `reply_to_guid`, or `message_guid`) to reply to an existing message. An optional non-negative integer `part_index` / `partIndex` selects that message's part and is invalid without a reply target.
+- `send.multipart` sends 1–20 text parts. `parts` is a required array of objects containing a non-empty `text` string and optional `text_formatting` array. Top-level `effect` / `effect_id` and `subject` match `imsg send-multipart`. File, attachment, and mention parts are rejected before bridge dispatch.
 - `tapback` sends or removes a reaction. Params: `message_id` or `message_guid`, plus `reaction` / `kind` / `emoji`, optional `remove`.
 - `message.edit` edits `message_id` / `message_guid` with `text`.
 - `message.unsend`, `message.delete`, and `message.notifyAnyways` target `message_id` / `message_guid`.
@@ -503,7 +532,13 @@ Result:
 { "ok": true }
 ```
 
-`send.rich` and `send.attachment` return `guid` / `message_id` when the bridge reports the sent message GUID.
+`send.rich` file/path mode and `send.multipart` return success only after a
+matching outgoing row is observed in the resolved chat. Their successful
+results include numeric `id`, `guid` / `message_id`, and `chat_guid`; an
+unobserved result is reported as delivery outcome unknown (`-32001`) and must
+not be retried automatically. Existing `send.rich` text/URL mode and
+`send.attachment` return `guid` / `message_id` and `chat_guid` when available.
+`send.multipart` additionally returns `parts_count`.
 
 ### `handles.check`
 
@@ -531,7 +566,7 @@ Result:
 
 ### Native polls
 
-`poll.send` creates a native Apple Messages Polls extension balloon through the IMCore bridge. The bridge must be injected with `imsg launch`; the AppleScript transport cannot send native extension payloads. Messages does not render the poll payload title on the balloon, so `poll.send` also sends a best-effort plain caption message right after the poll. The caption defaults to `question`; pass `comment` when the visible caption should differ from the stored poll question, or set `suppress_comment` to `true` when the caller already sent its own visible context and needs only the poll balloon. The camelCase alias `suppressComment` is also accepted.
+`poll.send` creates a native Apple Messages Polls extension balloon through the IMCore bridge. The bridge must be injected with `imsg launch`; the AppleScript transport cannot send native extension payloads. Messages does not render the poll payload title on the balloon, so `poll.send` also sends a best-effort plain caption message right after the poll. The caption defaults to `question`; pass `comment` when the visible caption should differ from the stored poll question, or set `suppress_comment` to `true` when the caller already sent its own visible context and needs only the poll balloon. `comment` and `suppress_comment: true` are mutually exclusive. The camelCase alias `suppressComment` is also accepted.
 
 Request:
 

--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -510,7 +510,8 @@ selectors is invalid and no bridge operation is attempted.
 An explicit `chat_guid` or `chat_identifier` does not require `chat.db` merely
 to reach the bridge. `chat_id` always does. Operations that validate local
 membership or payload state—poll vote/unvote and stickers—still require the
-database even with an explicit GUID. Rich-link mode also requires a stored
+database even with an explicit GUID. Strictly verified `send.rich` file/path
+mode and `send.multipart` also require it. Rich-link mode requires a stored
 existing iMessage chat; ordinary `send.rich` text does not.
 
 - `send.rich` sends text with optional `effect`, `subject`, `reply_to`, `part_index`, `dd_scan`, and `text_formatting`. It also accepts `file` or `path` and securely stages the file before sending it through the attachment bridge while preserving those same caption/effect/subject/reply/part/formatting semantics. Attachment capability is checked before staging or publishing the send. Alternatively, pass only one chat target plus an HTTP(S) `url` to send an Apple URL-preview balloon. URL mode is iMessage-only and rejects text, file, and other send modifiers; metadata or image lookup failure falls back to a metadata-only card, never a plain-message send.


### PR DESCRIPTION
## What Problem This Solves

The RPC surface had drifted from the canonical CLI message contract. Chat payloads were assembled separately, database search was unavailable over RPC, rich sends did not accept the CLI file/path form, multipart text sends were absent, method metadata and dispatch could diverge, and several semantic validations were weaker than their documented contracts.

More importantly, newly exposed rich-file and multipart sends could appear successful when the bridge helper acknowledged publication but no outgoing message row was observable. That false acknowledgement is unsafe because callers may treat the send as complete.

## Why This Change Was Made

This change makes the CLI payload models and one descriptor-owned registry authoritative across method discovery, capability reporting, request lanes, and dispatch. It adds bounded database-backed message search, text-only multipart sends, rich file/path parity, positive limit and poll validation, the narrow `allow_sms_fallback` control, and stable attachment field documentation.

Rich-file and multipart sends now cross a stricter post-publication boundary: success requires observing the matching outgoing database row. If publication may have occurred but the row cannot be observed, the RPC returns typed `-32001` delivery-outcome-unknown data with `may_have_completed`, never `ok`. Callers must not automatically retry that result.

The production delta is approximately +653/-245 lines, with +537/-15 lines of tests and +56/-16 lines of documentation. The growth is additive public protocol capability plus explicit ownership of delivery-safety verification.

## User Impact

RPC clients can use `messages.search`, text-only `send.multipart`, rich `file`/`path` sends, and `allow_sms_fallback`. Chat objects now share the CLI's canonical payload owner, method support and dispatch are derived from the same descriptors, positive bounds are enforced consistently, and attachment keys are documented as `total_bytes` and `original_path`.

For new rich-file and multipart sends, an unobserved post-publication result is deliberately surfaced as uncertain rather than successful. This may expose previously hidden delivery uncertainty, but prevents false success and unsafe retries.

## Evidence

- Full macOS test suite: 623 passed.
- `make lint`: green, with only prior nonfatal warnings.
- Universal build: green.
- Linux tests and build: green.
- Diff/whitespace check: clean.
- Final structured autoreview: clean, 0.97.
- Live read-only validation: supported methods include search, multipart, and rich sends; multipart is currently usable; bounded zero-result search works; CLI and RPC first-chat keysets match at 13 keys each; RPC framing is clean.
- Live mutation validation made exactly one multipart request and one rich-file request. Each helper returned success, but neither produced an observable outgoing database row. Neither request was retried. These attempts do not prove successful delivery; they exposed the false acknowledgement that the strict observation requirement now prevents.
- Post-recovery production topology was restored and is healthy: the retired gateway is disabled, the obsolete RPC count is zero, one current production-owned RPC and one Messages process remain, and v2 reports ready.
- Regression coverage includes observed, nil, error, unavailable-database, notification, empty-caption, and single-publication outcomes. It proves uncertain rich-file/multipart publication returns typed `-32001` with `may_have_completed` and never `ok`.

Required CI gates are `macos` on the `macos-26` runner and `linux-read-core`.
