### PR TITLE
fix(release): pin draft metadata fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       pull-requests: write
       statuses: read
     # Pin immutable Swift release hotfixes until the v1 compatibility tag includes them.
-    uses: openclaw/release-workflows/.github/workflows/release-swift-cli.yml@f91db4a989d59197321ffe1de6786863175effab
+    uses: openclaw/release-workflows/.github/workflows/release-swift-cli.yml@4a7f792b1f4ba57563ebbc589774b775b152a15a
     with:
       version: ${{ inputs.version }}
       repository-type: personal

--- a/Tests/imsgTests/ReleasePackagingTests.swift
+++ b/Tests/imsgTests/ReleasePackagingTests.swift
@@ -7,7 +7,7 @@ func releaseWorkflowPackagesUniversalBuildOutput() throws {
 
   #expect(
     workflow.contains(
-      "uses: openclaw/release-workflows/.github/workflows/release-swift-cli.yml@f91db4a989d59197321ffe1de6786863175effab"
+      "uses: openclaw/release-workflows/.github/workflows/release-swift-cli.yml@4a7f792b1f4ba57563ebbc589774b775b152a15a"
     ))
   #expect(workflow.contains("macos-archive-name: imsg-macos.zip"))
   #expect(workflow.contains("helper-name: imsg-bridge-helper.dylib"))


### PR DESCRIPTION
## What Problem This Solves

Signing and notarization now succeed, but the draft job calls `gh release create --verify-tag` without a Git checkout, so GitHub CLI cannot verify the frozen tag.

## Why This Change Was Made

Advance imsg's temporary workflow pin to `4a7f792b1f4ba57563ebbc589774b775b152a15a`. The draft job performs a credential-free checkout of the already-validated frozen tag before invoking `gh release create --verify-tag`.

## User Impact

No runtime behavior changes. This unblocks draft creation and independent publication verification for imsg 0.14.0.

## Evidence

- signing and notarization succeeded in release run 31431973503
- full `release-workflows/scripts/validate-workflows.sh` suite passed
- release packaging tests: 8 passed
- `actionlint` and `git diff --check` passed
- independent autoreview clean
