### PR TITLE
fix(release): pin Bash 3 signer fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       pull-requests: write
       statuses: read
     # Pin immutable Swift release hotfixes until the v1 compatibility tag includes them.
-    uses: openclaw/release-workflows/.github/workflows/release-swift-cli.yml@011e3898a049b64716ea1cb2c33d10d91980a5ab
+    uses: openclaw/release-workflows/.github/workflows/release-swift-cli.yml@45a465d20a6defe9f4f9d8ee4ecb0c81d0069f28
     with:
       version: ${{ inputs.version }}
       repository-type: personal

--- a/Tests/imsgTests/ReleasePackagingTests.swift
+++ b/Tests/imsgTests/ReleasePackagingTests.swift
@@ -7,7 +7,7 @@ func releaseWorkflowPackagesUniversalBuildOutput() throws {
 
   #expect(
     workflow.contains(
-      "uses: openclaw/release-workflows/.github/workflows/release-swift-cli.yml@011e3898a049b64716ea1cb2c33d10d91980a5ab"
+      "uses: openclaw/release-workflows/.github/workflows/release-swift-cli.yml@45a465d20a6defe9f4f9d8ee4ecb0c81d0069f28"
     ))
   #expect(workflow.contains("macos-archive-name: imsg-macos.zip"))
   #expect(workflow.contains("helper-name: imsg-bridge-helper.dylib"))


### PR DESCRIPTION
## What Problem This Solves

The hosted macOS signer uses Bash 3.2. Its `set -u` behavior treats an empty array expansion as unbound, so the prior PKCS#12 compatibility probe stopped before extraction.

## Why This Change Was Made

Advance imsg's temporary immutable release workflow pin to `45a465d20a6defe9f4f9d8ee4ecb0c81d0069f28`. That revision uses a Bash-3-safe helper function to invoke `openssl pkcs12` with `-legacy` only when supported.

## User Impact

No runtime behavior changes. This unblocks the frozen imsg 0.14.0 signer job.

## Evidence

- Bash 3.2 `set -u` helper proof passed
- full `release-workflows/scripts/validate-workflows.sh` suite passed
- `actionlint .github/workflows/release.yml`
- release packaging tests: 8 passed
- `git diff --check`
- independent autoreview clean
