### PR TITLE
fix(release): pin draft ID lookup fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       pull-requests: write
       statuses: read
     # Pin immutable Swift release hotfixes until the v1 compatibility tag includes them.
-    uses: openclaw/release-workflows/.github/workflows/release-swift-cli.yml@4a7f792b1f4ba57563ebbc589774b775b152a15a
+    uses: openclaw/release-workflows/.github/workflows/release-swift-cli.yml@6ecd9e56984238f6bab55eb5504a64fbf867e260
     with:
       version: ${{ inputs.version }}
       repository-type: personal

--- a/Tests/imsgTests/ReleasePackagingTests.swift
+++ b/Tests/imsgTests/ReleasePackagingTests.swift
@@ -7,7 +7,7 @@ func releaseWorkflowPackagesUniversalBuildOutput() throws {
 
   #expect(
     workflow.contains(
-      "uses: openclaw/release-workflows/.github/workflows/release-swift-cli.yml@4a7f792b1f4ba57563ebbc589774b775b152a15a"
+      "uses: openclaw/release-workflows/.github/workflows/release-swift-cli.yml@6ecd9e56984238f6bab55eb5504a64fbf867e260"
     ))
   #expect(workflow.contains("macos-archive-name: imsg-macos.zip"))
   #expect(workflow.contains("helper-name: imsg-bridge-helper.dylib"))


### PR DESCRIPTION
## What Problem This Solves

The draft release is created successfully, but the workflow then queries GitHub's release-by-tag REST endpoint, which returns 404 for drafts.

## Why This Change Was Made

Advance imsg's temporary workflow pin to `6ecd9e56984238f6bab55eb5504a64fbf867e260`. It resolves the draft database ID through `gh release view`, which is draft-aware.

## User Impact

No runtime behavior changes. This unblocks verifier handoff and publication for imsg 0.14.0.

## Evidence

- draft v0.14.0 was created with all signed assets in run 31433424326
- `gh release view v0.14.0 --json databaseId` returns the draft ID
- full release-workflows validation passed
- release packaging tests: 8 passed
- `actionlint`, `git diff --check`, and independent autoreview passed
