### PR TITLE
fix: search attributed message bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Read Commands
+- fix: search decoded attributed message bodies when the plain text column is empty (#223, thanks @lincicomb).
+
 ## 0.14.0 - 2026-08-10
 
 ### Highlights

--- a/Sources/IMsgCore/MessageStore+Search.swift
+++ b/Sources/IMsgCore/MessageStore+Search.swift
@@ -13,10 +13,15 @@ private struct SearchMessagesQuery {
       store.schema.hasReactionColumns
       ? " AND (m.associated_message_type IS NULL OR m.associated_message_type < 2000 OR m.associated_message_type > 3006)"
       : ""
-    let predicate =
+    let textPredicate =
       exact
       ? "IFNULL(m.text, '') = ? COLLATE NOCASE"
       : "IFNULL(m.text, '') LIKE ? ESCAPE '\\' COLLATE NOCASE"
+    let attributedBodyCandidate =
+      store.schema.hasAttributedBody
+      ? " OR (IFNULL(m.text, '') = '' AND m.attributedBody IS NOT NULL)"
+      : ""
+    let predicate = "(\(textPredicate)\(attributedBodyCandidate))"
     let textBinding = exact ? text : SearchMessagesQuery.likePattern(for: text)
     self.sql = """
       SELECT \(selection.selectList)
@@ -59,15 +64,18 @@ extension MessageStore {
           limit: physicalLimit
         )
         var messages: [Message] = []
+        var candidateCount = 0
         var parentCache: ReplyParentCache = [:]
         var pollOptionCache = PollOptionTextCache()
         let rows = try db.prepareRowIterator(query.sql, bindings: query.bindings)
         while let row = try rows.failableNext() {
+          candidateCount += 1
           let decoded = try decodeMessageRow(
             row,
             columns: query.selection.columns,
             fallbackChatID: query.fallbackChatID
           )
+          guard searchText(decoded.text, matches: trimmed, exact: exact) else { continue }
           messages.append(
             try message(
               from: decoded,
@@ -86,7 +94,7 @@ extension MessageStore {
             guard let previous = try self.precedingTextMessageForURLPreview(preview, db: db) else {
               return nil
             }
-            guard self.searchMessage(previous, matches: trimmed, exact: exact) else {
+            guard self.searchText(previous.text, matches: trimmed, exact: exact) else {
               return nil
             }
             return .replace(previous)
@@ -96,7 +104,8 @@ extension MessageStore {
           }
         ).sorted(by: searchMessagesNewestFirst)
 
-        if messages.count < physicalLimit || (coalesced.count >= limit && !usedFallbackReplacement)
+        if candidateCount < physicalLimit
+          || (coalesced.count >= limit && !usedFallbackReplacement)
         {
           return Array(coalesced.prefix(limit))
         }
@@ -108,11 +117,11 @@ extension MessageStore {
     }
   }
 
-  private func searchMessage(_ message: Message, matches text: String, exact: Bool) -> Bool {
+  private func searchText(_ candidate: String, matches text: String, exact: Bool) -> Bool {
     if exact {
-      return message.text.caseInsensitiveCompare(text) == .orderedSame
+      return candidate.caseInsensitiveCompare(text) == .orderedSame
     }
-    return message.text.range(of: text, options: [.caseInsensitive]) != nil
+    return candidate.range(of: text, options: [.caseInsensitive]) != nil
   }
 
   private func nextSearchPhysicalLimit(after current: Int) -> Int? {

--- a/Tests/IMsgCoreTests/MessageStoreAttributedBodyTests.swift
+++ b/Tests/IMsgCoreTests/MessageStoreAttributedBodyTests.swift
@@ -246,3 +246,112 @@ func messagesAfterUsesAttributedBodyFallback() throws {
   #expect(messages.count == 1)
   #expect(messages.first?.text == "new text")
 }
+
+@Test
+func searchMessagesMatchesPlainAndAttributedBodies() throws {
+  let db = try makeAttributedBodySearchDatabase()
+  let now = Date()
+  try insertSearchMessage(
+    db,
+    rowID: 1,
+    text: "plain searchable body",
+    attributedText: nil,
+    date: now
+  )
+  try insertSearchMessage(
+    db,
+    rowID: 2,
+    text: nil,
+    attributedText: "attributed searchable body",
+    date: now.addingTimeInterval(1)
+  )
+
+  let store = try MessageStore(connection: db, path: ":memory:")
+  let messages = try store.searchMessages(query: "searchable", match: "contains", limit: 10)
+
+  #expect(messages.map(\.rowID) == [2, 1])
+  #expect(messages.map(\.text) == ["attributed searchable body", "plain searchable body"])
+}
+
+@Test
+func searchMessagesExactlyMatchesPlainAndAttributedBodiesCaseInsensitively() throws {
+  let db = try makeAttributedBodySearchDatabase()
+  let now = Date()
+  try insertSearchMessage(
+    db,
+    rowID: 1,
+    text: "Exact Search Body",
+    attributedText: nil,
+    date: now
+  )
+  try insertSearchMessage(
+    db,
+    rowID: 2,
+    text: nil,
+    attributedText: "Exact Search Body",
+    date: now.addingTimeInterval(1)
+  )
+
+  let store = try MessageStore(connection: db, path: ":memory:")
+  let messages = try store.searchMessages(query: "exact search body", match: "exact", limit: 10)
+
+  #expect(messages.map(\.rowID) == [2, 1])
+}
+
+@Test
+func searchMessagesFillsLimitPastNonmatchingAttributedBodies() throws {
+  let db = try makeAttributedBodySearchDatabase()
+  let now = Date()
+  try insertSearchMessage(
+    db,
+    rowID: 1,
+    text: nil,
+    attributedText: "matching attributed body",
+    date: now
+  )
+  try insertSearchMessage(
+    db,
+    rowID: 2,
+    text: nil,
+    attributedText: "newer unrelated body",
+    date: now.addingTimeInterval(1)
+  )
+
+  let store = try MessageStore(connection: db, path: ":memory:")
+  let messages = try store.searchMessages(query: "matching", match: "contains", limit: 1)
+
+  #expect(messages.map(\.rowID) == [1])
+}
+
+private func makeAttributedBodySearchDatabase() throws -> Connection {
+  let db = try Connection(.inMemory)
+  try MessageDatabaseFixture.createSchema(
+    db,
+    options: .init(includeAttributedBody: true)
+  )
+  try db.run("INSERT INTO handle(ROWID, id) VALUES (1, '+123')")
+  return db
+}
+
+private func insertSearchMessage(
+  _ db: Connection,
+  rowID: Int64,
+  text: String?,
+  attributedText: String?,
+  date: Date
+) throws {
+  let body: Blob? = attributedText.map {
+    Blob(bytes: [0x01, 0x2b] + Array($0.utf8) + [0x86, 0x84])
+  }
+  try db.run(
+    """
+    INSERT INTO message(ROWID, handle_id, text, attributedBody, date, is_from_me, service)
+    VALUES (?, 1, ?, ?, ?, 0, 'iMessage')
+    """,
+    rowID,
+    text,
+    body,
+    TestDatabase.appleEpoch(date)
+  )
+  try db.run("INSERT INTO chat_message_join(chat_id, message_id) VALUES (1, ?)", rowID)
+}


### PR DESCRIPTION
## Summary

- admit empty-plain-text rows with an attributed body as search candidates
- filter decoded text before enrichment while keeping raw candidate accounting for logical limits
- cover plain and attributed bodies for contains, exact, and limit behavior
- add the fix to the Unreleased changelog

Fixes #223.

## Verification

```text
make lint
Done linting! Found 14 violations, 0 serious in 236 files.

make test
Test run with 276 tests in 5 suites passed after 1.329 seconds.

make build
Built bin/imsg (arm64 x86_64)
Built bin/imsg-bridge-helper.dylib (arm64e arm64 x86_64)
```

Dependency freshness was also checked with `swift package update`; Commander 0.2.4, SQLite.swift 0.16.0, and PhoneNumberKit 5.0.6 are current and the manifest/lockfile did not change.

Live proof used the built release binary against the local Messages database with a neutral one-character query, retained only result row IDs, and independently classified their storage in SQLite without printing message content, senders, chats, or GUIDs:

```text
PRAGMA quick_check: ok
eligible attributed-body-only rows: 980
search_results=100
plain_text_results=34
attributed_body_only_results=66
```

The pre-fix focused regression test returned only the plain row (`[1]`) instead of the expected attributed-plus-plain rows (`[2, 1]`). After the fix, contains, case-insensitive exact, and limit-expansion regressions all pass.
