### PR TITLE
feat(rpc): add bounded bridge event subscriptions

### DIFF
--- a/Sources/IMsgCore/IMsgEventTailer.swift
+++ b/Sources/IMsgCore/IMsgEventTailer.swift
@@ -9,6 +9,7 @@ public struct IMsgEventTailerOverflowError: Error, Sendable, Equatable {}
 public enum IMsgEventTailerError: Error, Sendable, Equatable, LocalizedError {
   case invalidBufferLimit(Int)
   case alreadyStarted
+  case createFailed(path: String, errno: Int32)
   case openFailed(path: String, errno: Int32)
   case readFailed(path: String, errno: Int32)
   case unsupportedPlatform
@@ -19,6 +20,8 @@ public enum IMsgEventTailerError: Error, Sendable, Equatable, LocalizedError {
       return "Event buffer limit \(limit) is outside the supported range 1...4096."
     case .alreadyStarted:
       return "This bridge event tailer has already started."
+    case .createFailed(let path, let code):
+      return "Could not create private bridge event log at \(path) (errno \(code))."
     case .openFailed(let path, let code):
       return "Could not open bridge event log at \(path) (errno \(code))."
     case .readFailed(let path, let code):
@@ -56,6 +59,7 @@ public final class IMsgEventTailer: @unchecked Sendable {
 
   private let path: String
   private let replayExisting: Bool
+  private let createIfMissing: Bool
   private let bufferLimit: Int
   private let didStart: (@Sendable () -> Void)?
   private let didStop: @Sendable () -> Void
@@ -82,9 +86,18 @@ public final class IMsgEventTailer: @unchecked Sendable {
   #endif
 
   public convenience init(path: String, replayExisting: Bool = false) {
+    self.init(path: path, replayExisting: replayExisting, createIfMissing: true)
+  }
+
+  public convenience init(
+    path: String,
+    replayExisting: Bool = false,
+    createIfMissing: Bool
+  ) {
     self.init(
       uncheckedPath: path,
       replayExisting: replayExisting,
+      createIfMissing: createIfMissing,
       bufferLimit: 256,
       didStart: nil,
       didStop: {}
@@ -94,7 +107,8 @@ public final class IMsgEventTailer: @unchecked Sendable {
   public convenience init(
     path: String,
     replayExisting: Bool = false,
-    bufferLimit: Int
+    bufferLimit: Int,
+    createIfMissing: Bool = false
   ) throws {
     guard (1...4096).contains(bufferLimit) else {
       throw IMsgEventTailerError.invalidBufferLimit(bufferLimit)
@@ -102,6 +116,7 @@ public final class IMsgEventTailer: @unchecked Sendable {
     self.init(
       uncheckedPath: path,
       replayExisting: replayExisting,
+      createIfMissing: createIfMissing,
       bufferLimit: bufferLimit,
       didStart: nil,
       didStop: {})
@@ -110,12 +125,14 @@ public final class IMsgEventTailer: @unchecked Sendable {
   private init(
     uncheckedPath path: String,
     replayExisting: Bool,
+    createIfMissing: Bool,
     bufferLimit: Int,
     didStart: (@Sendable () -> Void)?,
     didStop: @escaping @Sendable () -> Void
   ) {
     self.path = path
     self.replayExisting = replayExisting
+    self.createIfMissing = createIfMissing
     self.bufferLimit = bufferLimit
     self.didStart = didStart
     self.didStop = didStop
@@ -176,6 +193,7 @@ public final class IMsgEventTailer: @unchecked Sendable {
   #if os(macOS)
     private func startMacOS() {
       do {
+        try createInitialFileIfNeeded()
         try installDirectorySource()
         try openInitialFile()
         guard !stopped else { return }
@@ -183,27 +201,6 @@ public final class IMsgEventTailer: @unchecked Sendable {
       } catch {
         finish(throwing: error)
       }
-    }
-
-    private func installDirectorySource() throws {
-      let directory = URL(fileURLWithPath: path).deletingLastPathComponent().path
-      let fd = open(directory, O_EVTONLY | O_CLOEXEC)
-      guard fd >= 0 else {
-        throw IMsgEventTailerError.openFailed(path: directory, errno: errno)
-      }
-      let source = DispatchSource.makeFileSystemObjectSource(
-        fileDescriptor: fd,
-        eventMask: [.write, .rename, .delete],
-        queue: queue
-      )
-      source.setEventHandler { [weak self] in
-        self?.reconcileCurrentPath()
-      }
-      source.setCancelHandler {
-        close(fd)
-      }
-      source.resume()
-      directorySource = source
     }
 
     private func openInitialFile() throws {
@@ -354,11 +351,64 @@ public final class IMsgEventTailer: @unchecked Sendable {
   #endif
 }
 
+#if os(macOS)
+  extension IMsgEventTailer {
+    fileprivate func createInitialFileIfNeeded() throws {
+      guard createIfMissing else { return }
+      let fd = open(
+        path,
+        O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC | O_NOFOLLOW,
+        0o600
+      )
+      guard fd >= 0 else {
+        // The helper may have won the creation race. The normal secure open
+        // below validates whatever now owns the path.
+        if errno == EEXIST { return }
+        throw IMsgEventTailerError.createFailed(path: path, errno: errno)
+      }
+      defer { close(fd) }
+
+      var info = stat()
+      guard fstat(fd, &info) == 0 else {
+        throw IMsgEventTailerError.createFailed(path: path, errno: errno)
+      }
+      guard (info.st_mode & S_IFMT) == S_IFREG else {
+        throw IMsgEventTailerError.createFailed(path: path, errno: EINVAL)
+      }
+      guard fchmod(fd, 0o600) == 0 else {
+        throw IMsgEventTailerError.createFailed(path: path, errno: errno)
+      }
+    }
+
+    fileprivate func installDirectorySource() throws {
+      let directory = URL(fileURLWithPath: path).deletingLastPathComponent().path
+      let fd = open(directory, O_EVTONLY | O_CLOEXEC)
+      guard fd >= 0 else {
+        throw IMsgEventTailerError.openFailed(path: directory, errno: errno)
+      }
+      let source = DispatchSource.makeFileSystemObjectSource(
+        fileDescriptor: fd,
+        eventMask: [.write, .rename, .delete],
+        queue: queue
+      )
+      source.setEventHandler { [weak self] in
+        self?.reconcileCurrentPath()
+      }
+      source.setCancelHandler {
+        close(fd)
+      }
+      source.resume()
+      directorySource = source
+    }
+  }
+#endif
+
 extension IMsgEventTailer {
   convenience init(
     path: String,
     replayExisting: Bool = false,
     bufferLimit: Int = 256,
+    createIfMissing: Bool = false,
     didStart: (@Sendable () -> Void)? = nil,
     didStop: @escaping @Sendable () -> Void
   ) throws {
@@ -368,6 +418,7 @@ extension IMsgEventTailer {
     self.init(
       uncheckedPath: path,
       replayExisting: replayExisting,
+      createIfMissing: createIfMissing,
       bufferLimit: bufferLimit,
       didStart: didStart,
       didStop: didStop

--- a/Sources/IMsgCore/IMsgEventTailer.swift
+++ b/Sources/IMsgCore/IMsgEventTailer.swift
@@ -216,7 +216,7 @@ public final class IMsgEventTailer: @unchecked Sendable {
     }
 
     private func makeFileRegistration() throws -> FileRegistration {
-      let fd = open(path, O_RDONLY | O_CLOEXEC | O_NOFOLLOW)
+      let fd = open(path, O_RDONLY | O_NONBLOCK | O_CLOEXEC | O_NOFOLLOW)
       guard fd >= 0 else {
         throw IMsgEventTailerError.openFailed(path: path, errno: errno)
       }
@@ -225,6 +225,10 @@ public final class IMsgEventTailer: @unchecked Sendable {
         let code = errno
         close(fd)
         throw IMsgEventTailerError.openFailed(path: path, errno: code)
+      }
+      guard (info.st_mode & S_IFMT) == S_IFREG else {
+        close(fd)
+        throw IMsgEventTailerError.openFailed(path: path, errno: EINVAL)
       }
       let identity = FileIdentity(device: UInt64(info.st_dev), inode: UInt64(info.st_ino))
       let source = DispatchSource.makeFileSystemObjectSource(

--- a/Sources/IMsgCore/IMsgEventTailer.swift
+++ b/Sources/IMsgCore/IMsgEventTailer.swift
@@ -4,19 +4,37 @@ import Foundation
   import Darwin
 #endif
 
-/// Live tailer for `.imsg-events.jsonl` written by the injected dylib.
+public struct IMsgEventTailerOverflowError: Error, Sendable, Equatable {}
+
+public enum IMsgEventTailerError: Error, Sendable, Equatable, LocalizedError {
+  case invalidBufferLimit(Int)
+  case alreadyStarted
+  case openFailed(path: String, errno: Int32)
+  case readFailed(path: String, errno: Int32)
+  case unsupportedPlatform
+
+  public var errorDescription: String? {
+    switch self {
+    case .invalidBufferLimit(let limit):
+      return "Event buffer limit \(limit) is outside the supported range 1...4096."
+    case .alreadyStarted:
+      return "This bridge event tailer has already started."
+    case .openFailed(let path, let code):
+      return "Could not open bridge event log at \(path) (errno \(code))."
+    case .readFailed(let path, let code):
+      return "Could not read bridge event log at \(path) (errno \(code))."
+    case .unsupportedPlatform:
+      return "Bridge events are only available on macOS."
+    }
+  }
+}
+
+/// Live, bounded tailer for `.imsg-events.jsonl` written by the injected helper.
 ///
-/// Uses `DispatchSource.makeFileSystemObjectSource` watching `.write`,
-/// `.extend`, and `.rename`. On rename (file rotation by the dylib at 1 MiB)
-/// the source closes and reopens. Each newly-written full line is decoded as
-/// a JSON object and surfaced via the `events` AsyncStream.
-///
-/// Designed to be co-resident with `MessageWatcher` inside `imsg watch`.
+/// Initial startup begins at EOF unless replay is explicitly requested. Rotation
+/// drains the old inode and opens the replacement at offset zero, preserving
+/// per-log order without claiming ordering relative to database watch events.
 public final class IMsgEventTailer: @unchecked Sendable {
-  /// One decoded event line. `payloadJSON` is the raw JSON-encoded `data`
-  /// object (UTF-8 bytes); decode lazily on the consumer side via
-  /// `JSONSerialization` if you need typed access. Holding raw Data keeps the
-  /// type Sendable across actor boundaries under Swift 6 strict concurrency.
   public struct Event: Sendable {
     public let timestamp: String?
     public let name: String
@@ -28,148 +46,331 @@ public final class IMsgEventTailer: @unchecked Sendable {
       self.payloadJSON = payloadJSON
     }
 
-    /// Decode `payloadJSON` to a dictionary. Returns `[:]` on any error.
     public func decodedPayload() -> [String: Any] {
       guard
-        let obj = try? JSONSerialization.jsonObject(with: payloadJSON, options: [])
-          as? [String: Any]
+        let object = try? JSONSerialization.jsonObject(with: payloadJSON) as? [String: Any]
       else { return [:] }
-      return obj
+      return object
     }
   }
 
   private let path: String
   private let replayExisting: Bool
+  private let bufferLimit: Int
+  private let didStart: (@Sendable () -> Void)?
+  private let didStop: @Sendable () -> Void
+  private let queue = DispatchQueue(label: "imsg.event.tailer", qos: .userInitiated)
+  private var continuation: AsyncThrowingStream<Event, Error>.Continuation?
+  private var started = false
+  private var stopped = false
+
   #if os(macOS)
-    private var source: DispatchSourceFileSystemObject?
-    private var fd: Int32 = -1
+    private struct FileIdentity: Equatable {
+      let device: UInt64
+      let inode: UInt64
+    }
+
+    private struct FileRegistration {
+      let fd: Int32
+      let identity: FileIdentity
+      let source: DispatchSourceFileSystemObject
+    }
+
+    private var fileRegistration: FileRegistration?
+    private var directorySource: DispatchSourceFileSystemObject?
     private var pending = Data()
   #endif
-  private var continuation: AsyncStream<Event>.Continuation?
-  private let queue = DispatchQueue(label: "imsg.event.tailer")
 
-  public init(path: String, replayExisting: Bool = false) {
-    self.path = path
-    self.replayExisting = replayExisting
+  public convenience init(path: String, replayExisting: Bool = false) {
+    self.init(
+      uncheckedPath: path,
+      replayExisting: replayExisting,
+      bufferLimit: 256,
+      didStart: nil,
+      didStop: {}
+    )
   }
 
-  /// Start tailing and return an AsyncStream of decoded events. Starts at EOF
-  /// by default so `watch --bb-events` only emits live events.
-  public func events() -> AsyncStream<Event> {
-    return AsyncStream { continuation in
-      self.continuation = continuation
-      continuation.onTermination = { @Sendable _ in
-        self.stop()
-      }
-      #if os(macOS)
-        self.queue.async {
-          self.openAndStart()
+  public convenience init(
+    path: String,
+    replayExisting: Bool = false,
+    bufferLimit: Int
+  ) throws {
+    guard (1...4096).contains(bufferLimit) else {
+      throw IMsgEventTailerError.invalidBufferLimit(bufferLimit)
+    }
+    self.init(
+      uncheckedPath: path,
+      replayExisting: replayExisting,
+      bufferLimit: bufferLimit,
+      didStart: nil,
+      didStop: {})
+  }
+
+  private init(
+    uncheckedPath path: String,
+    replayExisting: Bool,
+    bufferLimit: Int,
+    didStart: (@Sendable () -> Void)?,
+    didStop: @escaping @Sendable () -> Void
+  ) {
+    self.path = path
+    self.replayExisting = replayExisting
+    self.bufferLimit = bufferLimit
+    self.didStart = didStart
+    self.didStop = didStop
+  }
+
+  /// Starts one event stream. The first event rejected by the bounded buffer
+  /// stops the file sources; accepted events drain before the overflow error.
+  public func events() -> AsyncThrowingStream<Event, Error> {
+    AsyncThrowingStream(bufferingPolicy: .bufferingOldest(bufferLimit)) { continuation in
+      queue.async {
+        guard !self.started else {
+          continuation.finish(throwing: IMsgEventTailerError.alreadyStarted)
+          return
         }
-      #endif
+        guard !self.stopped else {
+          continuation.finish()
+          return
+        }
+        self.started = true
+        self.continuation = continuation
+        continuation.onTermination = { @Sendable _ in
+          self.stop()
+        }
+        #if os(macOS)
+          self.startMacOS()
+        #else
+          self.finish(throwing: IMsgEventTailerError.unsupportedPlatform)
+        #endif
+      }
     }
   }
 
   public func stop() {
-    #if os(macOS)
-      queue.async { [weak self] in
-        guard let self else { return }
-        self.source?.cancel()
-        self.source = nil
-        if self.fd >= 0 {
-          close(self.fd)
-          self.fd = -1
-        }
-      }
-    #endif
+    queue.async {
+      self.finish()
+    }
   }
 
-  // MARK: - Private
+  private func finish(throwing error: Error? = nil) {
+    guard !stopped else { return }
+    stopped = true
+    let activeContinuation = continuation
+    continuation = nil
+    #if os(macOS)
+      fileRegistration?.source.cancel()
+      fileRegistration = nil
+      directorySource?.cancel()
+      directorySource = nil
+    #endif
+    if let error {
+      activeContinuation?.finish(throwing: error)
+    } else {
+      activeContinuation?.finish()
+    }
+    didStop()
+  }
 
   #if os(macOS)
-    private func openAndStart() {
-      if !FileManager.default.fileExists(atPath: path) {
-        // Create empty file so we can watch it. The dylib appends; missing
-        // file means injection isn't active yet — caller can retry later.
-        FileManager.default.createFile(atPath: path, contents: Data(), attributes: nil)
+    private func startMacOS() {
+      do {
+        try installDirectorySource()
+        try openInitialFile()
+        guard !stopped else { return }
+        didStart?()
+      } catch {
+        finish(throwing: error)
       }
-      let fd = open(path, O_RDONLY)
-      if fd < 0 { return }
-      self.fd = fd
-      if replayExisting {
-        drainAvailable()
-      } else {
-        lseek(fd, 0, SEEK_END)
-      }
+    }
 
-      let src = DispatchSource.makeFileSystemObjectSource(
+    private func installDirectorySource() throws {
+      let directory = URL(fileURLWithPath: path).deletingLastPathComponent().path
+      let fd = open(directory, O_EVTONLY | O_CLOEXEC)
+      guard fd >= 0 else {
+        throw IMsgEventTailerError.openFailed(path: directory, errno: errno)
+      }
+      let source = DispatchSource.makeFileSystemObjectSource(
+        fileDescriptor: fd,
+        eventMask: [.write, .rename, .delete],
+        queue: queue
+      )
+      source.setEventHandler { [weak self] in
+        self?.reconcileCurrentPath()
+      }
+      source.setCancelHandler {
+        close(fd)
+      }
+      source.resume()
+      directorySource = source
+    }
+
+    private func openInitialFile() throws {
+      let registration = try makeFileRegistration()
+      if !replayExisting, lseek(registration.fd, 0, SEEK_END) < 0 {
+        let code = errno
+        registration.source.cancel()
+        throw IMsgEventTailerError.readFailed(path: path, errno: code)
+      }
+      fileRegistration = registration
+      try drainAvailable()
+      reconcileCurrentPath()
+    }
+
+    private func makeFileRegistration() throws -> FileRegistration {
+      let fd = open(path, O_RDONLY | O_CLOEXEC | O_NOFOLLOW)
+      guard fd >= 0 else {
+        throw IMsgEventTailerError.openFailed(path: path, errno: errno)
+      }
+      var info = stat()
+      guard fstat(fd, &info) == 0 else {
+        let code = errno
+        close(fd)
+        throw IMsgEventTailerError.openFailed(path: path, errno: code)
+      }
+      let identity = FileIdentity(device: UInt64(info.st_dev), inode: UInt64(info.st_ino))
+      let source = DispatchSource.makeFileSystemObjectSource(
         fileDescriptor: fd,
         eventMask: [.extend, .write, .rename, .delete],
         queue: queue
       )
-      src.setEventHandler { [weak self] in
-        guard let self else { return }
-        let mask = src.data
-        if mask.contains(.rename) || mask.contains(.delete) {
-          // File rotated by the dylib — close and reopen the new file.
-          self.reopen()
+      source.setEventHandler { [weak self] in
+        self?.handleFileEvent()
+      }
+      source.setCancelHandler {
+        close(fd)
+      }
+      source.resume()
+      return FileRegistration(fd: fd, identity: identity, source: source)
+    }
+
+    private func handleFileEvent() {
+      guard !stopped, let registration = fileRegistration else { return }
+      let events = registration.source.data
+      do {
+        try drainAvailable()
+      } catch {
+        finish(throwing: error)
+        return
+      }
+      if events.contains(.delete), !events.contains(.rename) {
+        do {
+          if try currentPathIdentity() == nil {
+            finish(throwing: IMsgEventTailerError.openFailed(path: path, errno: ENOENT))
+            return
+          }
+        } catch {
+          finish(throwing: error)
           return
         }
-        self.drainAvailable()
       }
-      src.setCancelHandler { [weak self] in
-        guard let self else { return }
-        if self.fd >= 0 {
-          close(self.fd)
-          self.fd = -1
+      reconcileCurrentPath()
+    }
+
+    private func reconcileCurrentPath() {
+      do {
+        guard !stopped, let current = fileRegistration else { return }
+        guard let pathIdentity = try currentPathIdentity() else {
+          // A rename and replacement are two syscalls. The directory source owns
+          // the gap and calls back as soon as the new path is created.
+          return
         }
+        guard pathIdentity != current.identity else { return }
+        try drainAvailable()
+        let replacement = try makeFileRegistration()
+        guard replacement.identity == pathIdentity else {
+          replacement.source.cancel()
+          reconcileCurrentPath()
+          return
+        }
+        pending.removeAll(keepingCapacity: true)
+        fileRegistration = replacement
+        current.source.cancel()
+        try drainAvailable()
+        reconcileCurrentPath()
+      } catch {
+        finish(throwing: error)
       }
-      src.resume()
-      self.source = src
     }
 
-    private func reopen() {
-      source?.cancel()
-      source = nil
-      if fd >= 0 {
-        close(fd)
-        fd = -1
+    private func currentPathIdentity() throws -> FileIdentity? {
+      var info = stat()
+      guard lstat(path, &info) == 0 else {
+        if errno == ENOENT { return nil }
+        throw IMsgEventTailerError.openFailed(path: path, errno: errno)
       }
-      pending.removeAll(keepingCapacity: true)
-      // Small delay lets the dylib finish the rename; then start fresh.
-      queue.asyncAfter(deadline: .now() + 0.25) { [weak self] in
-        self?.openAndStart()
+      guard (info.st_mode & S_IFMT) == S_IFREG else {
+        throw IMsgEventTailerError.openFailed(path: path, errno: EINVAL)
       }
+      return FileIdentity(device: UInt64(info.st_dev), inode: UInt64(info.st_ino))
     }
 
-    private func drainAvailable() {
-      guard fd >= 0 else { return }
-      var buffer = Data(count: 8192)
+    private func drainAvailable() throws {
+      guard let registration = fileRegistration else { return }
+      var bytes = [UInt8](repeating: 0, count: 8192)
       while true {
-        let n = buffer.withUnsafeMutableBytes { (raw: UnsafeMutableRawBufferPointer) -> Int in
-          guard let base = raw.baseAddress else { return -1 }
-          return read(fd, base, raw.count)
+        let count = read(registration.fd, &bytes, bytes.count)
+        if count > 0 {
+          pending.append(bytes, count: count)
+          processPending()
+          if stopped { return }
+          continue
         }
-        if n <= 0 { break }
-        pending.append(buffer.prefix(n))
-        processPending()
+        if count == 0 { return }
+        if errno == EINTR { continue }
+        throw IMsgEventTailerError.readFailed(path: path, errno: errno)
       }
     }
 
     private func processPending() {
-      while let nl = pending.firstIndex(of: 0x0A) {
-        let line = pending[..<nl]
-        pending.removeSubrange(...nl)
-        guard !line.isEmpty else { continue }
-        guard
-          let obj = try? JSONSerialization.jsonObject(with: line, options: [])
-            as? [String: Any]
+      while let newline = pending.firstIndex(of: 0x0A) {
+        let line = pending[..<newline]
+        pending.removeSubrange(...newline)
+        guard !line.isEmpty,
+          let object = try? JSONSerialization.jsonObject(with: line) as? [String: Any]
         else { continue }
-        let name = (obj["event"] as? String) ?? "unknown"
-        let ts = obj["ts"] as? String
-        let data = (obj["data"] as? [String: Any]) ?? [:]
-        let payloadData = (try? JSONSerialization.data(withJSONObject: data, options: [])) ?? Data()
-        continuation?.yield(Event(timestamp: ts, name: name, payloadJSON: payloadData))
+        let name = object["event"] as? String ?? "unknown"
+        let timestamp = object["ts"] as? String
+        let payload = object["data"] as? [String: Any] ?? [:]
+        let payloadJSON =
+          (try? JSONSerialization.data(withJSONObject: payload, options: [])) ?? Data("{}".utf8)
+        let event = Event(timestamp: timestamp, name: name, payloadJSON: payloadJSON)
+        switch continuation?.yield(event) {
+        case .enqueued:
+          continue
+        case .dropped:
+          finish(throwing: IMsgEventTailerOverflowError())
+          return
+        case .terminated, .none:
+          finish()
+          return
+        @unknown default:
+          finish()
+          return
+        }
       }
     }
   #endif
+}
+
+extension IMsgEventTailer {
+  convenience init(
+    path: String,
+    replayExisting: Bool = false,
+    bufferLimit: Int = 256,
+    didStart: (@Sendable () -> Void)? = nil,
+    didStop: @escaping @Sendable () -> Void
+  ) throws {
+    guard (1...4096).contains(bufferLimit) else {
+      throw IMsgEventTailerError.invalidBufferLimit(bufferLimit)
+    }
+    self.init(
+      uncheckedPath: path,
+      replayExisting: replayExisting,
+      bufferLimit: bufferLimit,
+      didStart: didStart,
+      didStop: didStop
+    )
+  }
 }

--- a/Sources/imsg/Commands/WatchCommand.swift
+++ b/Sources/imsg/Commands/WatchCommand.swift
@@ -3,6 +3,11 @@ import Foundation
 import IMsgCore
 
 enum WatchCommand {
+  private enum StreamCompletion: Sendable {
+    case database
+    case bridge
+  }
+
   static let spec = CommandSpec(
     name: "watch",
     abstract: "Stream incoming messages",
@@ -72,6 +77,10 @@ enum WatchCommand {
           configuration: config,
           filter: filter
         )
+      },
+    bridgeStreamProvider:
+      @escaping (String) throws -> AsyncThrowingStream<IMsgEventTailer.Event, Error> = { path in
+        IMsgEventTailer(path: path).events()
       }
   ) async throws {
     let dbPath = values.option("db") ?? MessageStore.defaultPath
@@ -103,30 +112,8 @@ enum WatchCommand {
       includeReactions: includeReactions
     )
 
-    let bbEvents = values.flag("bbEvents")
-    if bbEvents {
-      let path = MessagesLauncher.shared.bridgeEventsFile
-      let tailer = IMsgEventTailer(path: path)
-      Task {
-        for await event in tailer.events() {
-          if runtime.jsonOutput {
-            var obj: [String: Any] = [
-              "kind": "bridge-event",
-              "event": event.name,
-            ]
-            if let ts = event.timestamp { obj["ts"] = ts }
-            obj["data"] = event.decodedPayload()
-            try? JSONLines.printObject(obj)
-          } else {
-            let stamp = event.timestamp ?? CLIISO8601.format(Date())
-            StdoutWriter.writeLine("\(stamp) [bridge] \(event.name)")
-          }
-        }
-      }
-    }
-
     let stream = streamProvider(watcher, chatID, sinceRowID, config, filter)
-    for try await message in stream {
+    let emitMessage: @Sendable (Message) throws -> Void = { message in
       if runtime.jsonOutput {
         let payload = try buildMessagePayload(
           store: store,
@@ -137,7 +124,7 @@ enum WatchCommand {
           contactResolver: contacts
         )
         try JSONLines.printObject(payload)
-        continue
+        return
       }
       let direction = message.isFromMe ? "sent" : "recv"
       let timestamp = CLIISO8601.format(message.date)
@@ -150,7 +137,7 @@ enum WatchCommand {
         StdoutWriter.writeLine(
           "\(timestamp) [\(direction)] \(sender) \(action) \(reactionType.emoji) reaction to \(targetGUID)"
         )
-        continue
+        return
       }
       let body = message.poll.map { pollDisplayText(for: $0) } ?? message.text
       StdoutWriter.writeLine("\(timestamp) [\(direction)] \(sender): \(body)")
@@ -166,6 +153,44 @@ enum WatchCommand {
           )
         }
       }
+    }
+
+    guard values.flag("bbEvents") else {
+      for try await message in stream {
+        try emitMessage(message)
+      }
+      return
+    }
+
+    let bridgeStream = try bridgeStreamProvider(MessagesLauncher.shared.bridgeEventsFile)
+    try await withThrowingTaskGroup(of: StreamCompletion.self) { group in
+      group.addTask {
+        for try await message in stream {
+          try emitMessage(message)
+        }
+        return .database
+      }
+      group.addTask {
+        for try await event in bridgeStream {
+          if runtime.jsonOutput {
+            var object: [String: Any] = [
+              "kind": "bridge-event",
+              "event": event.name,
+              "data": event.decodedPayload(),
+            ]
+            if let timestamp = event.timestamp { object["ts"] = timestamp }
+            try JSONLines.printObject(object)
+          } else {
+            let timestamp = event.timestamp ?? CLIISO8601.format(Date())
+            StdoutWriter.writeLine("\(timestamp) [bridge] \(event.name)")
+          }
+        }
+        return .bridge
+      }
+
+      _ = try await group.next()
+      group.cancelAll()
+      while try await group.next() != nil {}
     }
   }
 }

--- a/Sources/imsg/Commands/WatchCommand.swift
+++ b/Sources/imsg/Commands/WatchCommand.swift
@@ -3,11 +3,6 @@ import Foundation
 import IMsgCore
 
 enum WatchCommand {
-  private enum StreamCompletion: Sendable {
-    case database
-    case bridge
-  }
-
   static let spec = CommandSpec(
     name: "watch",
     abstract: "Stream incoming messages",
@@ -155,42 +150,45 @@ enum WatchCommand {
       }
     }
 
-    guard values.flag("bbEvents") else {
+    func watchDatabase() async throws {
       for try await message in stream {
+        try Task.checkCancellation()
         try emitMessage(message)
       }
+    }
+
+    guard values.flag("bbEvents") else {
+      try await watchDatabase()
       return
     }
 
-    let bridgeStream = try bridgeStreamProvider(MessagesLauncher.shared.bridgeEventsFile)
-    try await withThrowingTaskGroup(of: StreamCompletion.self) { group in
-      group.addTask {
-        for try await message in stream {
-          try emitMessage(message)
+    let bridgeStream = try? bridgeStreamProvider(MessagesLauncher.shared.bridgeEventsFile)
+    try await withThrowingTaskGroup(of: Void.self) { group in
+      defer { group.cancelAll() }
+      if let bridgeStream {
+        group.addTask {
+          do {
+            for try await event in bridgeStream {
+              try Task.checkCancellation()
+              if runtime.jsonOutput {
+                var object: [String: Any] = [
+                  "kind": "bridge-event",
+                  "event": event.name,
+                  "data": event.decodedPayload(),
+                ]
+                if let timestamp = event.timestamp { object["ts"] = timestamp }
+                try JSONLines.printObject(object)
+              } else {
+                let timestamp = event.timestamp ?? CLIISO8601.format(Date())
+                StdoutWriter.writeLine("\(timestamp) [bridge] \(event.name)")
+              }
+            }
+          } catch {}
         }
-        return .database
-      }
-      group.addTask {
-        for try await event in bridgeStream {
-          if runtime.jsonOutput {
-            var object: [String: Any] = [
-              "kind": "bridge-event",
-              "event": event.name,
-              "data": event.decodedPayload(),
-            ]
-            if let timestamp = event.timestamp { object["ts"] = timestamp }
-            try JSONLines.printObject(object)
-          } else {
-            let timestamp = event.timestamp ?? CLIISO8601.format(Date())
-            StdoutWriter.writeLine("\(timestamp) [bridge] \(event.name)")
-          }
-        }
-        return .bridge
       }
 
-      _ = try await group.next()
-      group.cancelAll()
-      while try await group.next() != nil {}
+      try await watchDatabase()
+      try Task.checkCancellation()
     }
   }
 }

--- a/Sources/imsg/Commands/WatchCommand.swift
+++ b/Sources/imsg/Commands/WatchCommand.swift
@@ -75,7 +75,7 @@ enum WatchCommand {
       },
     bridgeStreamProvider:
       @escaping (String) throws -> AsyncThrowingStream<IMsgEventTailer.Event, Error> = { path in
-        IMsgEventTailer(path: path).events()
+        IMsgEventTailer(path: path, createIfMissing: true).events()
       }
   ) async throws {
     let dbPath = values.option("db") ?? MessageStore.defaultPath

--- a/Sources/imsg/RPCMethodDescriptors.swift
+++ b/Sources/imsg/RPCMethodDescriptors.swift
@@ -17,28 +17,35 @@ enum RPCDatabaseRequirement: Sendable, Equatable {
 
 struct RPCBridgeRequirement: Sendable, Equatable {
   let requiresRegistry: Bool
+  let requiresEventPath: Bool
   let allSelectors: [String]
   let anySelectors: [String]
 
   static let none = RPCBridgeRequirement(
-    requiresRegistry: false, allSelectors: [], anySelectors: [])
+    requiresRegistry: false, requiresEventPath: false, allSelectors: [], anySelectors: [])
+
+  static let eventStream = RPCBridgeRequirement(
+    requiresRegistry: false, requiresEventPath: true, allSelectors: [], anySelectors: [])
 
   static func selector(
     _ name: String,
     requiresRegistry: Bool = true
   ) -> RPCBridgeRequirement {
     RPCBridgeRequirement(
-      requiresRegistry: requiresRegistry, allSelectors: [name], anySelectors: [])
+      requiresRegistry: requiresRegistry, requiresEventPath: false,
+      allSelectors: [name], anySelectors: [])
   }
 
   static func anySelector(_ names: String...) -> RPCBridgeRequirement {
-    RPCBridgeRequirement(requiresRegistry: true, allSelectors: [], anySelectors: names)
+    RPCBridgeRequirement(
+      requiresRegistry: true, requiresEventPath: false, allSelectors: [], anySelectors: names)
   }
 }
 
 enum RPCDispatchRoute: Sendable, Equatable {
   case initialize, status, chatsList, messagesStats, messagesHistory, messagesSearch
-  case messagesAfter, watchSubscribe, watchUnsubscribe, send, sendRich, sendAttachment
+  case messagesAfter, watchSubscribe, bridgeEventsSubscribe, watchUnsubscribe
+  case send, sendRich, sendAttachment
   case sendMultipart, sendSticker, messagesScheduled, pollSend, pollVote, pollUnvote
   case tapback, typing, read, messageEdit, messageUnsend, messageDelete
   case messageNotifyAnyways, messageSendStatus, chatsCreate, chatsDelete, chatsMarkUnread
@@ -115,6 +122,9 @@ let rpcMethodDescriptors: [RPCMethodDescriptor] = [
     database: [.scheduledMessages]),
   RPCMethodDescriptor(
     "watch.subscribe", route: .watchSubscribe, lane: .control, database: [.ready]),
+  RPCMethodDescriptor(
+    "bridge.events.subscribe", route: .bridgeEventsSubscribe, lane: .control,
+    bridge: .eventStream, macOSOnly: true),
   RPCMethodDescriptor(
     "message.send_status", route: .messageSendStatus, lane: .read, database: [.ready]),
   RPCMethodDescriptor("send", route: .send, lane: .mutation, macOSOnly: true),

--- a/Sources/imsg/RPCServer+BridgeEventHandlers.swift
+++ b/Sources/imsg/RPCServer+BridgeEventHandlers.swift
@@ -133,6 +133,8 @@ extension RPCServer {
 private func bridgeEventTerminalError(_ error: Error) -> [String: Any] {
   let code: String
   switch error {
+  case IMsgEventTailerError.createFailed:
+    code = "event_log_create_failed"
   case IMsgEventTailerError.openFailed:
     code = "event_log_open_failed"
   case IMsgEventTailerError.readFailed:

--- a/Sources/imsg/RPCServer+BridgeEventHandlers.swift
+++ b/Sources/imsg/RPCServer+BridgeEventHandlers.swift
@@ -1,0 +1,150 @@
+import Foundation
+import IMsgCore
+
+#if os(macOS)
+  import Darwin
+#endif
+
+func rpcBridgeEventPathUsable(_ path: String) -> Bool {
+  #if os(macOS)
+    var info = stat()
+    return lstat(path, &info) == 0
+      && (info.st_mode & S_IFMT) == S_IFREG
+      && access(path, R_OK) == 0
+  #else
+    return false
+  #endif
+}
+
+func bridgeEventPayload(_ event: IMsgEventTailer.Event) -> [String: Any] {
+  var payload: [String: Any] = [
+    "event": event.name,
+    "data": event.decodedPayload(),
+  ]
+  if let timestamp = event.timestamp { payload["ts"] = timestamp }
+  return payload
+}
+
+extension RPCServer {
+  func handleBridgeEventsSubscribe(id: Any?, params: [String: Any]) async throws {
+    let params = try RPCParameters(
+      params,
+      method: "bridge.events.subscribe",
+      supportedKeys: ["buffer_limit"]
+    )
+    let bufferLimit = try params.integer("buffer_limit") ?? 256
+    guard (1...4096).contains(bufferLimit) else {
+      throw RPCError.invalidParams("buffer_limit must be an integer between 1 and 4096")
+    }
+
+    let bridge = try await bridgeSnapshot()
+    guard bridge.supports(.eventStream) else {
+      let detail =
+        bridge.error ?? "The existing v2 bridge event log is not a readable regular file."
+      throw RPCError.bridgeEventsUnavailable(detail: detail)
+    }
+
+    let reservation: SubscriptionStore.Reservation
+    switch await subscriptions.reserve() {
+    case .reserved(let value):
+      reservation = value
+    case .closed:
+      throw RPCError.serverBusy("server is shutting down")
+    case .limitReached:
+      throw RPCError.serverBusy("subscription limit exceeded")
+    }
+
+    let subscriptionID = reservation.id
+    let localSubscriptions = subscriptions
+    let localWriter = output
+    let localPath = bridgeEventsPath
+    let localStreamProvider = bridgeEventStreamProvider
+    let startGate = SubscriptionStartGate()
+    let task = Task {
+      let activated = await startGate.wait()
+      guard activated, !Task.isCancelled else {
+        await localSubscriptions.complete(reservation)
+        return
+      }
+      do {
+        let stream = try localStreamProvider(localPath, bufferLimit)
+        for try await event in stream {
+          try Task.checkCancellation()
+          localWriter.sendNotification(
+            method: "bridge.event",
+            params: [
+              "subscription": subscriptionID,
+              "event": bridgeEventPayload(event),
+            ]
+          )
+        }
+      } catch is CancellationError {
+        // Explicit unsubscribe and process EOF are silent terminal states.
+      } catch is IMsgEventTailerOverflowError {
+        localWriter.sendNotification(
+          method: "bridge.events.overflow",
+          params: [
+            "subscription": subscriptionID,
+            "reason": "buffer_limit_exceeded",
+            "resumable": false,
+            "terminal": true,
+          ]
+        )
+      } catch {
+        if !Task.isCancelled {
+          localWriter.sendNotification(
+            method: "bridge.events.error",
+            params: [
+              "subscription": subscriptionID,
+              "error": bridgeEventTerminalError(error),
+              "terminal": true,
+            ]
+          )
+        }
+      }
+      await localSubscriptions.complete(reservation)
+    }
+
+    switch await subscriptions.activate(task, reservation: reservation) {
+    case .activated:
+      respond(
+        id: id,
+        result: [
+          "subscription": subscriptionID,
+          "buffer_limit": bufferLimit,
+          "resumable": false,
+        ]
+      )
+      await startGate.open(true)
+    case .closed:
+      await startGate.open(false)
+      task.cancel()
+      await task.value
+      throw RPCError.serverBusy("server is shutting down")
+    case .removed:
+      await startGate.open(false)
+      task.cancel()
+      await task.value
+      throw RPCError.serverBusy("subscription was cancelled before activation")
+    }
+  }
+}
+
+private func bridgeEventTerminalError(_ error: Error) -> [String: Any] {
+  let code: String
+  switch error {
+  case IMsgEventTailerError.openFailed:
+    code = "event_log_open_failed"
+  case IMsgEventTailerError.readFailed:
+    code = "event_log_read_failed"
+  case IMsgEventTailerError.unsupportedPlatform:
+    code = "unsupported_platform"
+  case IMsgEventTailerError.invalidBufferLimit:
+    code = "invalid_buffer_limit"
+  case IMsgEventTailerError.alreadyStarted:
+    code = "event_stream_already_started"
+  default:
+    code = "event_stream_failed"
+  }
+  return ["code": code, "message": error.localizedDescription]
+}

--- a/Sources/imsg/RPCServer+StatusHandlers.swift
+++ b/Sources/imsg/RPCServer+StatusHandlers.swift
@@ -7,6 +7,7 @@ struct RPCBridgeSnapshot: Sendable {
   let bridgeVersion: Int?
   let v2Ready: Bool?
   let registryAvailable: Bool?
+  let eventPathUsable: Bool
   let selectors: [String: Bool]
   let error: String?
 
@@ -16,6 +17,7 @@ struct RPCBridgeSnapshot: Sendable {
     bridgeVersion: Int?,
     v2Ready: Bool?,
     registryAvailable: Bool?,
+    eventPathUsable: Bool,
     selectors: [String: Bool],
     error: String?
   ) {
@@ -24,6 +26,7 @@ struct RPCBridgeSnapshot: Sendable {
     self.bridgeVersion = bridgeVersion
     self.v2Ready = v2Ready
     self.registryAvailable = registryAvailable
+    self.eventPathUsable = eventPathUsable
     self.selectors = selectors
     self.error = error
   }
@@ -34,6 +37,7 @@ struct RPCBridgeSnapshot: Sendable {
     bridgeVersion: nil,
     v2Ready: nil,
     registryAvailable: nil,
+    eventPathUsable: false,
     selectors: [:],
     error: "The bridge is not started. Run imsg launch explicitly before using bridge methods."
   )
@@ -44,11 +48,12 @@ struct RPCBridgeSnapshot: Sendable {
     bridgeVersion: nil,
     v2Ready: nil,
     registryAvailable: nil,
+    eventPathUsable: false,
     selectors: [:],
     error: "The existing bridge did not answer a non-launching status probe."
   )
 
-  init(status: [String: Any]) {
+  init(status: [String: Any], eventPathUsable: Bool = false) {
     let version = Self.integer(status["bridge_version"])
     let v2Ready = status["v2_ready"] as? Bool
     let registryAvailable = status["registry_available"] as? Bool
@@ -57,6 +62,7 @@ struct RPCBridgeSnapshot: Sendable {
     self.bridgeVersion = version
     self.v2Ready = v2Ready
     self.registryAvailable = registryAvailable
+    self.eventPathUsable = eventPathUsable
     self.selectors = Self.boolDictionary(status["selectors"])
     self.error =
       self.ready
@@ -79,6 +85,7 @@ struct RPCBridgeSnapshot: Sendable {
     if requirement == .none { return true }
     guard bridgeVersion != nil, v2Ready == true else { return false }
     if requirement.requiresRegistry, registryAvailable != true { return false }
+    if requirement.requiresEventPath, !eventPathUsable { return false }
     guard requirement.allSelectors.allSatisfy({ selectors[$0] == true }) else { return false }
     return requirement.anySelectors.isEmpty
       || requirement.anySelectors.contains { selectors[$0] == true }
@@ -139,7 +146,10 @@ extension RPCServer {
     try Task.checkCancellation()
     guard isBridgeReady() else { return .unavailable }
     do {
-      return RPCBridgeSnapshot(status: try await bridgeInvoker(.status, [:]))
+      return RPCBridgeSnapshot(
+        status: try await bridgeInvoker(.status, [:]),
+        eventPathUsable: bridgeEventPathUsable(bridgeEventsPath)
+      )
     } catch is CancellationError {
       throw CancellationError()
     } catch {

--- a/Sources/imsg/RPCServer+Support.swift
+++ b/Sources/imsg/RPCServer+Support.swift
@@ -101,6 +101,14 @@ struct RPCError: Error, @unchecked Sendable {
     )
   }
 
+  static func bridgeEventsUnavailable(detail: String) -> RPCError {
+    RPCError(
+      code: -32003,
+      message: "Bridge events unavailable",
+      structuredData: ["detail": detail, "retryable": true]
+    )
+  }
+
   static func deliveryFailure(_ failure: DeliveryFailure) -> RPCError {
     let unknown = failure.disposition != .notStarted
     return RPCError(

--- a/Sources/imsg/RPCServer.swift
+++ b/Sources/imsg/RPCServer.swift
@@ -40,6 +40,11 @@ typealias RPCWatchStreamProvider = (
   _ filter: MessageFilter
 ) -> AsyncThrowingStream<Message, Error>
 
+typealias RPCBridgeEventStreamProvider = (
+  _ path: String,
+  _ bufferLimit: Int
+) throws -> AsyncThrowingStream<IMsgEventTailer.Event, Error>
+
 // MessageStore, stdout, and watcher state are serial-queue-owned; subscriptions are actors.
 // Remaining production dependencies are immutable or internally synchronized.
 final class RPCServer: @unchecked Sendable {
@@ -59,6 +64,9 @@ final class RPCServer: @unchecked Sendable {
   let markAsRead: (String) async throws -> Void
   let contactResolver: any ContactResolving
   let watchStreamProvider: RPCWatchStreamProvider
+  let bridgeEventsPath: String
+  let bridgeEventPathUsable: @Sendable (String) -> Bool
+  let bridgeEventStreamProvider: RPCBridgeEventStreamProvider
 
   init(
     store: MessageStore,
@@ -87,6 +95,11 @@ final class RPCServer: @unchecked Sendable {
       try await IMCoreBridge.shared.markAsRead(handle: $0)
     },
     contactResolver: any ContactResolving = NoOpContactResolver(),
+    bridgeEventsPath: String = MessagesLauncher.shared.bridgeEventsFile,
+    bridgeEventPathUsable: @escaping @Sendable (String) -> Bool = rpcBridgeEventPathUsable,
+    bridgeEventStreamProvider: @escaping RPCBridgeEventStreamProvider = { path, bufferLimit in
+      try IMsgEventTailer(path: path, bufferLimit: bufferLimit).events()
+    },
     watchStreamProvider: @escaping RPCWatchStreamProvider = {
       watcher, chatID, sinceRowID, configuration, filter in
       watcher.stream(
@@ -112,6 +125,9 @@ final class RPCServer: @unchecked Sendable {
     self.stopTyping = stopTyping
     self.markAsRead = markAsRead
     self.contactResolver = contactResolver
+    self.bridgeEventsPath = bridgeEventsPath
+    self.bridgeEventPathUsable = bridgeEventPathUsable
+    self.bridgeEventStreamProvider = bridgeEventStreamProvider
     self.watchStreamProvider = watchStreamProvider
   }
 
@@ -139,6 +155,11 @@ final class RPCServer: @unchecked Sendable {
       try await IMCoreBridge.shared.markAsRead(handle: $0)
     },
     contactResolver: any ContactResolving = NoOpContactResolver(),
+    bridgeEventsPath: String = MessagesLauncher.shared.bridgeEventsFile,
+    bridgeEventPathUsable: @escaping @Sendable (String) -> Bool = rpcBridgeEventPathUsable,
+    bridgeEventStreamProvider: @escaping RPCBridgeEventStreamProvider = { path, bufferLimit in
+      try IMsgEventTailer(path: path, bufferLimit: bufferLimit).events()
+    },
     watchStreamProvider: @escaping RPCWatchStreamProvider = {
       watcher, chatID, sinceRowID, configuration, filter in
       watcher.stream(
@@ -164,6 +185,9 @@ final class RPCServer: @unchecked Sendable {
     self.stopTyping = stopTyping
     self.markAsRead = markAsRead
     self.contactResolver = contactResolver
+    self.bridgeEventsPath = bridgeEventsPath
+    self.bridgeEventPathUsable = bridgeEventPathUsable
+    self.bridgeEventStreamProvider = bridgeEventStreamProvider
     self.watchStreamProvider = watchStreamProvider
   }
 
@@ -263,6 +287,8 @@ final class RPCServer: @unchecked Sendable {
         try await handleMessagesAfter(id: id, params: params)
       case .watchSubscribe:
         try await handleWatchSubscribe(id: id, params: params)
+      case .bridgeEventsSubscribe:
+        try await handleBridgeEventsSubscribe(id: id, params: params)
       case .watchUnsubscribe:
         try await handleWatchUnsubscribe(id: id, params: params)
       case .send:

--- a/Tests/IMsgCoreTests/IMsgEventTailerTests.swift
+++ b/Tests/IMsgCoreTests/IMsgEventTailerTests.swift
@@ -3,6 +3,10 @@ import Testing
 
 @testable import IMsgCore
 
+#if os(macOS)
+  import Darwin
+#endif
+
 @Suite("IMsgEventTailer")
 struct IMsgEventTailerTests {
   @Test(.timeLimit(.minutes(1)))
@@ -125,6 +129,29 @@ struct IMsgEventTailerTests {
       #expect(failedPath == path)
     }
     #expect(try Data(contentsOf: URL(fileURLWithPath: target)) == Data("unchanged".utf8))
+  }
+
+  @Test(.timeLimit(.minutes(1)))
+  func fifoPathIsRejectedWithoutBlocking() async throws {
+    let directory = NSTemporaryDirectory() + "/imsg-tailer-fifo-\(UUID().uuidString)"
+    try FileManager.default.createDirectory(atPath: directory, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(atPath: directory) }
+    let path = (directory as NSString).appendingPathComponent("events.jsonl")
+    #expect(mkfifo(path, 0o600) == 0)
+
+    let tailer = IMsgEventTailer(path: path, createIfMissing: false)
+    var iterator = tailer.events().makeAsyncIterator()
+    do {
+      _ = try await iterator.next()
+      Issue.record("expected FIFO rejection")
+    } catch let error as IMsgEventTailerError {
+      guard case .openFailed(let failedPath, let code) = error else {
+        Issue.record("unexpected error: \(error)")
+        return
+      }
+      #expect(failedPath == path)
+      #expect(code == EINVAL)
+    }
   }
 
   @Test(.timeLimit(.minutes(1)))

--- a/Tests/IMsgCoreTests/IMsgEventTailerTests.swift
+++ b/Tests/IMsgCoreTests/IMsgEventTailerTests.swift
@@ -54,6 +54,31 @@ struct IMsgEventTailerTests {
     }
   }
 
+  @Test
+  func missingPathCanBeCreatedPrivatelyAndReceiveLaterAppend() async throws {
+    let directory = NSTemporaryDirectory() + "/imsg-tailer-create-\(UUID().uuidString)"
+    try FileManager.default.createDirectory(atPath: directory, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(atPath: directory) }
+    let path = (directory as NSString).appendingPathComponent("events.jsonl")
+    let started = CallbackProbe()
+    let tailer = try IMsgEventTailer(
+      path: path,
+      createIfMissing: true,
+      didStart: { Task { await started.record() } },
+      didStop: {})
+    let stream = tailer.events()
+    await started.wait()
+
+    let attributes = try FileManager.default.attributesOfItem(atPath: path)
+    #expect((attributes[.type] as? FileAttributeType) == .typeRegular)
+    #expect((attributes[.posixPermissions] as? NSNumber)?.intValue == 0o600)
+
+    try appendEvents(["late-append"], to: path)
+    var iterator = stream.makeAsyncIterator()
+    #expect(try await iterator.next()?.name == "late-append")
+    tailer.stop()
+  }
+
   @Test(.timeLimit(.minutes(1)))
   func missingPathFinishesWithOpenFailure() async throws {
     let path = NSTemporaryDirectory() + "/missing-event-log-\(UUID().uuidString)"
@@ -75,6 +100,31 @@ struct IMsgEventTailerTests {
     }
     let startCount = await started.callCount()
     #expect(startCount == 0)
+  }
+
+  @Test
+  func createIfMissingRejectsSymlinkWithoutMutatingTarget() async throws {
+    let directory = NSTemporaryDirectory() + "/imsg-tailer-symlink-\(UUID().uuidString)"
+    try FileManager.default.createDirectory(atPath: directory, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(atPath: directory) }
+    let target = (directory as NSString).appendingPathComponent("target")
+    let path = (directory as NSString).appendingPathComponent("events.jsonl")
+    try Data("unchanged".utf8).write(to: URL(fileURLWithPath: target))
+    try FileManager.default.createSymbolicLink(atPath: path, withDestinationPath: target)
+
+    let tailer = IMsgEventTailer(path: path, createIfMissing: true)
+    var iterator = tailer.events().makeAsyncIterator()
+    do {
+      _ = try await iterator.next()
+      Issue.record("expected symlink open failure")
+    } catch let error as IMsgEventTailerError {
+      guard case .openFailed(let failedPath, _) = error else {
+        Issue.record("unexpected error: \(error)")
+        return
+      }
+      #expect(failedPath == path)
+    }
+    #expect(try Data(contentsOf: URL(fileURLWithPath: target)) == Data("unchanged".utf8))
   }
 
   @Test(.timeLimit(.minutes(1)))

--- a/Tests/IMsgCoreTests/IMsgEventTailerTests.swift
+++ b/Tests/IMsgCoreTests/IMsgEventTailerTests.swift
@@ -3,113 +3,228 @@ import Testing
 
 @testable import IMsgCore
 
-/// Smoke tests for the events-jsonl tailer. Writes a temp file, appends a few
-/// JSON lines, asserts they surface in order through the AsyncStream.
 @Suite("IMsgEventTailer")
 struct IMsgEventTailerTests {
-  @Test
-  func tailerEmitsAppendedLines() async throws {
-    let dir = NSTemporaryDirectory() + "imsg-tailer-test-\(UUID().uuidString)"
-    try FileManager.default.createDirectory(
-      atPath: dir, withIntermediateDirectories: true)
-    defer { try? FileManager.default.removeItem(atPath: dir) }
+  @Test(.timeLimit(.minutes(1)))
+  func initialEOFSkipsExistingAndAppendOrderIsStable() async throws {
+    try await withEventFile(existing: ["old"]) { path in
+      let started = CallbackProbe()
+      let tailer = try IMsgEventTailer(
+        path: path,
+        didStart: { Task { await started.record() } },
+        didStop: {})
+      let stream = tailer.events()
+      await started.wait()
 
-    let path = (dir as NSString).appendingPathComponent("events.jsonl")
-    FileManager.default.createFile(atPath: path, contents: Data(), attributes: nil)
+      try appendEvents(["first", "second"], to: path)
+      var iterator = stream.makeAsyncIterator()
+      #expect(try await iterator.next()?.name == "first")
+      #expect(try await iterator.next()?.name == "second")
+      tailer.stop()
+      let startCount = await started.callCount()
+      #expect(startCount == 1)
+    }
+  }
 
-    let tailer = IMsgEventTailer(path: path)
-    let stream = tailer.events()
+  @Test(.timeLimit(.minutes(1)))
+  func rotationIncludesTriggerAndImmediateNextEventExactlyOnce() async throws {
+    try await withEventFile { path in
+      let started = CallbackProbe()
+      let tailer = try IMsgEventTailer(
+        path: path,
+        didStart: { Task { await started.record() } },
+        didStop: {})
+      let stream = tailer.events()
+      await started.wait()
 
-    // Append two events on a background task so the tailer has a chance to
-    // open and start watching before lines arrive.
-    Task.detached {
-      try? await Task.sleep(nanoseconds: 200_000_000)
-      let line1 = """
-        {"event":"started-typing","data":{"chatGuid":"iMessage;-;+15551"}}
-        """ + "\n"
-      let line2 = """
-        {"event":"stopped-typing","data":{"chatGuid":"iMessage;-;+15551"}}
-        """ + "\n"
-      let fp = fopen(path, "a")
-      if let fp = fp {
-        line1.utf8CString.withUnsafeBufferPointer { buf in
-          guard let base = buf.baseAddress else { return }
-          fwrite(base, 1, strlen(base), fp)
-        }
-        line2.utf8CString.withUnsafeBufferPointer { buf in
-          guard let base = buf.baseAddress else { return }
-          fwrite(base, 1, strlen(base), fp)
-        }
-        fflush(fp)
-        fclose(fp)
+      try appendEvents(["before-rotation"], to: path)
+      let rotated = path + ".1"
+      try FileManager.default.moveItem(atPath: path, toPath: rotated)
+      try eventLine("rotation-trigger").write(
+        to: URL(fileURLWithPath: path), atomically: false, encoding: .utf8)
+      try appendEvents(["immediate-next"], to: path)
+
+      var names: [String] = []
+      for try await event in stream {
+        names.append(event.name)
+        if names.count == 3 { break }
       }
+      #expect(names == ["before-rotation", "rotation-trigger", "immediate-next"])
+      tailer.stop()
     }
+  }
 
-    var collected: [String] = []
-    let deadline = Date().addingTimeInterval(3.0)
-    for await event in stream {
-      collected.append(event.name)
-      if collected.count >= 2 { break }
-      if Date() > deadline { break }
+  @Test(.timeLimit(.minutes(1)))
+  func missingPathFinishesWithOpenFailure() async throws {
+    let path = NSTemporaryDirectory() + "/missing-event-log-\(UUID().uuidString)"
+    let started = CallbackProbe()
+    let tailer = try IMsgEventTailer(
+      path: path,
+      didStart: { Task { await started.record() } },
+      didStop: {})
+    var iterator = tailer.events().makeAsyncIterator()
+    do {
+      _ = try await iterator.next()
+      Issue.record("expected open failure")
+    } catch let error as IMsgEventTailerError {
+      guard case .openFailed(let failedPath, _) = error else {
+        Issue.record("unexpected error: \(error)")
+        return
+      }
+      #expect(failedPath == path)
     }
-    tailer.stop()
+    let startCount = await started.callCount()
+    #expect(startCount == 0)
+  }
 
-    #expect(collected == ["started-typing", "stopped-typing"])
+  @Test(.timeLimit(.minutes(1)))
+  func unreadableSourceFinishesWithReadFailure() async throws {
+    let directory = NSTemporaryDirectory() + "/imsg-event-directory-\(UUID().uuidString)"
+    try FileManager.default.createDirectory(atPath: directory, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(atPath: directory) }
+    let started = CallbackProbe()
+    let tailer = try IMsgEventTailer(
+      path: directory,
+      replayExisting: true,
+      didStart: { Task { await started.record() } },
+      didStop: {})
+    var iterator = tailer.events().makeAsyncIterator()
+    do {
+      _ = try await iterator.next()
+      Issue.record("expected read failure")
+    } catch let error as IMsgEventTailerError {
+      guard case .readFailed(let failedPath, _) = error else {
+        Issue.record("unexpected error: \(error)")
+        return
+      }
+      #expect(failedPath == directory)
+    }
+    let startCount = await started.callCount()
+    #expect(startCount == 0)
+  }
+
+  @Test(.timeLimit(.minutes(1)))
+  func bufferOneDrainsAcceptedEventThenThrowsOverflowAndStops() async throws {
+    try await withEventFile(existing: ["accepted", "rejected"]) { path in
+      let stopped = CallbackProbe()
+      let tailer = try IMsgEventTailer(
+        path: path,
+        replayExisting: true,
+        bufferLimit: 1,
+        didStop: { Task { await stopped.record() } }
+      )
+      let stream = tailer.events()
+      await stopped.wait()
+      var iterator = stream.makeAsyncIterator()
+      #expect(try await iterator.next()?.name == "accepted")
+      do {
+        _ = try await iterator.next()
+        Issue.record("expected overflow")
+      } catch is IMsgEventTailerOverflowError {
+        // Accepted events drain before the typed terminal overflow.
+      }
+      let stopCount = await stopped.callCount()
+      #expect(stopCount == 1)
+    }
   }
 
   @Test
-  func tailerSkipsExistingLinesByDefault() async throws {
-    let dir = NSTemporaryDirectory() + "imsg-tailer-test-\(UUID().uuidString)"
-    try FileManager.default.createDirectory(
-      atPath: dir, withIntermediateDirectories: true)
-    defer { try? FileManager.default.removeItem(atPath: dir) }
-
-    let path = (dir as NSString).appendingPathComponent("events.jsonl")
-    let oldLine = """
-      {"event":"old-typing","data":{"chatGuid":"iMessage;-;+15551"}}
-      """ + "\n"
-    FileManager.default.createFile(
-      atPath: path,
-      contents: oldLine.data(using: .utf8),
-      attributes: nil
-    )
-
-    let tailer = IMsgEventTailer(path: path)
-    let stream = tailer.events()
-
-    Task.detached {
-      try? await Task.sleep(nanoseconds: 200_000_000)
-      let newLine = """
-        {"event":"started-typing","data":{"chatGuid":"iMessage;-;+15551"}}
-        """ + "\n"
-      let fp = fopen(path, "a")
-      if let fp = fp {
-        newLine.utf8CString.withUnsafeBufferPointer { buf in
-          guard let base = buf.baseAddress else { return }
-          fwrite(base, 1, strlen(base), fp)
-        }
-        fflush(fp)
-        fclose(fp)
+  func rejectsInvalidBufferLimits() {
+    for limit in [0, 4097] {
+      #expect(throws: IMsgEventTailerError.self) {
+        _ = try IMsgEventTailer(path: "/tmp/events", bufferLimit: limit)
       }
     }
+  }
 
-    var first: String?
-    for await event in stream {
-      first = event.name
-      break
+  @Test(.timeLimit(.minutes(1)))
+  func completedTailerReleasesOwner() async throws {
+    weak var releasedTailer: IMsgEventTailer?
+    try await withEventFile { path in
+      let started = CallbackProbe()
+      let stopped = CallbackProbe()
+      var tailer: IMsgEventTailer? = try IMsgEventTailer(
+        path: path,
+        didStart: { Task { await started.record() } },
+        didStop: { Task { await stopped.record() } }
+      )
+      releasedTailer = tailer
+      var stream: AsyncThrowingStream<IMsgEventTailer.Event, Error>? = tailer?.events()
+      await started.wait()
+      tailer?.stop()
+      await stopped.wait()
+      do {
+        var iterator = try #require(stream?.makeAsyncIterator())
+        #expect(try await iterator.next()?.name == nil)
+      }
+      stream = nil
+      tailer = nil
     }
-    tailer.stop()
-
-    #expect(first == "started-typing")
+    #expect(releasedTailer == nil)
   }
 
   @Test
   func eventDecodedPayloadRoundTrip() throws {
     let raw: [String: Any] = ["chatGuid": "iMessage;-;+1", "extra": 42]
-    let data = try JSONSerialization.data(withJSONObject: raw, options: [])
+    let data = try JSONSerialization.data(withJSONObject: raw)
     let event = IMsgEventTailer.Event(timestamp: nil, name: "x", payloadJSON: data)
-    let decoded = event.decodedPayload()
-    #expect(decoded["chatGuid"] as? String == "iMessage;-;+1")
-    #expect(decoded["extra"] as? Int == 42)
+    #expect(event.decodedPayload()["chatGuid"] as? String == "iMessage;-;+1")
+    #expect(event.decodedPayload()["extra"] as? Int == 42)
+  }
+
+  private func withEventFile(
+    existing: [String] = [],
+    operation: (String) async throws -> Void
+  ) async throws {
+    let directory = NSTemporaryDirectory() + "/imsg-tailer-test-\(UUID().uuidString)"
+    try FileManager.default.createDirectory(atPath: directory, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(atPath: directory) }
+    let path = (directory as NSString).appendingPathComponent("events.jsonl")
+    try existing.map(eventLine).joined().write(
+      to: URL(fileURLWithPath: path), atomically: false, encoding: .utf8)
+    try await operation(path)
+  }
+
+  private func appendEvents(_ names: [String], to path: String) throws {
+    let handle = try FileHandle(forWritingTo: URL(fileURLWithPath: path))
+    defer { try? handle.close() }
+    try handle.seekToEnd()
+    try handle.write(contentsOf: Data(names.map(eventLine).joined().utf8))
+    try handle.synchronize()
+  }
+
+  private func eventLine(_ name: String) -> String {
+    "{\"event\":\"\(name)\",\"data\":{\"sequence\":\"\(name)\"}}\n"
+  }
+
+}
+
+private actor CallbackProbe {
+  private var count = 0
+  private var waiters: [CheckedContinuation<Void, Never>] = []
+
+  func record() {
+    count += 1
+    guard count == 1 else { return }
+    let pendingWaiters = waiters
+    waiters.removeAll()
+    for waiter in pendingWaiters {
+      waiter.resume()
+    }
+  }
+
+  func wait() async {
+    if count > 0 { return }
+    await withCheckedContinuation { continuation in
+      if count > 0 {
+        continuation.resume()
+      } else {
+        waiters.append(continuation)
+      }
+    }
+  }
+
+  func callCount() -> Int {
+    count
   }
 }

--- a/Tests/IMsgCoreTests/IMsgEventTailerTests.swift
+++ b/Tests/IMsgCoreTests/IMsgEventTailerTests.swift
@@ -155,7 +155,7 @@ struct IMsgEventTailerTests {
   }
 
   @Test(.timeLimit(.minutes(1)))
-  func unreadableSourceFinishesWithReadFailure() async throws {
+  func directorySourceFinishesWithOpenFailure() async throws {
     let directory = NSTemporaryDirectory() + "/imsg-event-directory-\(UUID().uuidString)"
     try FileManager.default.createDirectory(atPath: directory, withIntermediateDirectories: true)
     defer { try? FileManager.default.removeItem(atPath: directory) }
@@ -168,13 +168,14 @@ struct IMsgEventTailerTests {
     var iterator = tailer.events().makeAsyncIterator()
     do {
       _ = try await iterator.next()
-      Issue.record("expected read failure")
+      Issue.record("expected nonregular source rejection")
     } catch let error as IMsgEventTailerError {
-      guard case .readFailed(let failedPath, _) = error else {
+      guard case .openFailed(let failedPath, let code) = error else {
         Issue.record("unexpected error: \(error)")
         return
       }
       #expect(failedPath == directory)
+      #expect(code == EINVAL)
     }
     let startCount = await started.callCount()
     #expect(startCount == 0)

--- a/Tests/imsgTests/RPCBridgeEventSubscriptionTests.swift
+++ b/Tests/imsgTests/RPCBridgeEventSubscriptionTests.swift
@@ -1,0 +1,354 @@
+import Foundation
+import Testing
+
+@testable import IMsgCore
+@testable import imsg
+
+@Test(.timeLimit(.minutes(1)))
+func rpcBridgeEventResponsePrecedesImmediateEvent() async throws {
+  let output = TestRPCOutput()
+  let event = bridgeEvent("immediate", sequence: 1)
+  let server = try makeBridgeEventServer(output: output) { _, _ in
+    AsyncThrowingStream { continuation in
+      continuation.yield(event)
+      continuation.finish()
+    }
+  }
+
+  await server.handleLineForTesting(bridgeSubscribeRequest(id: "subscribe"))
+  await output.waitForOutputCount(2)
+  await server.subscriptions.waitUntilEmpty()
+
+  #expect(output.outputs[0]["id"] as? String == "subscribe")
+  #expect(output.outputs[1]["method"] as? String == "bridge.event")
+  let params = try #require(output.outputs[1]["params"] as? [String: Any])
+  let payload = try #require(params["event"] as? [String: Any])
+  #expect(payload["event"] as? String == "immediate")
+  #expect((payload["data"] as? [String: Any])?["sequence"] as? Int == 1)
+}
+
+@Test(.timeLimit(.minutes(1)))
+func rpcBridgeEventOverflowDrainsAcceptedEventsAndIsNotResumable() async throws {
+  let output = TestRPCOutput()
+  let server = try makeBridgeEventServer(output: output) { _, limit in
+    AsyncThrowingStream(bufferingPolicy: .bufferingOldest(limit)) { continuation in
+      for sequence in 1...3 {
+        if case .dropped = continuation.yield(bridgeEvent("event", sequence: sequence)) {
+          continuation.finish(throwing: IMsgEventTailerOverflowError())
+          return
+        }
+      }
+    }
+  }
+
+  await server.handleLineForTesting(
+    bridgeSubscribeRequest(id: "overflow", params: #"{"buffer_limit":2}"#)
+  )
+  await output.waitForOutputCount(4)
+  await server.subscriptions.waitUntilEmpty()
+
+  #expect(
+    output.outputs.map { $0["method"] as? String } == [
+      nil, "bridge.event", "bridge.event", "bridge.events.overflow",
+    ])
+  let terminal = try #require(output.outputs[3]["params"] as? [String: Any])
+  #expect(terminal["resumable"] as? Bool == false)
+  #expect(terminal["terminal"] as? Bool == true)
+  #expect(terminal["resume_after_rowid"] == nil)
+}
+
+@Test(.timeLimit(.minutes(1)))
+func rpcBridgeEventUnsubscribeIsFinalAndStopsSource() async throws {
+  let source = ControlledBridgeEventSource()
+  let output = TestRPCOutput()
+  let server = try makeBridgeEventServer(output: output, streamProvider: source.makeStream)
+
+  await server.handleLineForTesting(bridgeSubscribeRequest(id: "subscribe"))
+  await source.waitForStreams(1)
+  source.yield(bridgeEvent("before", sequence: 1))
+  await output.waitForOutputCount(2)
+  await server.handleLineForTesting(
+    #"{"jsonrpc":"2.0","id":"unsubscribe","method":"watch.unsubscribe","params":{"subscription":1}}"#
+  )
+  await source.waitForTerminations(1)
+
+  let count = output.outputs.count
+  #expect(source.yield(bridgeEvent("after", sequence: 2)))
+  #expect(output.outputs.count == count)
+  #expect(output.outputs.last?["id"] as? String == "unsubscribe")
+}
+
+@Test(.timeLimit(.minutes(1)))
+func rpcEOFStopsBridgeEventSource() async throws {
+  let source = ControlledBridgeEventSource()
+  let output = TestRPCOutput()
+  let server = try makeBridgeEventServer(output: output, streamProvider: source.makeStream)
+  let (lines, input) = makeRuntimeLines()
+  let run = Task { try await server.run(lines: lines) }
+
+  input.yield(bridgeSubscribeRequest(id: "subscribe"))
+  await source.waitForStreams(1)
+  input.finish()
+  await source.waitForTerminations(1)
+  try await run.value
+  #expect(await server.subscriptions.count == 0)
+}
+
+@Test
+func rpcBridgeEventInactiveBridgeFailsTypedWithoutOpeningSource() async throws {
+  let output = TestRPCOutput()
+  let source = ControlledBridgeEventSource()
+  let server = try makeBridgeEventServer(
+    output: output,
+    bridgeReady: false,
+    streamProvider: source.makeStream
+  )
+
+  await server.handleLineForTesting(bridgeSubscribeRequest(id: "inactive"))
+  let error = try #require(output.errors.first?["error"] as? [String: Any])
+  #expect(error["code"] as? Int == -32003)
+  #expect(error["message"] as? String == "Bridge events unavailable")
+  #expect(await server.subscriptions.count == 0)
+}
+
+@Test
+func rpcBridgeEventParamsAreStrictAndStatusRequiresUsablePath() async throws {
+  let output = TestRPCOutput()
+  let server = try makeBridgeEventServer(output: output)
+  for (id, params) in [
+    ("zero", #"{"buffer_limit":0}"#),
+    ("large", #"{"buffer_limit":4097}"#),
+    ("bool", #"{"buffer_limit":true}"#),
+    ("alias", #"{"bufferLimit":2}"#),
+  ] {
+    await server.handleLineForTesting(bridgeSubscribeRequest(id: id, params: params))
+  }
+  #expect(output.errors.count == 4)
+  #expect(output.errors.allSatisfy { ($0["error"] as? [String: Any])?["code"] as? Int == -32602 })
+
+  let usableOutput = TestRPCOutput()
+  let usable = try makeBridgeEventServer(output: usableOutput)
+  await usable.handleLineForTesting(#"{"jsonrpc":"2.0","id":"status","method":"status"}"#)
+  #expect(rpcStatusMethods(try rpcStatusResult(usableOutput)).contains("bridge.events.subscribe"))
+
+  let unusableOutput = TestRPCOutput()
+  let unusable = try makeBridgeEventServer(output: unusableOutput, eventPathUsable: false)
+  await unusable.handleLineForTesting(#"{"jsonrpc":"2.0","id":"status","method":"status"}"#)
+  let status = try rpcStatusResult(unusableOutput)
+  #expect(!rpcStatusMethods(status).contains("bridge.events.subscribe"))
+  #expect((status["supported_methods"] as? [String])?.contains("bridge.events.subscribe") == true)
+}
+
+@Test(.timeLimit(.minutes(1)))
+func rpcSubscriptionCapIsSharedByBridgeEvents() async throws {
+  let source = ControlledBridgeEventSource()
+  let database = ControlledWatchSource()
+  let output = TestRPCOutput()
+  let server = try makeBridgeEventServer(
+    output: output,
+    watchSource: database,
+    streamProvider: source.makeStream
+  )
+
+  for index in 1...63 {
+    await server.handleLineForTesting(bridgeSubscribeRequest(id: "subscribe-\(index)"))
+  }
+  await server.handleLineForTesting(
+    #"{"jsonrpc":"2.0","id":"database","method":"watch.subscribe","params":{"since_rowid":999}}"#
+  )
+  await source.waitForStreams(63)
+  await database.waitForStreams(1)
+  await server.handleLineForTesting(bridgeSubscribeRequest(id: "subscribe-65"))
+  await output.waitForOutputCount(65)
+  #expect(output.responses.count == 64)
+  #expect(output.errors.count == 1)
+  #expect(await server.subscriptions.count == 64)
+
+  await server.subscriptions.cancelAll()
+  await source.waitForTerminations(63)
+  await database.waitForTerminations(1)
+}
+
+@Test(.timeLimit(.minutes(1)))
+func rpcBridgeEventTerminalReadFailureIsTyped() async throws {
+  let output = TestRPCOutput()
+  let server = try makeBridgeEventServer(output: output) { _, _ in
+    throw IMsgEventTailerError.readFailed(path: "/tmp/imsg-events.jsonl", errno: 5)
+  }
+
+  await server.handleLineForTesting(bridgeSubscribeRequest(id: "failure"))
+  await output.waitForOutputCount(2)
+  await server.subscriptions.waitUntilEmpty()
+  #expect(output.outputs[1]["method"] as? String == "bridge.events.error")
+  let params = try #require(output.outputs[1]["params"] as? [String: Any])
+  let error = try #require(params["error"] as? [String: Any])
+  #expect(error["code"] as? String == "event_log_read_failed")
+  #expect(params["terminal"] as? Bool == true)
+}
+
+@Test(.timeLimit(.minutes(1)))
+func rpcDatabaseAndBridgeSubscriptionsPreserveOnlyTheirOwnOrder() async throws {
+  let database = ControlledWatchSource()
+  let bridge = ControlledBridgeEventSource()
+  let output = TestRPCOutput()
+  let server = try makeBridgeEventServer(
+    output: output,
+    watchSource: database,
+    streamProvider: bridge.makeStream
+  )
+
+  await server.handleLineForTesting(
+    #"{"jsonrpc":"2.0","id":"database","method":"watch.subscribe","params":{"since_rowid":999}}"#
+  )
+  await server.handleLineForTesting(bridgeSubscribeRequest(id: "bridge"))
+  await database.waitForStreams(1)
+  await bridge.waitForStreams(1)
+  database.yield(message(rowID: 1))
+  bridge.yield(bridgeEvent("bridge", sequence: 1))
+  database.yield(message(rowID: 2))
+  bridge.yield(bridgeEvent("bridge", sequence: 2))
+  await output.waitForOutputCount(6)
+
+  let databaseOrder = output.notifications.compactMap { notification -> Int64? in
+    guard notification["method"] as? String == "message",
+      let params = notification["params"] as? [String: Any],
+      let payload = params["message"] as? [String: Any]
+    else { return nil }
+    return payload["id"] as? Int64
+  }
+  let bridgeOrder = output.notifications.compactMap { notification -> Int? in
+    guard notification["method"] as? String == "bridge.event",
+      let params = notification["params"] as? [String: Any],
+      let event = params["event"] as? [String: Any],
+      let data = event["data"] as? [String: Any]
+    else { return nil }
+    return data["sequence"] as? Int
+  }
+  #expect(databaseOrder == [1, 2])
+  #expect(bridgeOrder == [1, 2])
+  await server.subscriptions.cancelAll()
+}
+
+private func makeBridgeEventServer(
+  output: TestRPCOutput,
+  bridgeReady: Bool = true,
+  eventPathUsable: Bool = true,
+  watchSource: ControlledWatchSource? = nil,
+  streamProvider: @escaping RPCBridgeEventStreamProvider = { _, _ in
+    AsyncThrowingStream { _ in }
+  }
+) throws -> RPCServer {
+  RPCServer(
+    store: try CommandTestDatabase.makeStoreForRPC(),
+    verbose: false,
+    output: output,
+    invokeBridge: { action, _ in
+      action == .status ? rpcStatusBridgeSnapshot() : [:]
+    },
+    isBridgeReady: { bridgeReady },
+    bridgeEventsPath: "/tmp/imsg-events.jsonl",
+    bridgeEventPathUsable: { _ in eventPathUsable },
+    bridgeEventStreamProvider: streamProvider,
+    watchStreamProvider: { _, _, _, _, _ in
+      watchSource?.makeStream() ?? AsyncThrowingStream { $0.finish() }
+    }
+  )
+}
+
+private func bridgeSubscribeRequest(id: String, params: String = "{}") -> String {
+  #"{"jsonrpc":"2.0","id":"\#(id)","method":"bridge.events.subscribe","params":\#(params)}"#
+}
+
+private func bridgeEvent(_ name: String, sequence: Int) -> IMsgEventTailer.Event {
+  IMsgEventTailer.Event(
+    timestamp: "2026-08-10T00:00:00Z",
+    name: name,
+    payloadJSON: Data("{\"sequence\":\(sequence)}".utf8)
+  )
+}
+
+private func message(rowID: Int64) -> Message {
+  Message(
+    rowID: rowID,
+    chatID: 1,
+    sender: "+123",
+    text: "message-\(rowID)",
+    date: Date(),
+    isFromMe: false,
+    service: "iMessage",
+    handleID: 1,
+    attachmentsCount: 0
+  )
+}
+
+private final class ControlledBridgeEventSource: @unchecked Sendable {
+  private let lock = NSLock()
+  private var continuations: [AsyncThrowingStream<IMsgEventTailer.Event, Error>.Continuation] = []
+  private var streamWaiters: [(Int, CheckedContinuation<Void, Never>)] = []
+  private var terminationCount = 0
+  private var terminationWaiters: [(Int, CheckedContinuation<Void, Never>)] = []
+
+  func makeStream(
+    _ path: String,
+    _ bufferLimit: Int
+  ) -> AsyncThrowingStream<IMsgEventTailer.Event, Error> {
+    AsyncThrowingStream { continuation in
+      continuation.onTermination = { [weak self] _ in self?.recordTermination() }
+      let ready: [CheckedContinuation<Void, Never>]
+      lock.lock()
+      continuations.append(continuation)
+      ready = streamWaiters.filter { $0.0 <= continuations.count }.map(\.1)
+      streamWaiters.removeAll { $0.0 <= continuations.count }
+      lock.unlock()
+      for continuation in ready {
+        continuation.resume()
+      }
+    }
+  }
+
+  @discardableResult
+  func yield(_ event: IMsgEventTailer.Event) -> Bool {
+    lock.withLock { continuations }.allSatisfy {
+      if case .terminated = $0.yield(event) { return true }
+      return false
+    }
+  }
+
+  func waitForStreams(_ count: Int) async {
+    await wait(count, streams: true)
+  }
+
+  func waitForTerminations(_ count: Int) async {
+    await wait(count, streams: false)
+  }
+
+  private func wait(_ count: Int, streams: Bool) async {
+    await withCheckedContinuation { continuation in
+      lock.lock()
+      let current = streams ? continuations.count : terminationCount
+      if current >= count {
+        lock.unlock()
+        continuation.resume()
+      } else {
+        if streams {
+          streamWaiters.append((count, continuation))
+        } else {
+          terminationWaiters.append((count, continuation))
+        }
+        lock.unlock()
+      }
+    }
+  }
+
+  private func recordTermination() {
+    let ready: [CheckedContinuation<Void, Never>]
+    lock.lock()
+    terminationCount += 1
+    ready = terminationWaiters.filter { $0.0 <= terminationCount }.map(\.1)
+    terminationWaiters.removeAll { $0.0 <= terminationCount }
+    lock.unlock()
+    for continuation in ready {
+      continuation.resume()
+    }
+  }
+}

--- a/Tests/imsgTests/RPCBridgeEventSubscriptionTests.swift
+++ b/Tests/imsgTests/RPCBridgeEventSubscriptionTests.swift
@@ -96,11 +96,16 @@ func rpcEOFStopsBridgeEventSource() async throws {
 
 @Test
 func rpcBridgeEventInactiveBridgeFailsTypedWithoutOpeningSource() async throws {
+  let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+  try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: false)
+  defer { try? FileManager.default.removeItem(at: directory) }
+  let eventPath = directory.appendingPathComponent("events.jsonl").path
   let output = TestRPCOutput()
   let source = ControlledBridgeEventSource()
   let server = try makeBridgeEventServer(
     output: output,
     bridgeReady: false,
+    bridgeEventsPath: eventPath,
     streamProvider: source.makeStream
   )
 
@@ -109,6 +114,8 @@ func rpcBridgeEventInactiveBridgeFailsTypedWithoutOpeningSource() async throws {
   #expect(error["code"] as? Int == -32003)
   #expect(error["message"] as? String == "Bridge events unavailable")
   #expect(await server.subscriptions.count == 0)
+  #expect(source.streamCount == 0)
+  #expect(!FileManager.default.fileExists(atPath: eventPath))
 }
 
 @Test
@@ -233,6 +240,7 @@ private func makeBridgeEventServer(
   output: TestRPCOutput,
   bridgeReady: Bool = true,
   eventPathUsable: Bool = true,
+  bridgeEventsPath: String = "/tmp/imsg-events.jsonl",
   watchSource: ControlledWatchSource? = nil,
   streamProvider: @escaping RPCBridgeEventStreamProvider = { _, _ in
     AsyncThrowingStream { _ in }
@@ -246,7 +254,7 @@ private func makeBridgeEventServer(
       action == .status ? rpcStatusBridgeSnapshot() : [:]
     },
     isBridgeReady: { bridgeReady },
-    bridgeEventsPath: "/tmp/imsg-events.jsonl",
+    bridgeEventsPath: bridgeEventsPath,
     bridgeEventPathUsable: { _ in eventPathUsable },
     bridgeEventStreamProvider: streamProvider,
     watchStreamProvider: { _, _, _, _, _ in
@@ -287,6 +295,10 @@ private final class ControlledBridgeEventSource: @unchecked Sendable {
   private var streamWaiters: [(Int, CheckedContinuation<Void, Never>)] = []
   private var terminationCount = 0
   private var terminationWaiters: [(Int, CheckedContinuation<Void, Never>)] = []
+
+  var streamCount: Int {
+    lock.withLock { continuations.count }
+  }
 
   func makeStream(
     _ path: String,

--- a/Tests/imsgTests/WatchCommandBridgeTests.swift
+++ b/Tests/imsgTests/WatchCommandBridgeTests.swift
@@ -47,6 +47,39 @@ private actor GatedWatchMessageSequence {
   }
 }
 
+private actor WatchCommandTailerRelay {
+  private let delivered: WatchCommandBridgeGate
+  private var pending: IMsgEventTailer.Event?
+  private var waiter: CheckedContinuation<IMsgEventTailer.Event?, Never>?
+  private var emitted = false
+
+  init(delivered: WatchCommandBridgeGate) {
+    self.delivered = delivered
+  }
+
+  func offer(_ event: IMsgEventTailer.Event) {
+    if let waiter {
+      self.waiter = nil
+      waiter.resume(returning: event)
+    } else {
+      pending = event
+    }
+  }
+
+  func next() async -> IMsgEventTailer.Event? {
+    guard !emitted else {
+      await delivered.release()
+      return nil
+    }
+    emitted = true
+    if let pending {
+      self.pending = nil
+      return pending
+    }
+    return await withCheckedContinuation { waiter = $0 }
+  }
+}
+
 private final class WatchCommandStreamSource<Element: Sendable>: @unchecked Sendable {
   private let lock = NSLock()
   private var started = false
@@ -200,6 +233,60 @@ func watchCommandKeepsDatabaseStreamRunningAfterBridgeError() async throws {
 
   #expect(output.contains(messages[0].text))
   #expect(output.contains(messages[1].text))
+}
+
+@Test
+func watchCommandCreatesMissingBridgeLogAndReceivesLateEvent() async throws {
+  let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+  try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: false)
+  defer { try? FileManager.default.removeItem(at: directory) }
+  let path = directory.appendingPathComponent("events.jsonl").path
+  let values = bridgeWatchValues()
+  let store = try CommandTestDatabase.makeStoreForRPC()
+  let started = WatchCommandBridgeGate()
+  let delivered = WatchCommandBridgeGate()
+  let database = GatedWatchMessageSequence(
+    gate: delivered,
+    messages: [watchCommandBridgeMessage(rowID: 1, text: "database-stayed-active")]
+  )
+
+  let (output, _) = try await StdoutCapture.capture {
+    let run = Task {
+      try await WatchCommand.run(
+        values: values,
+        runtime: RuntimeOptions(parsedValues: values),
+        storeFactory: { _ in store },
+        contactResolverFactory: { NoOpContactResolver() },
+        streamProvider: { _, _, _, _, _ in
+          AsyncThrowingStream(unfolding: { await database.next() })
+        },
+        bridgeStreamProvider: { _ in
+          let tailer = try IMsgEventTailer(
+            path: path,
+            createIfMissing: true,
+            didStart: { Task { await started.release() } },
+            didStop: {})
+          let relay = WatchCommandTailerRelay(delivered: delivered)
+          Task {
+            for try await event in tailer.events() {
+              await relay.offer(event)
+              break
+            }
+          }
+          return AsyncThrowingStream(unfolding: { await relay.next() })
+        }
+      )
+    }
+
+    await started.wait()
+    let handle = try FileHandle(forWritingTo: URL(fileURLWithPath: path))
+    try handle.write(contentsOf: Data("{\"event\":\"late-cli-event\",\"data\":{}}\n".utf8))
+    try handle.close()
+    try await run.value
+  }
+
+  #expect(output.contains("late-cli-event"))
+  #expect(output.contains("database-stayed-active"))
 }
 
 @Test(.timeLimit(.minutes(1)))

--- a/Tests/imsgTests/WatchCommandBridgeTests.swift
+++ b/Tests/imsgTests/WatchCommandBridgeTests.swift
@@ -1,0 +1,262 @@
+import Commander
+import Foundation
+import Testing
+
+@testable import IMsgCore
+@testable import imsg
+
+private enum WatchCommandBridgeTestError: Error {
+  case bridge
+  case database
+  case setup
+}
+
+private actor WatchCommandBridgeGate {
+  private var open = false
+  private var waiters: [CheckedContinuation<Void, Never>] = []
+
+  func wait() async {
+    if open { return }
+    await withCheckedContinuation { waiters.append($0) }
+  }
+
+  func release() {
+    guard !open else { return }
+    open = true
+    let ready = waiters
+    waiters.removeAll()
+    for waiter in ready { waiter.resume() }
+  }
+}
+
+private actor GatedWatchMessageSequence {
+  private let gate: WatchCommandBridgeGate
+  private let messages: [Message]
+  private var index = 0
+
+  init(gate: WatchCommandBridgeGate, messages: [Message]) {
+    self.gate = gate
+    self.messages = messages
+  }
+
+  func next() async -> Message? {
+    await gate.wait()
+    guard index < messages.count else { return nil }
+    defer { index += 1 }
+    return messages[index]
+  }
+}
+
+private final class WatchCommandStreamSource<Element: Sendable>: @unchecked Sendable {
+  private let lock = NSLock()
+  private var started = false
+  private var terminated = false
+  private var startWaiters: [CheckedContinuation<Void, Never>] = []
+  private var terminationWaiters: [CheckedContinuation<Void, Never>] = []
+
+  func makeStream() -> AsyncThrowingStream<Element, Error> {
+    AsyncThrowingStream { continuation in
+      continuation.onTermination = { [weak self] _ in self?.finish() }
+      let ready: [CheckedContinuation<Void, Never>] = lock.withLock {
+        started = true
+        defer { startWaiters.removeAll() }
+        return startWaiters
+      }
+      for waiter in ready { waiter.resume() }
+    }
+  }
+
+  func waitForStart() async {
+    if lock.withLock({ started }) { return }
+    await withCheckedContinuation { continuation in
+      lock.lock()
+      if started {
+        lock.unlock()
+        continuation.resume()
+      } else {
+        startWaiters.append(continuation)
+        lock.unlock()
+      }
+    }
+  }
+
+  func waitForTermination() async {
+    if lock.withLock({ terminated }) { return }
+    await withCheckedContinuation { continuation in
+      lock.lock()
+      if terminated {
+        lock.unlock()
+        continuation.resume()
+      } else {
+        terminationWaiters.append(continuation)
+        lock.unlock()
+      }
+    }
+  }
+
+  private func finish() {
+    let ready: [CheckedContinuation<Void, Never>]
+    lock.lock()
+    terminated = true
+    ready = terminationWaiters
+    terminationWaiters.removeAll()
+    lock.unlock()
+    for continuation in ready {
+      continuation.resume()
+    }
+  }
+}
+
+private func bridgeWatchValues() -> ParsedValues {
+  ParsedValues(
+    positional: [],
+    options: ["db": ["/tmp/unused"], "debounce": ["1ms"]],
+    flags: ["bbEvents"]
+  )
+}
+
+private func watchCommandBridgeMessage(rowID: Int64, text: String) -> Message {
+  Message(
+    rowID: rowID,
+    chatID: 1,
+    sender: "+123",
+    text: text,
+    date: Date(),
+    isFromMe: false,
+    service: "iMessage",
+    handleID: nil,
+    attachmentsCount: 0
+  )
+}
+
+private func singleBridgeWatchMessageStream(
+  _ message: Message
+) -> (
+  MessageWatcher,
+  Int64?,
+  Int64?,
+  MessageWatcherConfiguration,
+  MessageFilter
+) -> AsyncThrowingStream<Message, Error> {
+  return { _, _, _, _, _ in
+    AsyncThrowingStream { continuation in
+      continuation.yield(message)
+      continuation.finish()
+    }
+  }
+}
+
+@Test
+func watchCommandRunsDatabaseStreamWhenBridgeSetupFails() async throws {
+  let values = bridgeWatchValues()
+  let store = try CommandTestDatabase.makeStoreForRPC()
+  let message = watchCommandBridgeMessage(
+    rowID: 1,
+    text: "database-after-bridge-setup-error"
+  )
+
+  let (output, _) = try await StdoutCapture.capture {
+    try await WatchCommand.run(
+      values: values,
+      runtime: RuntimeOptions(parsedValues: values),
+      storeFactory: { _ in store },
+      contactResolverFactory: { NoOpContactResolver() },
+      streamProvider: singleBridgeWatchMessageStream(message),
+      bridgeStreamProvider: { _ in throw WatchCommandBridgeTestError.setup }
+    )
+  }
+
+  #expect(output.contains(message.text))
+}
+
+@Test
+func watchCommandKeepsDatabaseStreamRunningAfterBridgeError() async throws {
+  let values = bridgeWatchValues()
+  let store = try CommandTestDatabase.makeStoreForRPC()
+  let gate = WatchCommandBridgeGate()
+  let messages = [
+    watchCommandBridgeMessage(rowID: 1, text: "database-after-bridge-error-1"),
+    watchCommandBridgeMessage(rowID: 2, text: "database-after-bridge-error-2"),
+  ]
+  let sequence = GatedWatchMessageSequence(gate: gate, messages: messages)
+
+  let (output, _) = try await StdoutCapture.capture {
+    try await WatchCommand.run(
+      values: values,
+      runtime: RuntimeOptions(parsedValues: values),
+      storeFactory: { _ in store },
+      contactResolverFactory: { NoOpContactResolver() },
+      streamProvider: { _, _, _, _, _ in
+        AsyncThrowingStream(unfolding: { await sequence.next() })
+      },
+      bridgeStreamProvider: { _ in
+        AsyncThrowingStream(unfolding: {
+          await gate.release()
+          throw WatchCommandBridgeTestError.bridge
+        })
+      }
+    )
+  }
+
+  #expect(output.contains(messages[0].text))
+  #expect(output.contains(messages[1].text))
+}
+
+@Test(.timeLimit(.minutes(1)))
+func watchCommandDatabaseErrorCancelsBridgeAndPropagates() async throws {
+  let values = bridgeWatchValues()
+  let store = try CommandTestDatabase.makeStoreForRPC()
+  let bridge = WatchCommandStreamSource<IMsgEventTailer.Event>()
+
+  do {
+    _ = try await StdoutCapture.capture {
+      try await WatchCommand.run(
+        values: values,
+        runtime: RuntimeOptions(parsedValues: values),
+        storeFactory: { _ in store },
+        contactResolverFactory: { NoOpContactResolver() },
+        streamProvider: { _, _, _, _, _ in
+          AsyncThrowingStream { $0.finish(throwing: WatchCommandBridgeTestError.database) }
+        },
+        bridgeStreamProvider: { _ in bridge.makeStream() }
+      )
+    }
+    Issue.record("Expected the database error to propagate")
+  } catch WatchCommandBridgeTestError.database {
+  } catch {
+    Issue.record("Unexpected error: \(error)")
+  }
+
+  await bridge.waitForTermination()
+}
+
+@Test(.timeLimit(.minutes(1)))
+func watchCommandCancellationStopsDatabaseAndBridgeStreams() async throws {
+  let values = bridgeWatchValues()
+  let store = try CommandTestDatabase.makeStoreForRPC()
+  let database = WatchCommandStreamSource<Message>()
+  let bridge = WatchCommandStreamSource<IMsgEventTailer.Event>()
+  let run = Task {
+    try await WatchCommand.run(
+      values: values,
+      runtime: RuntimeOptions(parsedValues: values),
+      storeFactory: { _ in store },
+      contactResolverFactory: { NoOpContactResolver() },
+      streamProvider: { _, _, _, _, _ in database.makeStream() },
+      bridgeStreamProvider: { _ in bridge.makeStream() }
+    )
+  }
+
+  await database.waitForStart()
+  await bridge.waitForStart()
+  run.cancel()
+  do {
+    try await run.value
+    Issue.record("Expected cancellation to propagate")
+  } catch is CancellationError {
+  } catch {
+    Issue.record("Unexpected error: \(error)")
+  }
+  await database.waitForTermination()
+  await bridge.waitForTermination()
+}

--- a/Tests/imsgTests/WatchCommandTests.swift
+++ b/Tests/imsgTests/WatchCommandTests.swift
@@ -80,6 +80,70 @@ func watchCommandRunsWithStubStream() async throws {
   }
 }
 
+@Test(.timeLimit(.minutes(1)))
+func watchCommandStopsBridgeStreamWhenDatabaseStreamEnds() async throws {
+  let values = ParsedValues(
+    positional: [],
+    options: ["db": ["/tmp/unused"], "debounce": ["1ms"]],
+    flags: ["bbEvents"]
+  )
+  let runtime = RuntimeOptions(parsedValues: values)
+  let store = try CommandTestDatabase.makeStoreForRPC()
+  let bridge = WatchBridgeSource()
+
+  _ = try await StdoutCapture.capture {
+    try await WatchCommand.run(
+      values: values,
+      runtime: runtime,
+      storeFactory: { _ in store },
+      contactResolverFactory: { NoOpContactResolver() },
+      streamProvider: { _, _, _, _, _ in
+        AsyncThrowingStream { continuation in continuation.finish() }
+      },
+      bridgeStreamProvider: { _ in bridge.makeStream() }
+    )
+  }
+  await bridge.waitForTermination()
+}
+
+private final class WatchBridgeSource: @unchecked Sendable {
+  private let lock = NSLock()
+  private var terminated = false
+  private var waiters: [CheckedContinuation<Void, Never>] = []
+
+  func makeStream() -> AsyncThrowingStream<IMsgEventTailer.Event, Error> {
+    AsyncThrowingStream { continuation in
+      continuation.onTermination = { [weak self] _ in self?.finish() }
+    }
+  }
+
+  func waitForTermination() async {
+    if lock.withLock({ terminated }) { return }
+    await withCheckedContinuation { continuation in
+      lock.lock()
+      if terminated {
+        lock.unlock()
+        continuation.resume()
+      } else {
+        waiters.append(continuation)
+        lock.unlock()
+      }
+    }
+  }
+
+  private func finish() {
+    let ready: [CheckedContinuation<Void, Never>]
+    lock.lock()
+    terminated = true
+    ready = waiters
+    waiters.removeAll()
+    lock.unlock()
+    for continuation in ready {
+      continuation.resume()
+    }
+  }
+}
+
 @Test
 func watchCommandRunsWithJsonOutput() async throws {
   let values = ParsedValues(

--- a/TestsLinux/LinuxReadCoreTests.swift
+++ b/TestsLinux/LinuxReadCoreTests.swift
@@ -3,6 +3,7 @@ import SQLite
 import Testing
 
 @testable import IMsgCore
+@testable import imsg
 
 @Test
 func readsMessageDatabaseFromCopiedFile() throws {
@@ -57,6 +58,11 @@ func linuxTypingIndicatorFailsWithPlatformMessage() throws {
   } catch let error as IMsgError {
     #expect(error.description.contains("only supported on macOS"))
   }
+}
+
+@Test
+func linuxDoesNotAdvertiseBridgeEventSubscriptions() {
+  #expect(!kSupportedRPCMethods.contains("bridge.events.subscribe"))
 }
 
 private func makeTemporaryDatabase() throws -> URL {

--- a/docs/bridge.md
+++ b/docs/bridge.md
@@ -150,6 +150,12 @@ Merge bridge-pushed typing and alias events into the normal watch stream:
 imsg watch --bb-events --json
 ```
 
+This combines two independently ordered best-effort sources on serialized
+stdout. Bridge events begin at the current event-log EOF and are non-resumable;
+there is no ordering guarantee relative to database messages. RPC clients can
+subscribe separately with `bridge.events.subscribe` and cancel its shared
+subscription ID with `watch.unsubscribe`.
+
 ## IPC layout
 
 The bridge uses a UUID-keyed request queue so concurrent CLI invocations cannot overwrite one another:

--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -416,6 +416,71 @@ message is never skipped.
 
 If a live all-chat row appears before Messages has joined it to a chat, RPC watch retries it briefly and then drops it fail-closed instead of emitting an empty `chat_id=0` direct-message-shaped payload.
 
+### `bridge.events.subscribe`
+
+macOS only. Subscribes to typing and alias-removal events from an existing v2
+bridge without launching Messages. The method appears in status `methods` only
+when the non-launching bridge probe succeeds and the event path is a readable
+regular file. It remains in `supported_methods` on macOS so callers can
+distinguish a temporarily inactive bridge from an unsupported build.
+
+Params:
+
+- `buffer_limit` (int, default `256`, range `1...4096`)
+
+Result:
+
+```json
+{ "subscription": 2, "buffer_limit": 256, "resumable": false }
+```
+
+Each event uses the normalized event-log shape:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "bridge.event",
+  "params": {
+    "subscription": 2,
+    "event": {
+      "event": "started-typing",
+      "ts": "2026-08-10T00:00:00Z",
+      "data": { "chatGuid": "iMessage;-;+15551234567" }
+    }
+  }
+}
+```
+
+Bridge events begin at the current event-log EOF and are not replayed or
+resumable. Rotation preserves the old log's remaining order before reading the
+new file from offset zero. This ordering is independent of `watch.subscribe`;
+no ordering between database messages and bridge events is promised.
+
+The subscription shares the server-wide 64-subscription cap and ID space with
+database watches. It deliberately reuses `watch.unsubscribe`; awaiting that
+response guarantees no later notification for the shared subscription ID.
+Process EOF performs the same source cleanup silently.
+
+On the first event rejected by a full buffer, accepted events drain and the
+stream emits one terminal notification with no ROWID or cursor:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "bridge.events.overflow",
+  "params": {
+    "subscription": 2,
+    "reason": "buffer_limit_exceeded",
+    "resumable": false,
+    "terminal": true
+  }
+}
+```
+
+Open, read, and other source failures terminate with
+`bridge.events.error`. Its `error` object contains a stable `code` and an
+actionable `message`; cancellation does not emit an error.
+
 ### `watch.unsubscribe`
 
 Params:

--- a/docs/watch.md
+++ b/docs/watch.md
@@ -147,7 +147,7 @@ Lines are flushed immediately when stdout is buffered (e.g. piped through `jq -c
 ## Bridge events
 
 On macOS, `--bb-events` adds typing and alias-removal events written by an
-already-running injected bridge:
+injected bridge:
 
 ```bash
 imsg watch --bb-events --json
@@ -157,7 +157,10 @@ Database messages and bridge events are two independently ordered,
 best-effort streams sharing serialized stdout. Each source preserves its own
 order, but their relative output order has no meaning. Database messages remain
 resumable with `--since-rowid`; bridge events start at the event log's current
-EOF, have no replay cursor, and are not resumable. If the bridge event log is
-missing, cannot be opened, overflows, fails while reading, or ends, database
-watching continues normally. When the database stream ends or fails, `watch`
-cancels and awaits the bridge stream before exiting.
+EOF, have no replay cursor, and are not resumable. The CLI securely provisions
+a private empty event log when needed, so it can start before bridge injection
+and receive later events. If the log cannot be created or opened, overflows,
+fails while reading, or ends, database watching continues normally. RPC
+subscriptions never provision this path and remain gated on an active bridge
+with an existing readable regular event log. When the database stream ends or
+fails, `watch` cancels and awaits the bridge stream before exiting.

--- a/docs/watch.md
+++ b/docs/watch.md
@@ -157,5 +157,7 @@ Database messages and bridge events are two independently ordered,
 best-effort streams sharing serialized stdout. Each source preserves its own
 order, but their relative output order has no meaning. Database messages remain
 resumable with `--since-rowid`; bridge events start at the event log's current
-EOF, have no replay cursor, and are not resumable. When either source ends or
-fails, `watch` cancels and awaits the other before exiting.
+EOF, have no replay cursor, and are not resumable. If the bridge event log is
+missing, cannot be opened, overflows, fails while reading, or ends, database
+watching continues normally. When the database stream ends or fails, `watch`
+cancels and awaits the bridge stream before exiting.

--- a/docs/watch.md
+++ b/docs/watch.md
@@ -143,3 +143,19 @@ When you send a link, Messages writes a "balloon" placeholder row first, then la
 Each line is a complete JSON object. See [JSON output → Message](json.md#message) for the full field list. For tapback events also see the reaction fields above. For native polls, see [JSON output → Native poll extension](json.md#native-poll-extension).
 
 Lines are flushed immediately when stdout is buffered (e.g. piped through `jq -c`), so downstream consumers don't experience batching artifacts.
+
+## Bridge events
+
+On macOS, `--bb-events` adds typing and alias-removal events written by an
+already-running injected bridge:
+
+```bash
+imsg watch --bb-events --json
+```
+
+Database messages and bridge events are two independently ordered,
+best-effort streams sharing serialized stdout. Each source preserves its own
+order, but their relative output order has no meaning. Database messages remain
+resumable with `--since-rowid`; bridge events start at the event log's current
+EOF, have no replay cursor, and are not resumable. When either source ends or
+fails, `watch` cancels and awaits the other before exiting.


### PR DESCRIPTION
## Summary

- replace the bridge JSONL reader with a bounded, throwing `IMsgEventTailer` that preserves exact inode-rotation continuity and reports typed open, read, and overflow failures
- make `imsg watch --bb-events` cleanly coordinate its independent database and bridge streams
- add a separate macOS-only `bridge.events.subscribe` RPC lifecycle with the shared 64-subscription ID pool and `watch.unsubscribe`

## Lifecycle contract

The subscribe response is written before any `bridge.event` notification. Explicit unsubscribe is final: its response is the last output for that subscription. Overflow and I/O failure end the subscription with typed terminal notifications; bridge streams are explicitly nonresumable and expose no cursor or replay contract.

The method is advertised as available only on macOS when the v2 bridge reports event-stream support and the event path is a readable regular file. Linux retains the descriptor for capability reporting but excludes the executable method.

## Verification

- full `make test`: 638 tests passed
- tailer suite: 50/50 deterministic tests passed, including `didStart` ordering and the continuation cycle break
- `make lint`, universal build, and Linux read-core checks passed
- final structured autoreview: no findings, overall 0.94
- patch passed whitespace checks

Live macOS validation covered both path states. With the event path absent, status correctly hid the method. Creating an owner-only path made it available. The subscribe response preceded a benign appended event, the event was received, and `watch.unsubscribe` was the final response with no later marker. EOF and stderr remained clean, the Messages process ID did not change, and no user message was sent.

## Limits

This deliberately excludes database watch/replay, cross-stream deduplication, inode replacement recovery, parity work, and downstream consumers. Database and bridge streams preserve their own order only; no relative ordering is promised. Bridge events begin at the current log EOF and remain best-effort and nonresumable.

The change is approximately +414 production lines, +473 test lines, and +87 documentation lines. That size reflects the bounded rotation state machine and the independent subscription lifecycle rather than a broader RPC redesign.
