### PR TITLE
build: track SwiftPM release lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,6 @@ go.work.sum
 # SwiftPM
 .build/
 .swiftpm/
-Package.resolved
 *.xcodeproj
 
 # Build artifacts

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,33 @@
+{
+  "originHash" : "3b4b8fcc219563b7f4bea10a00c2ede7c4c4bd385bfd1cf2337a20a1256b3180",
+  "pins" : [
+    {
+      "identity" : "commander",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/steipete/Commander.git",
+      "state" : {
+        "revision" : "bd219c4ee9032fee3e009856f81fcc6ec09a85f4",
+        "version" : "0.2.4"
+      }
+    },
+    {
+      "identity" : "phonenumberkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/PhoneNumberKit/PhoneNumberKit.git",
+      "state" : {
+        "revision" : "e18a029dbada1d8eb32e3f81a4eb72eba539ff75",
+        "version" : "5.0.6"
+      }
+    },
+    {
+      "identity" : "sqlite.swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/stephencelis/SQLite.swift.git",
+      "state" : {
+        "revision" : "964c300fb0736699ce945c9edb56ecd62eba27a3",
+        "version" : "0.16.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Tests/imsgTests/ReleasePackagingTests.swift
+++ b/Tests/imsgTests/ReleasePackagingTests.swift
@@ -19,6 +19,13 @@ func releaseWorkflowPackagesUniversalBuildOutput() throws {
 }
 
 @Test
+func releaseWorkflowHasTrackedDependencyLock() throws {
+  _ = try readRepositoryFile("Package.resolved")
+  let ignoredPaths = try readRepositoryFile(".gitignore").split(separator: "\n")
+  #expect(!ignoredPaths.contains("Package.resolved"))
+}
+
+@Test
 func universalBuildScriptShipsArm64eHelperSlice() throws {
   let script = try readRepositoryFile("scripts/build-universal.sh")
 


### PR DESCRIPTION
## What Problem This Solves

Release run [31401419580](https://github.com/openclaw/imsg/actions/runs/31401419580) passed credential validation on attempt 2 but stopped before tagging because the shared Swift release workflow requires a tracked `Package.resolved`. The repository generated a valid lock locally while `.gitignore` explicitly excluded it.

No tag, draft release, artifact, or Homebrew update was created by the failed attempts.

## Why This Change Was Made

Track the existing SwiftPM lock and stop ignoring it so signed release builds resolve the exact reviewed dependency revisions. A packaging regression test now requires the lock to exist in a clean checkout and remain outside `.gitignore`.

## User Impact

This unblocks the frozen imsg 0.14.0 release and makes future signed builds reproducible across macOS and Linux release jobs.

## Evidence

- `swift package resolve` left `Package.resolved` byte-for-byte unchanged
- release packaging tests: 8 passed
- full suite: 653 passed
- touched-file Swift format and SwiftLint: clean, 0 violations
- `git diff --check`
- independent autoreview: clean, no accepted/actionable findings
