### PR TITLE
fix(release): pin signing keychain fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       pull-requests: write
       statuses: read
     # Pin immutable Swift release hotfixes until the v1 compatibility tag includes them.
-    uses: openclaw/release-workflows/.github/workflows/release-swift-cli.yml@45a465d20a6defe9f4f9d8ee4ecb0c81d0069f28
+    uses: openclaw/release-workflows/.github/workflows/release-swift-cli.yml@f91db4a989d59197321ffe1de6786863175effab
     with:
       version: ${{ inputs.version }}
       repository-type: personal

--- a/Tests/imsgTests/ReleasePackagingTests.swift
+++ b/Tests/imsgTests/ReleasePackagingTests.swift
@@ -7,7 +7,7 @@ func releaseWorkflowPackagesUniversalBuildOutput() throws {
 
   #expect(
     workflow.contains(
-      "uses: openclaw/release-workflows/.github/workflows/release-swift-cli.yml@45a465d20a6defe9f4f9d8ee4ecb0c81d0069f28"
+      "uses: openclaw/release-workflows/.github/workflows/release-swift-cli.yml@f91db4a989d59197321ffe1de6786863175effab"
     ))
   #expect(workflow.contains("macos-archive-name: imsg-macos.zip"))
   #expect(workflow.contains("helper-name: imsg-bridge-helper.dylib"))


### PR DESCRIPTION
## What Problem This Solves

The signer now imports the certificate and private key and resolves the expected identity, but `codesign` cannot access it because the ephemeral keychain was never added to the user keychain search list.

## Why This Change Was Made

Advance imsg's temporary workflow pin to `f91db4a989d59197321ffe1de6786863175effab`, which explicitly selects the ephemeral keychain before import and signing.

## User Impact

No runtime behavior changes. This unblocks the frozen imsg 0.14.0 signing and notarization stage.

## Evidence

- real identity proof signed and strictly verified a Mach-O probe using the ephemeral keychain
- full `release-workflows/scripts/validate-workflows.sh` suite passed
- release packaging tests: 8 passed
- `actionlint` and `git diff --check` passed
- independent autoreview clean
