### PR TITLE
fix(release): pin robust signer import

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,8 @@ jobs:
       contents: write
       pull-requests: write
       statuses: read
-    # Pin the immutable Swift Linux Bash-shell fix until the v1 compatibility tag includes it.
-    uses: openclaw/release-workflows/.github/workflows/release-swift-cli.yml@61a1fc61b482dc1befdaa0fc172e5506958b8608
+    # Pin immutable Swift release hotfixes until the v1 compatibility tag includes them.
+    uses: openclaw/release-workflows/.github/workflows/release-swift-cli.yml@0d04fb8583639378db1bc3f8ed897ee2eafb61d1
     with:
       version: ${{ inputs.version }}
       repository-type: personal

--- a/Tests/imsgTests/ReleasePackagingTests.swift
+++ b/Tests/imsgTests/ReleasePackagingTests.swift
@@ -7,7 +7,7 @@ func releaseWorkflowPackagesUniversalBuildOutput() throws {
 
   #expect(
     workflow.contains(
-      "uses: openclaw/release-workflows/.github/workflows/release-swift-cli.yml@61a1fc61b482dc1befdaa0fc172e5506958b8608"
+      "uses: openclaw/release-workflows/.github/workflows/release-swift-cli.yml@0d04fb8583639378db1bc3f8ed897ee2eafb61d1"
     ))
   #expect(workflow.contains("macos-archive-name: imsg-macos.zip"))
   #expect(workflow.contains("helper-name: imsg-bridge-helper.dylib"))


### PR DESCRIPTION
## What Problem This Solves

The frozen imsg 0.14.0 release now builds both macOS and Linux payloads, but GitHub's direct `security import` of the encrypted PKCS#12 fails on the hosted signing runner. The pinned workflow revision extracts the certificate and private key with OpenSSL, then imports those standard PEM objects separately into the ephemeral keychain.

## Why This Change Was Made

Advance imsg's temporary immutable workflow pin from the Bash-shell-only hotfix to `0d04fb8583639378db1bc3f8ed897ee2eafb61d1`, which includes both the Linux shell fix and robust signer import.

The same P12/password remain the credential transport; signing identity, keychain partition checks, permissions, notarization, verification, publication, and Homebrew contracts are unchanged.

## User Impact

No runtime behavior changes. This unblocks the already-frozen signed and notarized imsg 0.14.0 release.

## Evidence

- full `release-workflows/scripts/validate-workflows.sh` suite passed
- real credential proof: OpenSSL legacy-compatible extraction, separate certificate/private-key import, clean keychain identity `Developer ID Application: Peter Steinberger (Y5PE65HELJ)`
- `actionlint .github/workflows/release.yml`
- release packaging tests: 8 passed
- touched-file Swift format passed
- `git diff --check`
- independent autoreview clean
