### PR TITLE
fix(release): pin PKCS12 compatibility fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       pull-requests: write
       statuses: read
     # Pin immutable Swift release hotfixes until the v1 compatibility tag includes them.
-    uses: openclaw/release-workflows/.github/workflows/release-swift-cli.yml@0d04fb8583639378db1bc3f8ed897ee2eafb61d1
+    uses: openclaw/release-workflows/.github/workflows/release-swift-cli.yml@011e3898a049b64716ea1cb2c33d10d91980a5ab
     with:
       version: ${{ inputs.version }}
       repository-type: personal

--- a/Tests/imsgTests/ReleasePackagingTests.swift
+++ b/Tests/imsgTests/ReleasePackagingTests.swift
@@ -7,7 +7,7 @@ func releaseWorkflowPackagesUniversalBuildOutput() throws {
 
   #expect(
     workflow.contains(
-      "uses: openclaw/release-workflows/.github/workflows/release-swift-cli.yml@0d04fb8583639378db1bc3f8ed897ee2eafb61d1"
+      "uses: openclaw/release-workflows/.github/workflows/release-swift-cli.yml@011e3898a049b64716ea1cb2c33d10d91980a5ab"
     ))
   #expect(workflow.contains("macos-archive-name: imsg-macos.zip"))
   #expect(workflow.contains("helper-name: imsg-bridge-helper.dylib"))


### PR DESCRIPTION
## What Problem This Solves

The robust signer workflow reached the hosted macOS runner, where LibreSSL rejected OpenSSL 3's `pkcs12 -legacy` flag. The new immutable workflow revision detects whether the installed `openssl pkcs12` supports that option and uses it only when available.

## Why This Change Was Made

Advance imsg's temporary release workflow pin to `011e3898a049b64716ea1cb2c33d10d91980a5ab`. This revision includes the Linux Bash-shell fix, separate certificate/private-key import, and capability-driven PKCS#12 parsing across OpenSSL 3 and LibreSSL.

## User Impact

No runtime behavior changes. This unblocks the frozen signed/notarized imsg 0.14.0 release.

## Evidence

- full `release-workflows/scripts/validate-workflows.sh` suite passed
- real OpenSSL 3 credential extraction and separate keychain import produced the expected Peter Steinberger Developer ID identity
- hosted-runner failure established LibreSSL lacks `-legacy`; the workflow now probes support before using it
- `actionlint .github/workflows/release.yml`
- release packaging tests: 8 passed
- `git diff --check`
- independent autoreview clean
