### PR TITLE
chore: open next Unreleased section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## Unreleased
+
 ## 0.14.0 - 2026-08-10
 
 ### Highlights


### PR DESCRIPTION
## What Problem This Solves

Opens the next `## Unreleased` changelog section after the verified imsg 0.14.0 release.

The release workflow created and pushed this branch, but repository Actions policy prevented its `GITHUB_TOKEN` from opening the pull request.

## Why This Change Was Made

Release closeout requires a new Unreleased section so subsequent changes have a canonical release-note target.

## User Impact

None. This is release bookkeeping after publication.

## Evidence

- Release: https://github.com/openclaw/imsg/releases/tag/v0.14.0
- Workflow: https://github.com/openclaw/imsg/actions/runs/31434537833
- Public assets, SHA256SUMS, signed/notarized universal macOS binaries, Linux x86-64 version, release body, and Homebrew formula were independently verified.
